### PR TITLE
Adds links to figure and figcaptions

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -3031,6 +3031,18 @@ h3.kit-decide {
     width: 48px;
   }
 
+  a {
+
+    h3,
+    .title {
+      color: #fff;
+    }
+
+    &:hover {
+     text-decoration: none;
+    }
+  }
+
   figcaption {
     bottom: 0;
     color: #fff;
@@ -3043,7 +3055,7 @@ h3.kit-decide {
     width: 100%;
 
     h3,
-    p.title {
+    .title {
       font-family: 'Franklin Gothic' !important;
       font-size: rem-calc(36);
       line-height: rem-calc(36);

--- a/app/assets/stylesheets/custom/_once_plazas.scss
+++ b/app/assets/stylesheets/custom/_once_plazas.scss
@@ -57,10 +57,21 @@
     }
   }
 
+  a {
+
+    h3 {
+      color: #fff;
+    }
+
+    &:hover {
+     text-decoration: none;
+    }
+  }
+
   a:not(.button) {
     color: #000;
 
-    span {
+    .attachment {
       display: inline-block;
       line-height: rem-calc(20);
       margin-left: $line-height / 4;

--- a/app/views/pages/processes/once_plazas/index.html.erb
+++ b/app/views/pages/processes/once_plazas/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <% provide :social_media_meta_tags do %>
 <!-- Facebook OG -->
-<meta property="og:url"           content="https://decide.madrid.es/proceso/once-plazas" />
+<meta property="og:url"           content="<%= once_plazas_url %>" />
 <meta property="og:title"         content="Plan MAD-RE: Remodelación de 11 plazas en la periferia de Madrid" />
 <meta property="og:image"         content="<%= image_url '/social_media_once_plazas.png' %>" />
 <meta property="og:description"   content="Participa en el debate del concurso de ideas previo a la remodelación de 11 plazas públicas en los distritos de la periferia de Madrid." />

--- a/app/views/pages/processes/once_plazas/index.html.erb
+++ b/app/views/pages/processes/once_plazas/index.html.erb
@@ -66,17 +66,23 @@
       <div class="small-12 medium-6 large-4 column figure-box end">
         <div class="figure-container-card" data-equalizer-watch>
           <figure class="figure-card">
-            <%= image_tag "once_plazas/#{slug}.jpg", alt: "" %>
+            <%= link_to "https://decide.madrid.es/legislation/processes/#{process_id}/debate",
+                         title: "Ver proceso de #{name}" do %>
+              <%= image_tag "once_plazas/#{slug}.jpg", alt: "" %>
+            <% end %>
             <figcaption>
-              <span><%= district %></span><br>
-              <h3><%= name %></h3>
+              <%= link_to "https://decide.madrid.es/legislation/processes/#{process_id}/debate",
+                         title: "Ver proceso de #{name}" do %>
+                <span><%= district %></span><br>
+                <h3><%= name %></h3>
+              <% end %>
             </figcaption>
           </figure>
           <ul class="no-bullet">
             <li>
               <%= link_to "/docs/procesos/once_plazas/#{slug}.pdf", target: "_blank",
                           title: "Descargar mapa informativo de #{name} PDF - #{pdf_size}Kb (se abre en ventana nueva)" do %>
-                <%= image_tag "budgets_materials_2017/icon_diptico.png", alt: "" %><span>Mapa de <%= name %></span>
+                <%= image_tag "budgets_materials_2017/icon_diptico.png", alt: "" %><span class="attachment">Mapa de <%= name %></span>
               <% end %>
             </li>
             <li>

--- a/app/views/polls/results_2017.html.erb
+++ b/app/views/polls/results_2017.html.erb
@@ -43,10 +43,16 @@
     </div>
     <div class="small-12 medium-6 column">
       <figure class="figure-card pdf">
-        <%= image_tag "landings/first_voting_sustainable_report.jpg", alt: t("polls_reports.img_alt_1") %>
+        <%= link_to "/docs/informe_tecnico_100_sostenible.pdf", target: "_blank",
+                    title: t("polls_reports.label") + ' - ' + t("polls_reports.title_1") + ' - ' + 'PDF 712kb' do %>
+          <%= image_tag "landings/first_voting_sustainable_report.jpg", alt: t("polls_reports.img_alt_1") %>
+        <% end %>
         <figcaption>
-          <span><%= t("polls_reports.label") %></span><br>
-          <%= t("polls_reports.title_1") %>
+          <%= link_to "/docs/informe_tecnico_100_sostenible.pdf", target: "_blank",
+                      title: t("polls_reports.label") + ' - ' + t("polls_reports.title_1") + ' - ' + 'PDF 712kb' do %>
+            <span><%= t("polls_reports.label") %></span><br>
+            <p class="title"><%= t("polls_reports.title_1") %></p>
+          <% end %>
         </figcaption>
       </figure>
       <p><%= t("polls_reports.description_1_html") %></p>
@@ -58,10 +64,16 @@
     </div>
     <div class="small-12 medium-6 column">
       <figure class="figure-card pdf">
-        <%= image_tag "landings/first_voting_transport_report.jpg", alt: t("polls_reports.img_alt_2") %>
+        <%= link_to "/docs/informe_tecnico_billete_unico.pdf", target: "_blank",
+                      title: t("polls_reports.label") + ' - ' + t("polls_reports.title_2") + ' - ' + 'PDF 514kb' do %>
+          <%= image_tag "landings/first_voting_transport_report.jpg", alt: t("polls_reports.img_alt_2") %>
+        <% end %>
         <figcaption>
-          <span><%= t("polls_reports.label") %></span><br>
-          <%= t("polls_reports.title_2") %>
+          <%= link_to "/docs/informe_tecnico_billete_unico.pdf", target: "_blank",
+                        title: t("polls_reports.label") + ' - ' + t("polls_reports.title_2") + ' - ' + 'PDF 514kb' do %>
+            <span><%= t("polls_reports.label") %></span><br>
+            <p class="title"><%= t("polls_reports.title_2") %></p>
+          <% end %>
         </figcaption>
       </figure>
       <p><%= t("polls_reports.description_2_html") %></p>

--- a/app/views/welcome/_budgets_module_extra.html.erb
+++ b/app/views/welcome/_budgets_module_extra.html.erb
@@ -1,10 +1,14 @@
 <div class="row margin">
   <div class="small-12 medium-6 column">
     <figure class="figure-card">
-      <%= image_tag "welcome_once_plazas.jpg", alt: "" %>
+      <%= link_to once_plazas_path, title: t("welcome.budgets.once_plazas.link") do %>
+        <%= image_tag "welcome_once_plazas.jpg", alt: "" %>
+      <% end %>
       <figcaption>
-        <span><%= t("welcome.budgets.once_plazas.label") %></span><br>
-        <%= t("welcome.budgets.once_plazas.title") %>
+        <%= link_to once_plazas_path, title: t("welcome.budgets.once_plazas.link") do %>
+          <span><%= t("welcome.budgets.once_plazas.label") %></span><br>
+          <p class="title"><%= t("welcome.budgets.once_plazas.title") %></p>
+        <% end %>
       </figcaption>
     </figure>
     <p><%= t("welcome.budgets.once_plazas.text") %></p>
@@ -14,10 +18,14 @@
   </div>
   <div class="small-12 medium-6 column">
     <figure class="figure-card">
-      <%= image_tag "welcome_budgets_videos.jpg", alt: "" %>
+      <%= link_to budgets_videos_2017_path, title: t("welcome.budgets.videos.link") do %>
+        <%= image_tag "welcome_budgets_videos.jpg", alt: "" %>
+      <% end %>
       <figcaption>
-        <span><%= t("welcome.budgets.videos.label") %></span><br>
-        <%= t("welcome.budgets.videos.title") %>
+        <%= link_to budgets_videos_2017_path, title: t("welcome.budgets.videos.link") do %>
+          <span><%= t("welcome.budgets.videos.label") %></span><br>
+          <p class="title"><%= t("welcome.budgets.videos.title") %></p>
+        <% end %>
       </figcaption>
     </figure>
     <p><%= t("welcome.budgets.videos.text") %></p>

--- a/app/views/welcome/_features.html.erb
+++ b/app/views/welcome/_features.html.erb
@@ -12,10 +12,14 @@
   <div class="row margin-top">
     <div class="small-12 medium-6 column">
       <figure class="figure-card">
-        <%= image_tag "welcome_featured_proposals.png", alt: t("welcome.featured.proposals.alt_image") %>
+        <%= link_to proposals_path, title: t("welcome.featured.proposals.link") do %>
+          <%= image_tag "welcome_featured_proposals.png", alt: t("welcome.featured.proposals.alt_image") %>
+        <% end %>
         <figcaption>
-          <span><%= t("welcome.featured.label") %></span><br>
-          <h3><%= t('welcome.featured.proposals.title') %></h3>
+          <%= link_to proposals_path, title: t("welcome.featured.proposals.link") do %>
+            <span><%= t("welcome.featured.label") %></span><br>
+            <h3><%= t('welcome.featured.proposals.title') %></h3>
+          <% end %>
         </figcaption>
       </figure>
       <p><%= t('welcome.featured.proposals.text') %></p>
@@ -24,10 +28,14 @@
 
     <div class="small-12 medium-6 column">
       <figure class="figure-card">
-        <%= image_tag "welcome_featured_budgets.png", alt: t("welcome.featured.budgets.alt_image") %>
+        <%= link_to budgets_welcome_path, title: t("welcome.featured.budgets.link") do %>
+          <%= image_tag "welcome_featured_budgets.png", alt: t("welcome.featured.budgets.alt_image") %>
+        <% end %>
         <figcaption>
-          <span><%= t("welcome.featured.label") %></span><br>
-          <h3><%= t('welcome.featured.budgets.title') %></h3>
+          <%= link_to budgets_welcome_path, title: t("welcome.featured.budgets.link") do %>
+            <span><%= t("welcome.featured.label") %></span><br>
+            <h3><%= t('welcome.featured.budgets.title') %></h3>
+          <% end %>
         </figcaption>
       </figure>
       <p><%= t('welcome.featured.budgets.text') %></p>

--- a/app/views/welcome/_polls_reports.html.erb
+++ b/app/views/welcome/_polls_reports.html.erb
@@ -1,10 +1,16 @@
 <div class="row margin">
   <div class="small-12 medium-6 column">
     <figure class="figure-card pdf">
-      <%= image_tag "landings/first_voting_sustainable_report_big.jpg", alt: t("polls_reports.img_alt_1") %>
+      <%= link_to "/docs/informe_tecnico_100_sostenible.pdf", target: "_blank",
+                  title: t("polls_reports.label") + ' - ' + t("polls_reports.title_1") + ' - ' + 'PDF 712kb' do %>
+        <%= image_tag "landings/first_voting_sustainable_report_big.jpg", alt: t("polls_reports.img_alt_1") %>
+      <% end %>
       <figcaption>
-        <span><%= t("polls_reports.label") %></span><br>
-        <%= t("polls_reports.title_1") %>
+        <%= link_to "/docs/informe_tecnico_100_sostenible.pdf", target: "_blank",
+                    title: t("polls_reports.label") + ' - ' + t("polls_reports.title_1") + ' - ' + 'PDF 712kb' do %>
+          <span><%= t("polls_reports.label") %></span><br>
+          <p class="title"><%= t("polls_reports.title_1") %></p>
+        <% end %>
       </figcaption>
     </figure>
     <p><%= t("polls_reports.description_1_html") %></p>
@@ -15,10 +21,16 @@
   </div>
   <div class="small-12 medium-6 column">
     <figure class="figure-card pdf">
-      <%= image_tag "landings/first_voting_transport_report_big.jpg", alt: t("polls_reports.img_alt_2") %>
+      <%= link_to "/docs/informe_tecnico_billete_unico.pdf", target: "_blank",
+                  title: t("polls_reports.label") + ' - ' + t("polls_reports.title_2") + ' - ' + 'PDF 514kb' do %>
+        <%= image_tag "landings/first_voting_transport_report_big.jpg", alt: t("polls_reports.img_alt_2") %>
+      <% end %>
       <figcaption>
-        <span><%= t("polls_reports.label") %></span><br>
-        <%= t("polls_reports.title_2") %>
+        <%= link_to "/docs/informe_tecnico_billete_unico.pdf", target: "_blank",
+                    title: t("polls_reports.label") + ' - ' + t("polls_reports.title_2") + ' - ' + 'PDF 514kb' do %>
+          <span><%= t("polls_reports.label") %></span><br>
+          <p class="title"><%= t("polls_reports.title_2") %></p>
+        <% end %>
       </figcaption>
     </figure>
     <p><%= t("polls_reports.description_2_html") %></p>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -5,7 +5,7 @@
   <%= render "shared/canonical", href: root_url %>
 <% end %>
 
-<% cache ["welcome_index_20170621", user_signed_in?] do %>
+<% cache ["welcome_index_20170621b", user_signed_in?] do %>
   <div class="welcome">
 
     <h1 class="show-for-sr"><%= t("welcome.title") %></h1>


### PR DESCRIPTION
Para que sea más fácil navegar (sobre todo en la versión móvil) se han añadido enlaces a las imágenes `<figure>` y títulos `<figcaption>` de las páginas _welcome_, _landing_ del proceso "Once Plazas" y en la página de `resultados de la votación`.