### PR TITLE
Do not store refer after sign out

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,7 @@ class Users::SessionsController < Devise::SessionsController
     end
 
     def after_sign_out_path_for(resource)
-      request.referrer.present? ? request.referrer : super
+      super
     end
 
     def verifying_via_email?

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -16,7 +16,7 @@ feature 'Sessions' do
     click_link 'Sign out'
 
     expect(page).to have_content('You have been signed out successfully')
-    expect(current_path).to eq(debate_path(debate))
+    expect(current_path).to eq(root_path)
   end
 
 end


### PR DESCRIPTION
Temporary to redirect users to participatory budgets