### PR TITLE
Limiting results in admin interface

### DIFF
--- a/app/helpers/spending_proposals_helper.rb
+++ b/app/helpers/spending_proposals_helper.rb
@@ -65,4 +65,13 @@ module SpendingProposalsHelper
     end
   end
 
+  def numeric_range_options(range, step, number)
+    values = range
+    values = values.step(step) if step.present?
+    values = values.to_a
+    values = (values + [number.to_i]).uniq.compact.sort if number.present?
+
+    options_for_select(values, number)
+  end
+
 end

--- a/app/models/spending_proposal.rb
+++ b/app/models/spending_proposal.rb
@@ -61,12 +61,44 @@ class SpendingProposal < ActiveRecord::Base
 
   def self.scoped_filter(params, current_filter)
     results = self
+    results = limit_results(results, params)                      if params[:max_for_no_geozone].present? || params[:max_per_geozone].present?
     results = results.by_geozone(params[:geozone_id])             if params[:geozone_id].present?
     results = results.by_admin(params[:administrator_id])         if params[:administrator_id].present?
     results = results.by_tag(params[:tag_name])                   if params[:tag_name].present?
     results = results.by_valuator(params[:valuator_id])           if params[:valuator_id].present?
     results = results.send(current_filter)                        if current_filter.present?
     results.includes(:geozone, administrator: :user, valuators: :user)
+  end
+
+  def self.limit_results(results, params)
+    max_per_geozone = params[:max_per_geozone].to_i
+    max_for_no_geozone = params[:max_for_no_geozone].to_i
+
+    return results if max_per_geozone <= 0 && max_for_no_geozone <= 0
+
+    ids = []
+    if max_per_geozone > 0
+      Geozone.pluck(:id).each do |gid|
+        ids += SpendingProposal.select(:id).where(geozone_id: gid).order(cached_votes_up: :desc).limit(max_per_geozone).map(&:id)
+      end
+    end
+
+    if max_for_no_geozone > 0
+      ids += SpendingProposal.select(:id).city_wide.order(cached_votes_up: :desc).limit(max_for_no_geozone).map(&:id)
+    end
+
+    conditions = ["spending_proposals.id IN (?)"]
+    values = [ids]
+
+    if params[:max_per_geozone].blank?
+      conditions << "spending_proposals.geozone_id IS NOT ?"
+      values << nil
+    elsif params[:max_for_no_geozone].blank?
+      conditions << "spending_proposals.geozone_id IS ?"
+      values << nil
+    end
+
+    results.where(conditions.join(' OR '), *values)
   end
 
   def searchable_values

--- a/app/views/admin/spending_proposals/index.html.erb
+++ b/app/views/admin/spending_proposals/index.html.erb
@@ -41,6 +41,22 @@
                        label: false,
                        class: "js-submit-on-change" } %>
     </div>
+
+    <div class="small-12 medium-3 column float-right">
+      <%= select_tag :max_per_geozone,
+                      numeric_range_options((5..100), 5, params[:max_per_geozone]),
+                     { prompt: t("admin.spending_proposals.index.max_per_geozone"),
+                       label: false,
+                       class: "js-submit-on-change" } %>
+    </div>
+
+    <div class="small-12 medium-3 column">
+      <%= select_tag :max_for_no_geozone,
+                      numeric_range_options((5..300), 5, params[:max_for_no_geozone]),
+                     { prompt: t("admin.spending_proposals.index.max_for_no_geozone"),
+                       label: false,
+                       class: "js-submit-on-change" } %>
+    </div>
   <% end %>
 </div>
 

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -173,6 +173,8 @@ en:
         administrator_filter_all: All administrators
         valuator_filter_all: All valuators
         tags_filter_all: All tags
+        max_per_geozone: Max per geozone
+        max_for_no_geozone: Max for city-wide
         filters:
           valuation_open: Open
           without_admin: Without assigned admin

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -173,6 +173,8 @@ es:
         administrator_filter_all: Todos los administradores
         valuator_filter_all: Todos los evaluadores
         tags_filter_all: Todas las etiquetas
+        max_per_geozone: Corte por distrito
+        max_for_no_geozone: Corte por ciudad
         filters:
           valuation_open: Abiertas
           without_admin: Sin administrador


### PR DESCRIPTION
adds two more selects to admin' spending proposals index to limit results by geozone and district-wide