### PR TITLE
uses starts_at/ends_at as dates instead of times

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -15,24 +15,24 @@ class Poll < ActiveRecord::Base
 
   validate :date_range
 
-  scope :current,  -> { where('starts_at <= ? and ? <= ends_at', Time.current, Time.current) }
-  scope :incoming, -> { where('? < starts_at', Time.current) }
-  scope :expired,  -> { where('ends_at < ?', Time.current) }
+  scope :current,  -> { where('starts_at <= ? and ? <= ends_at', Date.current.beginning_of_day, Date.current.beginning_of_day) }
+  scope :incoming, -> { where('? < starts_at', Date.current.beginning_of_day) }
+  scope :expired,  -> { where('ends_at < ?', Date.current.beginning_of_day) }
   scope :published,  -> { where('published = ?', true) }
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
   scope :with_nvotes, -> { where.not(nvotes_poll_id: nil) }
 
   scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
 
-  def current?(timestamp = DateTime.current)
+  def current?(timestamp = Date.current.beginning_of_day)
     starts_at <= timestamp && timestamp <= ends_at
   end
 
-  def incoming?(timestamp = DateTime.current)
+  def incoming?(timestamp = Date.current.beginning_of_day)
     timestamp < starts_at
   end
 
-  def expired?(timestamp = DateTime.current)
+  def expired?(timestamp = Date.current.beginning_of_day)
     ends_at < timestamp
   end
 


### PR DESCRIPTION
Temp fix. Once rotation is over both fields should be migrated from datetime to date type.