### PR TITLE
circumvents acts_as_taggable_on problem with uppercased tags

### DIFF
--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -36,6 +36,9 @@ module ActsAsTaggableOn
 
   Tag.class_eval do
 
+    has_many :proposals, through: :taggings, source: :taggable, source_type: 'Proposal'
+    has_many :debates, through: :taggings, source: :taggable, source_type: 'Debate'
+
     def increment_custom_counter_for(taggable_type)
       Tag.increment_counter(custom_counter_field_name_for(taggable_type), id)
     end
@@ -67,8 +70,8 @@ module ActsAsTaggableOn
 
     def public_for_api?
       return false unless [nil, "category"].include? kind
-      return false unless Proposal.tagged_with(self).any? {|proposal| proposal.public_for_api? } || Debate.tagged_with(self).any? {|debate| debate.public_for_api? }
-      return false unless self.taggings.any? {|tagging| tagging.public_for_api? }
+      return false unless proposals.any?(&:public_for_api?) || debates.any?(&:public_for_api?)
+      return false unless self.taggings.any?(&:public_for_api?)
       return true
     end
 

--- a/spec/features/api/csv_exporter_spec.rb
+++ b/spec/features/api/csv_exporter_spec.rb
@@ -439,6 +439,34 @@ feature 'CSV Exporter' do
       expect(csv).to_not include("Admin tag")
     end
 
+    scenario "Uppercase and lowercase tags work ok together for proposals" do
+      create(:tag, name: "Health")
+      create(:tag, name: "health")
+      create(:proposal, tag_list: "health")
+      create(:proposal, tag_list: "Health")
+      @csv_exporter.export
+
+      visit csv_path_for("tags")
+      csv = CSV.parse(page.html).flatten
+
+      expect(csv).to include("health")
+      expect(csv).to include("Health")
+    end
+
+    scenario "Uppercase and lowercase tags work ok together for debates" do
+      create(:tag, name: "Health")
+      create(:tag, name: "health")
+      create(:debate, tag_list: "Health")
+      create(:debate, tag_list: "health")
+      @csv_exporter.export
+
+      visit csv_path_for("tags")
+      csv = CSV.parse(page.html).flatten
+
+      expect(csv).to include("health")
+      expect(csv).to include("Health")
+    end
+
     scenario "Do not display tags for hidden proposals" do
       proposal = create(:proposal, tag_list: "Health")
       hidden_proposal = create(:proposal, tag_list: "SPAM", hidden_at: Time.now)
@@ -453,7 +481,7 @@ feature 'CSV Exporter' do
     end
 
     scenario "Do not display tags for hidden debates" do
-      debate = create(:debate, tag_list: "Health")
+      debate = create(:debate, tag_list: "Health, Transportation")
       hidden_debate = create(:debate, tag_list: "SPAM", hidden_at: Time.now)
 
       @csv_exporter.export


### PR DESCRIPTION
Problem is that we have some duplicated tags in production with
uppercase and lowercase (e.g. "Medios" and "medios"). The gem expects
them to be all lowercase. And as such, some methods of the gem fail
(`Proposal.tagged_with('Medios')` returns 0 results). So I have
implemented my own thing using activerecord relationships.

Reference issue in acts_as_taggable_on:
https://github.com/mbleigh/acts-as-taggable-on/issues/661