### PR TITLE
Kit decide

### DIFF
--- a/app/views/pages/more_info/kit_decide/index.html.erb
+++ b/app/views/pages/more_info/kit_decide/index.html.erb
@@ -26,6 +26,7 @@
 
 <div class="row" data-sticky-container>
   <div class="small-12 column text-center sticky"
+       id="kit-decide"
        data-sticky
        data-top-anchor="kit-decide-content"
        data-margin-top="0">


### PR DESCRIPTION
- Añade un `id` en el menú de la página "Kit decide" necesario para que funcione el `sticky`