### PR TITLE
CSV export to shared server

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,6 +31,6 @@ every 29.minutes do
   rake "-s budgets:stats:balloting"
 end
 
-every 1.day, at: '4:00 am', roles: [:db] do
+every 1.day, at: '4:00 am', roles: [:cron] do
   rake "csv:export"
 end

--- a/lib/api/csv_exporter.rb
+++ b/lib/api/csv_exporter.rb
@@ -53,7 +53,7 @@ class API::CSVExporter
     end
 
     def folder
-      "public/api/"
+      "public/system/api/"
     end
 
 end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -468,7 +468,7 @@ module CommonActions
   end
 
   def csv_path_for(table)
-    "api/#{table}.csv"
+    "system/api/#{table}.csv"
   end
 
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/transparencia/issues/134

What
====
The csv files that are exported everynight live on each server, and since we have a ton of pdf/documents on the git repo and server capacity is limited... some nights we run out of spaces and files are not generated... breaking the daily release of data.

We need to use the new shared server that lives linked at `/public/system` so we:
- Don't run out of space
- Don't hold same files on 3 servers (just on one)

How
===
- Changing de destination folder for csv files on csv export rake task
- Changing the rake task scheduler role to "cron", since only one out of the 3 production servers (and one out of 2 preproduction) have that role, so only one will try to write on the shared server/folder.
- Created destination `/api` folder manually on both pre and pro servers on route `/participacion/shared/public/system/api`

Screenshots
===========
No need

Test
====
Deployed to preproductio with `cap preproduction deploy branch=feature/csv_export_shared_server` and tested shared folder

Deployment
==========
None

Warnings
========
Once deployed to production we must to inform datosabiertos@madrid.es about it so they use following urls instead of files:

```
https://decide.madrid.es/system/api/proposals.csv
https://decide.madrid.es/system/api/debates.csv
https://decide.madrid.es/system/api/comments.csv
https://decide.madrid.es/system/api/geozones.csv
https://decide.madrid.es/system/api/proposal_notifications.csv
https://decide.madrid.es/system/api/tags.csv
https://decide.madrid.es/system/api/taggings.csv
https://decide.madrid.es/system/api/votes.csv
```