### PR TITLE
Estadísticas de verificación por código en cartas

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -55,4 +55,9 @@ class Admin::StatsController < Admin::BaseController
     @user_count = Ballot.where('ballot_lines_count > ?', 0).count
   end
 
+  def redeemable_codes
+    @users = User.where.not(redeemable_code: nil)
+    @users_after_campaign = @users.where("verified_at >= ?", Date.new(2016, 6, 17).beginning_of_day).count
+  end
+
 end

--- a/app/views/admin/stats/redeemable_codes.html.erb
+++ b/app/views/admin/stats/redeemable_codes.html.erb
@@ -1,0 +1,25 @@
+<%= render 'shared/back_link' %>
+
+<h2><%= t("admin.stats.reedemable_codes.title")%></h2>
+
+<div class="stats">
+  <div class="row stats-numbers">
+    <div class="small-12 medium-3 column">
+      <p class="featured">
+        <%= t("admin.stats.reedemable_codes.total") %><br>
+        <span id="redeemable_codes_count" class="number">
+          <%= @users.count %>
+        </span>
+      </p>
+    </div>
+
+    <div class="small-12 medium-3 column end">
+      <p class="featured">
+        <%= t("admin.stats.reedemable_codes.campaign") %><br>
+        <span id="redeemable_codes_after_campaign_count" class="number">
+          <%= @users_after_campaign %>
+        </span>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/stats/show.html.erb
+++ b/app/views/admin/stats/show.html.erb
@@ -4,11 +4,12 @@
       <h1 class="inline-block"><%= t "admin.stats.show.stats_title" %></h1>
 
       <div class="float-right clear">
+        <%= link_to t("admin.stats.show.redeemable_codes"),
+                    redeemable_codes_admin_stats_path, class: "button hollow" %>
         <%= link_to t("admin.stats.show.direct_messages"),
                     direct_messages_admin_stats_path, class: "button hollow" %>
         <%= link_to t("admin.stats.show.proposal_notifications"),
                     proposal_notifications_admin_stats_path, class: "button hollow" %>
-
       </div>
 
       <div class="clear"></div>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -287,6 +287,7 @@ en:
         participatory_budget: Participatory Budget
         direct_messages: Direct messages
         proposal_notifications: Proposal notifications
+        redeemable_codes: Redeemable codes
         summary:
           ballot_line_votes: Votes in investment projects
           ballot_votes: Budgets voted
@@ -331,6 +332,10 @@ en:
         title: Proposal notifications
         total: Total
         proposals_with_notifications: Proposals with notifications
+      reedemable_codes:
+        title: Redeemable codes
+        total: Total
+        campaign: After sending 400.000 letters
     tags:
       create: Create Topic
       destroy: Destroy Topic

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -285,6 +285,7 @@ es:
         participatory_budget: Presupuestos Participativos
         direct_messages: Mensajes directos
         proposal_notifications: Notificaciones de propuestas
+        redeemable_codes: Códigos enviados por carta
         summary:
           ballot_line_votes: Votos en inversión
           ballot_votes: Presupuestos votados
@@ -331,6 +332,10 @@ es:
         title: Notificaciones de propuestas
         total: Total
         proposals_with_notifications: Propuestas con notificaciones
+      reedemable_codes:
+        title: Códigos enviados por carta
+        total: Total
+        campaign: Después de las 400.000 cartas
     tags:
       create: Crear Tema
       destroy: Eliminar Tema

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,7 @@ Rails.application.routes.draw do
       get :graph, on: :member
       get :proposal_notifications, on: :collection
       get :direct_messages, on: :collection
+      get :redeemable_codes, on: :collection
     end
 
     namespace :api do

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -230,4 +230,34 @@ feature 'Stats' do
 
   end
 
+  context "Redeemable codes" do
+
+    scenario "Total" do
+      create(:user, redeemable_code: 'abc')
+      create(:user, redeemable_code: 'def')
+      create(:user, redeemable_code: 'ghi')
+
+      visit admin_stats_path
+      click_link "Redeemable codes"
+
+      within("#redeemable_codes_count") do
+        expect(page).to have_content "3"
+      end
+    end
+
+    scenario "After campaign of June 17th 2016" do
+      create(:user, redeemable_code: 'abd', verified_at: Date.new(2016, 6, 16))
+      create(:user, redeemable_code: 'def', verified_at: Date.new(2016, 6, 17))
+      create(:user, redeemable_code: 'ghi', verified_at: Date.new(2016, 6, 18))
+
+      visit admin_stats_path
+      click_link "Redeemable codes"
+
+      within("#redeemable_codes_after_campaign_count") do
+        expect(page).to have_content "2"
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Añade una página con estadísticas sobre códigos de verificación por carta:

- Número total de códigos utilizados por usuarios
- Número de códigos utilizados desde la campaña de las 400.000 cartas