### PR TITLE
maintains responsible name when user is erased

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -134,7 +134,7 @@ class Proposal < ActiveRecord::Base
   protected
 
     def set_responsible_name
-      if author && author.level_two_or_three_verified?
+      if author && author.document_number?
         self.responsible_name = author.document_number
       end
     end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -97,6 +97,17 @@ describe Proposal do
       expect(proposal).to be_valid
       proposal.responsible_name = "12345678Z"
     end
+
+    it "should not be updated when the author is deleted" do
+      author = create(:user, :level_three, document_number: "12345678Z")
+      proposal.author = author
+      proposal.save
+
+      proposal.author.erase
+
+      proposal.save
+      expect(proposal.responsible_name).to eq "12345678Z"
+    end
   end
 
   describe "tag_list" do


### PR DESCRIPTION
Maintains a proposal's responsible name when the author is erased.