### PR TITLE
Allow admins to see budget results

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -1,6 +1,7 @@
 module Budgets
   class ResultsController < ApplicationController
     before_action :load_budget
+    before_action :load_heading
 
     load_and_authorize_resource :budget
 
@@ -12,15 +13,19 @@ module Budgets
     private
 
       def load_result
-        Budget::Result.new(@budget, heading)
+        Budget::Result.new(@budget, @heading)
       end
 
       def load_budget
         @budget = Budget.find_by(slug: params[:budget_id])
       end
 
-      def heading
-        @budget.headings.find_by(slug: params[:heading_id])
+      def load_heading
+        if params[:heading_id].present?
+          @heading = @budget.headings.find_by(slug: params[:heading_id])
+        else
+          @heading = @budget.headings.first
+        end
       end
 
   end

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -49,7 +49,7 @@ module Abilities
 
       can [:read, :valuate, :summary], SpendingProposal
 
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners, :read_results], Budget
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :update, :toggle_selection], Budget::Investment

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -45,6 +45,18 @@ feature 'Results' do
     end
   end
 
+  scenario "Load first budget heading if not specified" do
+    other_heading = create(:budget_heading, group: group)
+    other_investment = create(:budget_investment, :winner, heading: other_heading)
+
+    visit budget_results_path(budget)
+
+    within("#budget-investments-results") do
+      expect(page).to have_content investment1.title
+      expect(page).to_not have_content other_investment.title
+    end
+  end
+
   scenario "If budget is in a phase different from finished results can't be accessed" do
     budget.update phase: (Budget::PHASES - ["finished"]).sample
     visit budget_path(budget)

--- a/spec/models/abilities/administrator_spec.rb
+++ b/spec/models/abilities/administrator_spec.rb
@@ -93,6 +93,7 @@ describe "Abilities::Administrator" do
 
   it { should be_able_to(:create, Budget) }
   it { should be_able_to(:update, Budget) }
+  it { should be_able_to(:read_results, Budget) }
 
   it { should be_able_to(:create, Budget::ValuatorAssignment) }
 

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -457,6 +457,4 @@ describe "Abilities::Common" do
     it { should_not be_able_to(:destroy, own_spending_proposal) }
   end
 
-
-
 end

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -8,6 +8,9 @@ describe "Abilities::Everyone" do
   let(:debate) { create(:debate) }
   let(:proposal) { create(:proposal) }
 
+  let(:reviewing_ballot_budget) { create(:budget, phase: 'reviewing_ballots') }
+  let(:finished_budget) { create(:budget, phase: 'finished') }
+
   it { should be_able_to(:index, Debate) }
   it { should be_able_to(:show, debate) }
   it { should_not be_able_to(:edit, Debate) }
@@ -43,5 +46,7 @@ describe "Abilities::Everyone" do
   pending "only authors can access new and create for ProposalNotifications"
 
   it { should be_able_to(:index, Budget) }
+  it { should be_able_to(:read_results, finished_budget) }
+  it { should_not be_able_to(:read_results, reviewing_ballot_budget) }
 
 end


### PR DESCRIPTION
What
====
- Allows admins to see budget results in the _reviewing_ballots_ phase
- Allows all users to see budget results in the _finished_ phase 
- Loads the results for the first heading if no heading is specified
- Removes duplicate permission in _abilities/everyone.rb_

How
===
- Using _cancan_ permissions

Test
====
- Log in as an admin and visit the results page of a budget
- Without being logged in visit the results page of a budget

Deployment
==========
- As usual

Warnings
========
- You might have to set manually the budget phases to test manually
