### PR TITLE
Hashtag al compartir en redes sociales #65

### DIFF
--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -55,7 +55,7 @@
         <div class="sidebar-divider"></div>
         <h3><%= t("debates.show.share") %></h3>
         <div class="social-share-full">
-          <%= social_share_button_tag("#{@debate.title} ##{setting['twitter_hashtag']}") %>
+          <%= social_share_button_tag("#{@debate.title} #{setting['twitter_hashtag']}") %>
           <% if browser.mobile? %>
             <a href="whatsapp://send?text=<%= @debate.title %> <%= debate_url(@debate) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -55,7 +55,7 @@
         <div class="sidebar-divider"></div>
         <h3><%= t("debates.show.share") %></h3>
         <div class="social-share-full">
-          <%= social_share_button_tag("#{@debate.title} #decidemadrid") %>
+          <%= social_share_button_tag("#{@debate.title} ##{setting['twitter_hashtag']}") %>
           <% if browser.mobile? %>
             <a href="whatsapp://send?text=<%= @debate.title %> <%= debate_url(@debate) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -55,7 +55,7 @@
         <div class="sidebar-divider"></div>
         <h3><%= t("debates.show.share") %></h3>
         <div class="social-share-full">
-          <%= social_share_button_tag(@debate.title) %>
+          <%= social_share_button_tag("#{@debate.title} #decidemadrid") %>
           <% if browser.mobile? %>
             <a href="whatsapp://send?text=<%= @debate.title %> <%= debate_url(@debate) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -37,7 +37,7 @@
   <% if voted_for?(@featured_proposals_votes, proposal) %>
     <% if setting['twitter_handle'] %>
       <div class="share-supported">
-        <%= social_share_button_tag("#{proposal.title} ##{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+        <%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -37,7 +37,7 @@
   <% if voted_for?(@featured_proposals_votes, proposal) %>
     <% if setting['twitter_handle'] %>
       <div class="share-supported">
-        <%= social_share_button_tag(proposal.title, url: proposal_url(proposal), via: setting['twitter_handle']) %>
+        <%= social_share_button_tag("#{proposal.title} #decidemadrid", url: proposal_url(proposal), via: setting['twitter_handle']) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -37,7 +37,7 @@
   <% if voted_for?(@featured_proposals_votes, proposal) %>
     <% if setting['twitter_handle'] %>
       <div class="share-supported">
-        <%= social_share_button_tag("#{proposal.title} #decidemadrid", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+        <%= social_share_button_tag("#{proposal.title} ##{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -53,7 +53,7 @@
 
   <% if voted_for?(@proposal_votes, proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{proposal.title} #decidemadrid", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{proposal.title} ##{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -53,7 +53,7 @@
 
   <% if voted_for?(@proposal_votes, proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag(proposal.title, url: proposal_url(proposal), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{proposal.title} #decidemadrid", url: proposal_url(proposal), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -53,7 +53,7 @@
 
   <% if voted_for?(@proposal_votes, proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{proposal.title} ##{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -88,7 +88,7 @@
         <div class="sidebar-divider"></div>
         <h3><%= t("proposals.show.share") %></h3>
         <div class="social-share-full">
-          <%= social_share_button_tag(@proposal.title) %>
+          <%= social_share_button_tag("#{@proposal.title} #decidemadrid") %>
           <% if browser.mobile? %>
             <a href="whatsapp://send?text=<%= @proposal.title %> <%= proposal_url(@proposal) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -88,7 +88,7 @@
         <div class="sidebar-divider"></div>
         <h3><%= t("proposals.show.share") %></h3>
         <div class="social-share-full">
-          <%= social_share_button_tag("#{@proposal.title} ##{setting['twitter_hashtag']}") %>
+          <%= social_share_button_tag("#{@proposal.title} #{setting['twitter_hashtag']}") %>
           <% if browser.mobile? %>
             <a href="whatsapp://send?text=<%= @proposal.title %> <%= proposal_url(@proposal) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -88,7 +88,7 @@
         <div class="sidebar-divider"></div>
         <h3><%= t("proposals.show.share") %></h3>
         <div class="social-share-full">
-          <%= social_share_button_tag("#{@proposal.title} #decidemadrid") %>
+          <%= social_share_button_tag("#{@proposal.title} ##{setting['twitter_hashtag']}") %>
           <% if browser.mobile? %>
             <a href="whatsapp://send?text=<%= @proposal.title %> <%= proposal_url(@proposal) %>" data-action="share/whatsapp/share">
               <span class="icon-whatsapp whatsapp"></span>

--- a/app/views/spending_proposals/_votes.html.erb
+++ b/app/views/spending_proposals/_votes.html.erb
@@ -37,7 +37,7 @@
 
   <% if voted_for?(@spending_proposal_votes, spending_proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag(spending_proposal.title, url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{spending_proposal.title} #decidemadrid", url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/app/views/spending_proposals/_votes.html.erb
+++ b/app/views/spending_proposals/_votes.html.erb
@@ -37,7 +37,7 @@
 
   <% if voted_for?(@spending_proposal_votes, spending_proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{spending_proposal.title} ##{setting['twitter_hashtag']}", url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{spending_proposal.title} #{setting['twitter_hashtag']}", url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/app/views/spending_proposals/_votes.html.erb
+++ b/app/views/spending_proposals/_votes.html.erb
@@ -37,7 +37,7 @@
 
   <% if voted_for?(@spending_proposal_votes, spending_proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{spending_proposal.title} #decidemadrid", url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
+      <%= social_share_button_tag("#{spending_proposal.title} ##{setting['twitter_hashtag']}", url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
     </div>
   <% end %>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,6 +37,7 @@ Setting['per_page_code'] =  ''
 
 # Social settings
 Setting["twitter_handle"] = "abriendomadrid"
+Setting["twitter_hashtag"] = "decidemadrid"
 Setting["facebook_handle"] = "Abriendo-Madrid-1475577616080350"
 Setting["youtube_handle"] = "channel/UCFmaChI9quIY7lwHplnacfg"
 Setting["blog_url"] = "/blog"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,7 +37,7 @@ Setting['per_page_code'] =  ''
 
 # Social settings
 Setting["twitter_handle"] = "abriendomadrid"
-Setting["twitter_hashtag"] = "decidemadrid"
+Setting["twitter_hashtag"] = "#decidemadrid"
 Setting["facebook_handle"] = "Abriendo-Madrid-1475577616080350"
 Setting["youtube_handle"] = "channel/UCFmaChI9quIY7lwHplnacfg"
 Setting["blog_url"] = "/blog"


### PR DESCRIPTION
En los botones de compartir en twitter (no específicos del debate de Plaza España) he añadido el hashtag #decidemadrid entre el título y el link.

