### PR TITLE
Budget results improvements

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -18,7 +18,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id])
+        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
       end
 
       def load_heading

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -34,13 +34,13 @@
   <div class="small-12 medium-3 column">
     <ul class="menu vertical no-margin-top no-padding-top">
       <li>
-        <strong>
+        <h3>
           <%= t("budgets.results.heading_selection_title") %>
-        </strong>
+        </h3>
       </li>
 
-      <% @budget.headings.each do |heading| %>
-        <% active_class = heading.id.to_s == params[:heading_id] ? 'bold' : '' %>
+      <% @budget.headings.order('id ASC').each do |heading| %>
+        <% active_class = heading.to_param == params[:heading_id] ? 'bold' : '' %>
         <li class="<%= active_class %>">
           <%= link_to heading.name,
                       custom_budget_results_path(@budget, heading_id: heading.to_param) %>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -17,11 +17,25 @@
 </div>
 
 <div class="row margin-top">
+  <div class="small-12 column">
+    <ul class="tabs">
+      <li class="tabs-title is-active">
+        <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
+        <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget, heading_id: @budget.headings.first.to_param), class: "is-active"  %>
+      </li>
+      <li class="tabs-title">
+        <%= link_to t("budgets.stats.link"), custom_budget_stats_path(@budget)%>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div class="row">
   <div class="small-12 medium-3 column">
     <ul class="menu vertical no-margin-top no-padding-top">
       <li>
         <strong>
-          <%= t("budgets.results.geozone_selection_title") %>
+          <%= t("budgets.results.heading_selection_title") %>
         </strong>
       </li>
 
@@ -29,7 +43,7 @@
         <% active_class = heading.id.to_s == params[:heading_id] ? 'bold' : '' %>
         <li class="<%= active_class %>">
           <%= link_to heading.name,
-                      budget_results_path(@budget, heading_id: heading.to_param) %>
+                      custom_budget_results_path(@budget, heading_id: heading.to_param) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -43,7 +43,7 @@
 
       <% if @budget.finished? %>
         <%= link_to t("budgets.show.see_results"),
-                    budget_results_path(@budget, heading_id: @budget.headings.first),
+                    custom_budget_results_path(@budget, heading_id: @budget.headings.first),
                     class: "button margin-top expanded" %>
       <% end %>
     </div>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -22,14 +22,14 @@
     <div class="row margin-top">
       <div class="small-12 column">
         <ul class="tabs">
-          <!-- Pending results tab
+          <% if @budget.finished? %>
             <li class="tabs-title">
-            <%# link_to t("budget.results.link"), budget_results_path(@budget) %>
+              <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
+              <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget, heading_id: @budget.headings.first.to_param) %>
             </li>
-          -->
+          <% end %>
           <li class="tabs-title is-active">
-            <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-            <%= link_to t("budgets.stats.link"), budget_stats_path(@budget), class: "is-active" %>
+            <%= link_to t("budgets.stats.link"), custom_budget_stats_path(@budget), class: "is-active" %>
           </li>
         </ul>
       </div>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -127,10 +127,10 @@ en:
       unselected: See investments not selected for balloting phase
       see_results: See results
     results:
-      #link: Results
+      link: Results
       page_title: "%{budget} - Results"
       heading: "Participatory budget results"
-      geozone_selection_title: "By district"
+      heading_selection_title: "By district"
       spending_proposal: Proposal title
       ballot_lines_count: Times selected
       hide_discarded_link: Hide discarded

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -127,10 +127,10 @@ es:
       unselected: Ver las propuestas no seleccionadas para la votación final
       see_results: Ver resultados
     results:
-      #link: Resultados
+      link: Resultados
       page_title: "%{budget} - Resultados"
       heading: "Resultados presupuestos participativos"
-      geozone_selection_title: "Ámbito de actuación"
+      heading_selection_title: "Ámbito de actuación"
       spending_proposal: Título
       ballot_lines_count: Votos
       hide_discarded_link: Ocultar descartadas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
   get 'participatory_budget',                to: 'pages#show', id: 'budgets/welcome',            as: 'participatory_budget'
   get 'presupuestos', to: 'pages#show', id: 'more_info/budgets/welcome',  as: 'budgets_welcome'
   get "presupuestos/:id/estadisticas", to: "budgets/stats#show", as: 'custom_budget_stats'
+  get "presupuestos/:id/resultados", to: "budgets/results#show", as: 'custom_budget_results'
 
   resources :budgets, only: [:show, :index], path: 'presupuestos' do
     resources :groups, controller: "budgets/groups", only: [:show], path: 'grupo'

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -50,7 +50,7 @@ feature 'Results' do
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)
 
-    visit budget_results_path(budget)
+    visit custom_budget_results_path(budget)
 
     within("#budget-investments-compatible") do
       expect(page).to have_content investment1.title
@@ -63,7 +63,7 @@ feature 'Results' do
     visit budget_path(budget)
     expect(page).not_to have_link "See results"
 
-    visit budget_results_path(budget, heading_id: budget.headings.first)
+    visit custom_budget_results_path(budget, heading_id: budget.headings.first)
     expect(page).to have_content "You do not have permission to carry out the action"
   end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:**
- https://github.com/AyuntamientoMadrid/consul/issues/844 (points 1 & 2)
- https://github.com/consul/consul/issues/1737 (point 1)

What
====
1- Custom translated route for results `resultados`
2- Link between Stats and Results pages with custom routes `resultados` and `estadisticas`
3- Make Results current heading active
4- Order Results headings by id (make "All city" be the first heading on results page)

How
===
- Adding a new named custom route for results
- Adding missing tab links on both stats and results pages (making sure the Results tab on Stats page only shows when Budget is on Finished status) for everything else the Abilities take care
- Check the current heading from the params (using slugs, instead of id's as consul still behind on that)
- Order by id ASC, as we know for now its enough to make "Toda la ciudad" appear as first heading.

Screenshots
===========
## Results link on Stats page:
![screen shot 2017-07-12 at 12 44 06](https://user-images.githubusercontent.com/983242/28114150-d09b1228-66ff-11e7-8358-0c262438b8de.jpg)
## Stats link on Results page, plus current heading shown as active:
![screen shot 2017-07-12 at 12 44 02](https://user-images.githubusercontent.com/983242/28114151-d0a03064-66ff-11e7-83b7-24bfee05bc37.jpg)

Test
====
- I think updated, but lets see travis

Deployment
==========
- As usual

Warnings
========
- Many of this changes should be ported back to consul 
