### PR TITLE
Refactor of census_api to accept different response formats

### DIFF
--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -41,7 +41,7 @@ class CensusApi
     end
 
     def date_of_birth
-      str = data[:datos_habitante][:item][:fecha_nacimiento_string]
+      str = datos_habitante[:fecha_nacimiento_string]
       day, month, year = str.match(DDMMYYYY_REGEX).try(:[], 1..3)
       date = extract_date(year, month, day) || extract_date(year, day, month)
       unless date
@@ -60,7 +60,7 @@ class CensusApi
     end
 
     def gender
-      case data[:datos_habitante][:item][:descripcion_sexo]
+      case datos_habitante[:descripcion_sexo]
       when "Varón"
         "male"
       when "Mujer"
@@ -69,11 +69,11 @@ class CensusApi
     end
 
     def name
-      "#{data[:datos_habitante][:item][:nombre]} #{data[:datos_habitante][:item][:apellido1]}"
+      "#{datos_habitante[:nombre]} #{datos_habitante[:apellido1]}"
     end
 
     def document_number
-      str = data[:datos_habitante][:item][:identificador_documento]
+      str = datos_habitante[:identificador_documento]
     end
 
     private
@@ -87,11 +87,27 @@ class CensusApi
       end
 
       def datos_habitante
-        (data[:datos_habitante] && data[:datos_habitante][:item]) || {}
+        return {} if (data[:datos_habitante].blank? || data[:datos_habitante][:item].blank?)
+        case data[:datos_habitante][:item].class.name
+          when 'Hash'
+            data[:datos_habitante][:item]
+          when 'Array'
+            data[:datos_habitante][:item].last
+          else
+            {}
+        end
       end
 
       def datos_vivienda
-        (data[:datos_vivienda] && data[:datos_vivienda][:item]) || {}
+        return {} if (data[:datos_vivienda].blank? && data[:datos_vivienda][:item].blank?)
+        case data[:datos_vivienda][:item].class.name
+          when 'Hash'
+            data[:datos_vivienda][:item]
+          when 'Array'
+            data[:datos_vivienda][:item].last
+          else
+            {}
+        end
       end
 
       def data

--- a/spec/lib/census_api_spec.rb
+++ b/spec/lib/census_api_spec.rb
@@ -50,6 +50,16 @@ describe CensusApi do
 
       expect(response).to_not be_valid
     end
+
+    it "accepts response with array of items" do
+      item_array = {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {item:[{whatever: ""},{nombre: "Marie", apellido1: "Curie"}] }}}}
+
+      expect(api).to receive(:get_response_body).with(1, "123456").and_return(item_array)
+
+      response = api.call(1, "123456")
+      expect(response).to be_valid
+      expect(response.name).to eq("Marie Curie")
+    end
   end
 
   describe 'Response' do


### PR DESCRIPTION
Madrid Padrón API sometimes returns a hash, sometimes an array :tada: