### PR TITLE
updates spending proposal permissions

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -40,8 +40,11 @@ module Abilities
       can [:search, :create, :index, :destroy], ::Manager
 
       can :manage, Annotation
+      can [:read, :summary], SpendingProposal
 
-      can [:read, :update, :destroy, :summary], SpendingProposal
+      if Setting['feature.spending_proposal_features.valuation_allowed'].present?
+        can [:update, :destroy], SpendingProposal
+      end
     end
   end
 end

--- a/app/models/abilities/valuator.rb
+++ b/app/models/abilities/valuator.rb
@@ -3,9 +3,12 @@ module Abilities
     include CanCan::Ability
 
     def initialize(user)
+      can :read, SpendingProposal
+
       if Setting['feature.spending_proposal_features.valuation_allowed'].present?
-        can [:read, :update, :valuate], SpendingProposal
+        can [:update, :valuate], SpendingProposal
       end
+
     end
   end
 end

--- a/spec/features/admin/spending_proposals_spec.rb
+++ b/spec/features/admin/spending_proposals_spec.rb
@@ -18,6 +18,10 @@ feature 'Admin spending proposals' do
 
   context "Index" do
 
+    background do
+      Setting['feature.spending_proposal_features.valuation_allowed'] = true
+    end
+
     scenario 'Displaying spending proposals' do
       spending_proposal = create(:spending_proposal, cached_votes_up: 10, physical_votes: 20)
       visit admin_spending_proposals_path
@@ -403,6 +407,10 @@ feature 'Admin spending proposals' do
   end
 
   context "Edit" do
+
+    background do
+      Setting['feature.spending_proposal_features.valuation_allowed'] = true
+    end
 
     scenario "Change title, description or geozone" do
       spending_proposal = create(:spending_proposal)

--- a/spec/features/spending_proposals_spec.rb
+++ b/spec/features/spending_proposals_spec.rb
@@ -236,7 +236,7 @@ feature 'Spending proposals' do
 
   context "Destroy" do
 
-    scenario "Admin can destroy spending proposals" do
+    scenario "Admin cannot destroy spending proposals" do
       admin = create(:administrator)
       user = create(:user, :level_two)
       spending_proposal = create(:spending_proposal, author: user)
@@ -245,13 +245,8 @@ feature 'Spending proposals' do
 
       visit user_path(user)
       within("#spending_proposal_#{spending_proposal.id}") do
-        click_link "Delete"
+        expect(page).to_not have_link "Delete"
       end
-
-      expect(page).to have_content("Spending proposal deleted succesfully.")
-
-      visit user_path(user)
-      expect(page).not_to have_css("spending_proposal_list")
     end
 
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -248,11 +248,11 @@ feature 'Users' do
         end
       end
 
-      scenario 'delete button is shown if logged in user is admin' do
+      scenario 'delete button is not shown if logged in user is admin' do
         login_as(create(:administrator).user)
         visit user_path(@author)
         within("#spending_proposal_#{@spending_proposal.id}") do
-          expect(page).to have_content('Delete')
+          expect(page).to_not have_content('Delete')
         end
       end
 

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -66,8 +66,6 @@ describe "Abilities::Administrator" do
       Setting['feature.spending_proposal_features.valuation_allowed'] = true
     end
 
-    it { should be_able_to(:update, SpendingProposal) }
-    it { should be_able_to(:valuate, SpendingProposal) }
     it { should be_able_to(:destroy, SpendingProposal) }
   end
 
@@ -77,8 +75,6 @@ describe "Abilities::Administrator" do
       Setting['feature.spending_proposal_features.valuation_allowed'] = nil
     end
 
-    it { should_not be_able_to(:update, SpendingProposal) }
-    it { should_not be_able_to(:valuate, SpendingProposal) }
     it { should_not be_able_to(:destroy, SpendingProposal) }
   end
 end

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -6,10 +6,6 @@ describe "Abilities::Administrator" do
   let(:user) { administrator.user }
   let(:administrator) { create(:administrator) }
 
-  before(:each) do
-    Setting['feature.spending_proposal_features.valuation_allowed'] = true
-  end
-
   let(:other_user) { create(:user) }
   let(:hidden_user) { create(:user, :hidden) }
 
@@ -61,7 +57,28 @@ describe "Abilities::Administrator" do
   it { should be_able_to(:manage, Annotation) }
 
   it { should be_able_to(:read, SpendingProposal) }
-  it { should be_able_to(:update, SpendingProposal) }
-  it { should be_able_to(:valuate, SpendingProposal) }
-  it { should be_able_to(:destroy, SpendingProposal) }
+  it { should be_able_to(:summary, SpendingProposal) }
+
+
+  describe "valuation open" do
+
+    before(:each) do
+      Setting['feature.spending_proposal_features.valuation_allowed'] = true
+    end
+
+    it { should be_able_to(:update, SpendingProposal) }
+    it { should be_able_to(:valuate, SpendingProposal) }
+    it { should be_able_to(:destroy, SpendingProposal) }
+  end
+
+  describe "valuation finished" do
+
+    before(:each) do
+      Setting['feature.spending_proposal_features.valuation_allowed'] = nil
+    end
+
+    it { should_not be_able_to(:update, SpendingProposal) }
+    it { should_not be_able_to(:valuate, SpendingProposal) }
+    it { should_not be_able_to(:destroy, SpendingProposal) }
+  end
 end

--- a/spec/models/abilities/valuator_spec.rb
+++ b/spec/models/abilities/valuator_spec.rb
@@ -6,11 +6,26 @@ describe "Abilities::Valuator" do
   let(:user) { valuator.user }
   let(:valuator) { create(:valuator) }
 
-  before(:each) do
-    Setting['feature.spending_proposal_features.valuation_allowed'] = true
+  it { should be_able_to(:read, SpendingProposal) }
+
+  describe "valuation open" do
+
+    before(:each) do
+      Setting['feature.spending_proposal_features.valuation_allowed'] = true
+    end
+
+    it { should be_able_to(:update, SpendingProposal) }
+    it { should be_able_to(:valuate, SpendingProposal) }
   end
 
-  it { should be_able_to(:read, SpendingProposal) }
-  it { should be_able_to(:update, SpendingProposal) }
-  it { should be_able_to(:valuate, SpendingProposal) }
+  describe "valuation finished" do
+
+    before(:each) do
+      Setting['feature.spending_proposal_features.valuation_allowed'] = nil
+    end
+
+    it { should_not be_able_to(:update, SpendingProposal) }
+    it { should_not be_able_to(:valuate, SpendingProposal) }
+  end
+
 end


### PR DESCRIPTION
- Admins cannot update nor destroy spending proposals after valuation has finished
- Removes duplicate permissions between admins and valuators