### PR TITLE
Social share ballot

### DIFF
--- a/app/views/ballots/_ballot.html.erb
+++ b/app/views/ballots/_ballot.html.erb
@@ -13,6 +13,14 @@
           count: @ballot.spending_proposals.count) %>
     </h2>
 
+
+    <% if @ballot.geozone.present? && district_wide_amount_spent(@ballot) > 0 %>
+      <%= social_share_button_tag("#{t('ballots.show.social_share',
+                                        amount: format_price(district_wide_amount_spent(@ballot)),
+                                        geozone: @ballot.geozone.name)} #{setting['twitter_hashtag']}",
+                                  url: participatory_budget_url) %>
+    <% end %>
+
     <h3>
       <%= t("ballots.show.remaining_city_html",
           amount_city: format_price(@ballot.amount_available(nil))) %>

--- a/app/views/ballots/_ballot.html.erb
+++ b/app/views/ballots/_ballot.html.erb
@@ -40,7 +40,7 @@
       <h3 class="subtitle">
         <%= t("ballots.show.city_wide") %>
       </h3>
-      <% if @ballot.spending_proposals.by_geozone(@geozone).count > 0 %>
+      <% if @ballot.spending_proposals.by_geozone(nil).count > 0 %>
         <h4 class="amount-spent text-right">
           <%= t("ballots.show.amount_spent") %>
           <span><%= format_price(city_wide_amount_spent(@ballot)) %></span>

--- a/app/views/ballots/_ballot.html.erb
+++ b/app/views/ballots/_ballot.html.erb
@@ -5,6 +5,15 @@
     <%= t("shared.back") %>
   <% end %>
 
+  <div class="float-right">
+    <% if @ballot.geozone.present? && district_wide_amount_spent(@ballot) > 0 %>
+      <%= social_share_button_tag("#{t('ballots.show.social_share',
+                                        amount: format_price(district_wide_amount_spent(@ballot)),
+                                        geozone: @ballot.geozone.name)} #{setting['twitter_hashtag']}",
+                                  url: participatory_budget_url) %>
+    <% end %>
+  </div>
+
   <h1 class="text-center"><%= t("ballots.show.title") %></h1>
 
   <div class="small-12 medium-8 column small-centered text-center">
@@ -12,14 +21,6 @@
       <%= t("ballots.show.voted_html",
           count: @ballot.spending_proposals.count) %>
     </h2>
-
-
-    <% if @ballot.geozone.present? && district_wide_amount_spent(@ballot) > 0 %>
-      <%= social_share_button_tag("#{t('ballots.show.social_share',
-                                        amount: format_price(district_wide_amount_spent(@ballot)),
-                                        geozone: @ballot.geozone.name)} #{setting['twitter_hashtag']}",
-                                  url: participatory_budget_url) %>
-    <% end %>
 
     <h3>
       <%= t("ballots.show.remaining_city_html",

--- a/app/views/shared/_social_media_meta_tags_participatory_budget.html.erb
+++ b/app/views/shared/_social_media_meta_tags_participatory_budget.html.erb
@@ -1,19 +1,19 @@
 <!-- Twitter -->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@abriendomadrid" />
-<meta name="twitter:title" content="Presupuestos Participativos" />
+<meta name="twitter:title" content="Presupuestos Participativos en Madrid" />
 <meta name="twitter:description" content="Tú decides cómo invertir 60 millones de euros para tu ciudad" />
 <meta name="twitter:image" content="<%= image_url '/social-media-participatory-budget.png' %>" />
 <!-- Facebook OG -->
-<meta id="ogtitle" property="og:title" content="Presupuestos Participativos"/>
-<% if Setting['url'] %>
-  <meta property="article:publisher" content=<%= Setting['url'] %>/>
+<meta id="ogtitle" property="og:title" content="Presupuestos Participativos en Madrid"/>
+<% if setting['url'] %>
+  <meta property="article:publisher" content=<%= setting['url'] %>/>
 <% end %>
-<% if Setting['facebook_handle'] %>
-  <meta property="article:author" content="https://www.facebook.com/<%= Setting['facebook_handle'] %>"/>
+<% if setting['facebook_handle'] %>
+  <meta property="article:author" content="https://www.facebook.com/<%= setting['facebook_handle'] %>"/>
 <% end %>
 <meta property="og:type" content="article"/>
-<meta id="ogurl" property="og:url" content="https://decide.madrid.es/participatory_budget"/>
+<meta id="ogurl" property="og:url" content="<%= participatory_budget_url %>"/>
 <meta id="ogimage" property="og:image" content="<%= image_url '/social-media-participatory-budget.png' %>"/>
 <meta property="og:site_name" content="Decide Madrid"/>
 <meta id="ogdescription" property="og:description" content="Tú decides cómo invertir 60 millones de euros para tu ciudad"/>

--- a/app/views/spending_proposals/show.html.erb
+++ b/app/views/spending_proposals/show.html.erb
@@ -54,6 +54,7 @@
               <%= render 'ballot', spending_proposal: @spending_proposal %>
             </div>
          <% end %>
+        </div>
 
         <div class="sidebar-divider"></div>
         <h3><%= t("spending_proposals.show.share") %></h3>

--- a/app/views/spending_proposals/welcome.html.erb
+++ b/app/views/spending_proposals/welcome.html.erb
@@ -1,3 +1,7 @@
+<% provide :title do %><%= t('spending_proposals.welcome.page_title') %><% end %>
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags_participatory_budget" %>
+<% end %>
 <div class="expanded jumbo-investment-project-votes no-margin-top margin-bottom">
   <div class="row">
     <div class="small-12 large-7 column padding content">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,6 +541,7 @@ en:
       remaining_city_html: "You are <span>%{amount_city}</span> to invest citywide."
       remaining_district_html: "You are <span>%{amount_district}</span> to invest on <span>%{geozone}</span>."
       remove: Remove vote
+      social_share: I've decided where to invest %{amount} for %{geozone}
       voted_html:
         one: "You voted <span>one</span> proposal."
         other: "You voted <span>%{count}</span> proposals."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,13 +489,14 @@ en:
     welcome:
       city_link: Vote city proposals
       delegation: Delegation of votes
-      delegation_info_html: "Si activas la delegación en cualquiera de los espacios, tus votos se realizarán<br> automáticamente sobre las propuestas que haya decidido el espacio correspondiente."
-      delegation_meetings: espacios presenciales de debate
-      delegation_text: Delega tu votación en lo que se decida en cualquiera de los %{meetings}
-      delegation_title: Delegación de voto
+      delegation_info_html: "If you activate vote delegation on any local space, proposals decided by that space will automaticaly receive your votes"
+      delegation_meetings: local debate spaces
+      delegation_text: Delegate your votes to the proposals decided at any of the %{meetings}
+      delegation_title: Vote delegation
       districts: Districts
       districts_link: Vote district proposals
       in_two_minutes: All information about participatory budgets
+      page_title: Participatory budgeting
       title: "You already can vote investment projetcs!"
       text_first_html: "Desde hoy <strong>15 de mayo</strong> hasta el día <strong>30 de junio</strong> puedes votar las propuestas de inversión de los Presupuestos participativos 2016."
       text_second_html: "Puedes votar todas las propuestas que quieras hasta alcanzar el presupuesto destinado para el ámbito de <strong>toda la ciudad</strong> y del <strong>distrito</strong> que hayas seleccionado."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -496,6 +496,7 @@ es:
       districts: Distritos
       districts_link: Votar propuestas de distrito
       in_two_minutes: Toda la información sobre los presupuestos participativos
+      page_title: Presupuestos participativos
       title: "Ya puedes votar las propuestas"
       text_first_html: "Desde hoy <strong>15 de mayo</strong> hasta el día <strong>30 de junio</strong> puedes votar las propuestas de inversión de los Presupuestos participativos 2016."
       text_second_html: "Puedes votar todas las propuestas que quieras hasta alcanzar el presupuesto destinado para el ámbito de <strong>toda la ciudad</strong> y del <strong>distrito</strong> que hayas seleccionado."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -541,6 +541,7 @@ es:
       remaining_city_html: "Te quedan <span>%{amount_city}</span> para invertir en toda la ciudad."
       remaining_district_html: "Te quedan <span>%{amount_district}</span> para invertir en <span>%{geozone}</span>."
       remove: Quitar voto
+      social_share: He decidido dónde quiero que se inviertan %{amount} para %{geozone}. ¡Participa!
       voted_html:
         one: "Has votado <span>una</span> propuesta."
         other: "Has votado <span>%{count}</span> propuestas."


### PR DESCRIPTION
Si hay seleccionada alguna propuesta de distrito, se muestran los botones de compartir en redes sociales con un texto que incluye la cantidad y en qué distrito se está votando.

En principio está bien de apariencia, pero por si acaso @decabeza echa un ojo a ver si quieres moverlo de sitio/retocar estilos antes de dar tu visto bueno.