### PR TITLE
Flagged probe option comments

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -17,10 +17,10 @@ module UsersHelper
       deleted_commentable_text(comment)
     elsif commentable.hidden?
       "<abbr title='#{deleted_commentable_text(comment)}'>".html_safe +
-      comment.commentable.commentable_title +
+      comment.commentable_title +
       "</abbr>".html_safe
     else
-      link_to(comment.commentable.commentable_title, comment)
+      link_to(comment.commentable_title, comment)
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,6 +17,8 @@ class Comment < ActiveRecord::Base
   belongs_to :commentable, -> { with_hidden }, polymorphic: true, counter_cache: true
   belongs_to :user, -> { with_hidden }
 
+  delegate :commentable_title, :commentable_path, to: :commentable
+
   before_save :calculate_confidence_score
 
   scope :for_render, -> { with_hidden.includes(user: :organization) }

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
   <div class="small-12 column margin-top">
-    <%= link_to @comment.commentable.commentable_path, class: "back" do %>
+    <%= link_to @comment.commentable_path, class: "back" do %>
       <span class="icon-angle-left"></span>
-      <%= t("comments.show.return_to_commentable") + @comment.commentable.commentable_title %>
+      <%= t("comments.show.return_to_commentable") + @comment.commentable_title %>
     <% end %>
   </div>
 </div>

--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -34,7 +34,7 @@
       <tr id="comment_<%= comment.id %>">
         <td>
           <%= comment.commentable_type.constantize.model_name.human %> -
-          <%= link_to comment.commentable.title, comment.commentable %>
+          <%= link_to comment.commentable_title, comment.commentable_path %>
           <br>
           <span class="date"><%= l comment.updated_at.to_date %></span>
           <span class="bullet">&nbsp;&bull;&nbsp;</span>

--- a/spec/features/moderation/comments_spec.rb
+++ b/spec/features/moderation/comments_spec.rb
@@ -192,5 +192,55 @@ feature 'Moderate comments' do
       expect("Flagged comment").to appear_before("Flagged newer comment")
       expect("Flagged newer comment").to appear_before("Newer comment")
     end
+
+    context "Commentables" do
+
+      scenario 'Proposal' do
+        proposal = create(:proposal)
+        comment  = create(:comment, :flagged, commentable: proposal)
+
+        moderator = create(:moderator)
+        login_as(moderator.user)
+
+       visit moderation_comments_path
+
+        expect(page).to have_content "Proposal"
+        expect(page).to have_link proposal.title, href: proposal_path(proposal)
+        expect(page).to have_content comment.body
+      end
+
+      scenario 'Debate' do
+        debate = create(:debate)
+        comment  = create(:comment, :flagged, commentable: debate)
+
+        visit moderation_comments_path
+
+        expect(page).to have_content "Debate"
+        expect(page).to have_link debate.title, href: debate_path(debate)
+        expect(page).to have_content comment.body
+      end
+
+      scenario 'Spending Proposal' do
+        spending_proposal = create(:spending_proposal)
+        comment  = create(:comment, :flagged, commentable: spending_proposal)
+
+        visit moderation_comments_path
+
+        expect(page).to have_content "Spending Proposal"
+        expect(page).to have_link spending_proposal.title, href: spending_proposal_path(spending_proposal)
+        expect(page).to have_content comment.body
+      end
+
+      scenario 'Probe Option' do
+        probe_option = create(:probe_option)
+        comment  = create(:comment, :flagged, commentable: probe_option)
+
+        visit moderation_comments_path
+
+        expect(page).to have_content "Probe option"
+        expect(page).to have_link probe_option.name, href: probe_probe_option_path(probe_option.probe.codename, probe_option.id)
+        expect(page).to have_content comment.body
+      end
+    end
   end
 end


### PR DESCRIPTION
- Moderators can see flagged probe option comments (fixes exception 758)
- Refactors commentable methods
- Adds commentable specs for moderators