### PR TITLE
Fixs specs and translations

### DIFF
--- a/app/models/concerns/verification.rb
+++ b/app/models/concerns/verification.rb
@@ -61,4 +61,16 @@ module Verification
   def sms_code_not_confirmed?
     !sms_verified?
   end
+
+  def user_type
+    case
+    when level_three_verified?
+      :level_3_user
+    when level_two_verified?
+      :level_2_user
+    else
+      :level_1_user
+    end
+  end
+
 end

--- a/app/views/admin/hidden_users/show.html.erb
+++ b/app/views/admin/hidden_users/show.html.erb
@@ -3,11 +3,11 @@
 <h2><%= t("admin.hidden_users.show.title", user: @user.name) %></h2>
 
 <p>
-  <strong><%= t("admin.users.show.email") %></strong> <%= @user.email %> |
-  <strong><%= t("admin.users.show.phone") %></strong> <%= @user.phone %> |
-  <strong><%= t("admin.users.show.registered_at") %></strong>
+  <strong><%= t("admin.hidden_users.show.email") %></strong> <%= @user.email %> |
+  <strong><%= t("admin.hidden_users.show.phone") %></strong> <%= @user.phone %> |
+  <strong><%= t("admin.hidden_users.show.registered_at") %></strong>
   <%= l @user.confirmed_at, format: :long %> |
-  <strong><%= t("admin.users.show.hidden_at") %></strong> <%= @user.hidden_at || "No" %>
+  <strong><%= t("admin.hidden_users.show.hidden_at") %></strong> <%= @user.hidden_at || "No" %>
 </p>
 
 <% if @debates.present? %>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -200,6 +200,7 @@ en:
       show:
         email: 'Email:'
         hidden_at: 'Hidden at:'
+        phone: 'Phone:'
         registered_at: 'Registered at:'
         title: Activity of user (%{user})
     legislation:
@@ -927,18 +928,7 @@ en:
         roles: Roles
         verification_level: Verification level
       index:
-        filter: Filter
-        filters:
-          all: All
-          with_confirmed_hide: Confirmed
-          without_confirmed_hide: Pending
         title: Hidden users
-      show:
-        email: 'Email:'
-        phone: Phone
-        hidden_at: 'Hidden at:'
-        registered_at: 'Registered at:'
-        title: Activity of user (%{user})
       search:
         placeholder: Search user by email, name or document number
         search: Search

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -200,6 +200,7 @@ es:
       show:
         email: 'Email:'
         hidden_at: 'Bloqueado:'
+        phone: 'Teléfono:'
         registered_at: 'Fecha de alta:'
         title: Actividad del usuario (%{user})
     legislation:
@@ -927,18 +928,7 @@ es:
         roles: Roles
         verification_level: Nivel de verficación
       index:
-        filter: Filtro
-        filters:
-          all: Todos
-          with_confirmed_hide: Confirmados
-          without_confirmed_hide: Pendientes
         title: Usuarios
-      show:
-        email: 'Email:'
-        phone: Teléfono
-        hidden_at: 'Bloqueado:'
-        registered_at: 'Fecha de alta:'
-        title: Actividad del usuario (%{user})
       search:
         placeholder: Buscar usuario por email, nombre o DNI
         search: Buscar

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 feature 'Admin users' do
+
   background do
     @admin = create(:administrator)
     @user  = create(:user, username: 'Jose Luis Balbin')

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -10,9 +10,6 @@ feature 'Legislation' do
 
       visit legislation_processes_path(filter: 'next')
       expect(page).to have_text "There aren't planned processes"
-
-      visit legislation_processes_path(filter: 'past')
-      expect(page).to have_text "There aren't past processes"
     end
 
     scenario 'Processes can be listed' do


### PR DESCRIPTION
- We were missing a method (user_type) only available in Consul due to refactoring in Madrid
- Some misplaced translations (hidden_users vs users)
- Add a spec that is not aplicable to Madrid (display no archived processes)