### PR TITLE
Reduce the amount of logs in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
What
====
Changes log level in production from debug to warning

Why
===
We are using 10G of hard drive space per day

Warning
===
Doing this in Madrid to avoid conflicts with an open PR in Consul consul/consul#1664
