### PR TITLE
Fixes newsletter zip download

### DIFF
--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -6,8 +6,9 @@ class Admin::NewslettersController < Admin::BaseController
   def users
     zip = NewsletterZip.new('emails')
     zip.create
-    response.headers["X-Sendfile"] = nil
-    send_file(File.join(zip.path), type: 'application/zip')
+    File.open(File.join(zip.path), 'r') do |f|
+      send_data f.read, type: 'application/zip', filename: "emails.zip"
+    end
   end
 
 end

--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -6,6 +6,7 @@ class Admin::NewslettersController < Admin::BaseController
   def users
     zip = NewsletterZip.new('emails')
     zip.create
+    response.headers["X-Sendfile"] = nil
     send_file(File.join(zip.path), type: 'application/zip')
   end
 

--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.


### PR DESCRIPTION
- Consistent preproduction and production x-sendfile configuration
- Uses send_data instead of send_file to send newsletter file