### PR TITLE
Budget results urls

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -2832,6 +2832,13 @@ h2.map-title {
   }
 }
 
+.min-width-100 {
+
+  @include breakpoint(medium) {
+    min-width: rem-calc(100);
+  }
+}
+
 // 12. Nvotes
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -230,6 +230,11 @@ a {
     a {
       color: $text-medium;
       padding: 0;
+
+      &.bold {
+        font-weight: bold;
+        color: $brand;
+      }
     }
 
     h2 {
@@ -238,11 +243,6 @@ a {
 
     &.active {
       border-bottom: 2px solid $brand;
-      color: $brand;
-    }
-
-    &.bold {
-      font-weight: bold;
       color: $brand;
     }
   }

--- a/app/views/budgets/results/_results_table.html.erb
+++ b/app/views/budgets/results/_results_table.html.erb
@@ -1,4 +1,4 @@
-<div class="small-12 medium-9 column <%= results_type == :compatible ? 'success' : 'js-discarded' %>"
+<div class="small-12 medium-9 large-10 column <%= results_type == :compatible ? 'success' : 'js-discarded' %>"
      style="<%= results_type != :compatible ? 'display: none' : '' %>"
      id="<%= results_type %>-container">
 
@@ -15,13 +15,13 @@
         <th scope="col" class="text-center">
           <%= t("budgets.results.ballot_lines_count") %>
         </th>
-        <th scope="col" class="text-center">
+        <th scope="col" class="text-center min-width-100">
           <%= t("budgets.results.price") %>
         </th>
         <% if results_type == :compatible %>
           <th scope="col" class="text-right">
-            <%= format_price(heading_price) %><br>
-            <small><%= t("budgets.results.amount_available") %></small>
+            <small><%= t("budgets.results.amount_available") %></small><br>
+            <%= format_price(heading_price) %>
           </th>
         <% end %>
       </tr>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -43,7 +43,7 @@
         <% active_class = heading.to_param == params[:heading_id] ? 'bold' : '' %>
         <li class="<%= active_class %>">
           <%= link_to heading.name,
-                      custom_budget_results_path(@budget, heading_id: heading.to_param) %>
+                      custom_budget_heading_result_path(@budget, heading_id: heading.to_param) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -38,10 +38,10 @@
       </li>
 
       <% @budget.headings.order('id ASC').each do |heading| %>
-        <% active_class = heading.to_param == @heading.to_param ? 'bold' : '' %>
-        <li class="<%= active_class %>">
+        <li>
           <%= link_to heading.name,
-                      custom_budget_heading_result_path(@budget, heading_id: heading.to_param) %>
+                      custom_budget_heading_result_path(@budget, heading_id: heading.to_param),
+                      class: heading.to_param == @heading.to_param ? 'bold' : '' %>
         </li>
       <% end %>
     </ul>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -29,22 +29,22 @@
 </div>
 
 <div class="row">
-  <div class="small-12 medium-3 column">
-    <ul class="menu vertical no-margin-top no-padding-top">
-      <li>
+  <div class="small-12 medium-3 large-2 column">
+    <div class="row">
+      <ul class="menu vertical no-margin-top no-padding-top">
         <h3>
           <%= t("budgets.results.heading_selection_title") %>
         </h3>
-      </li>
 
-      <% @budget.headings.order('id ASC').each do |heading| %>
-        <li>
-          <%= link_to heading.name,
-                      custom_budget_heading_result_path(@budget, heading_id: heading.to_param),
-                      class: heading.to_param == @heading.to_param ? 'bold' : '' %>
-        </li>
-      <% end %>
-    </ul>
+        <% @budget.headings.order('id ASC').each do |heading| %>
+          <li>
+            <%= link_to heading.name,
+                        custom_budget_heading_result_path(@budget, heading_id: heading.to_param),
+                        class: heading.to_param == @heading.to_param ? 'bold' : '' %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 
   <span class="float-right"><%= link_to t("budgets.results.show_all_link"), "#", class: "js-toggle-link button hollow margin-bottom", data: {'toggle-selector' => '.js-discarded', 'toggle-text' => t("budgets.results.hide_discarded_link")} %></span>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -3,15 +3,13 @@
   <%= render "shared/canonical", href: budget_results_url(@budget, heading_id: @heading) %>
 <% end %>
 
-<div class="expanded budget no-margin-top">
-  <div class="row">
-    <div class="small-12 column padding text-center">
-      <%= back_link_to budget_path(@budget) %>
-
-      <h2 class="title">
-        <%= @budget.name %><br>
-        <%= t("budgets.results.heading") %>
-      </h2>
+<div class="budgets-stats">
+  <div class="expanded no-margin-top padding header">
+    <div class="row">
+      <div class="small-12 column text-center">
+        <%= back_link_to budget_path(@budget) %>
+        <h1 class="title"><%= t("budgets.results.heading") %><br><%= @budget.name %></h1>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -21,7 +21,7 @@
     <ul class="tabs">
       <li class="tabs-title is-active">
         <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-        <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget, heading_id: @budget.headings.first.to_param), class: "is-active"  %>
+        <%= link_to t("budgets.results.link"), custom_budget_heading_result_path(@budget, heading_id: @budget.headings.first.to_param), class: "is-active"  %>
       </li>
       <li class="tabs-title">
         <%= link_to t("budgets.stats.link"), custom_budget_stats_path(@budget)%>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -40,7 +40,7 @@
       </li>
 
       <% @budget.headings.order('id ASC').each do |heading| %>
-        <% active_class = heading.to_param == params[:heading_id] ? 'bold' : '' %>
+        <% active_class = heading.to_param == @heading.to_param ? 'bold' : '' %>
         <li class="<%= active_class %>">
           <%= link_to heading.name,
                       custom_budget_heading_result_path(@budget, heading_id: heading.to_param) %>

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -21,7 +21,7 @@
     <ul class="tabs">
       <li class="tabs-title is-active">
         <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-        <%= link_to t("budgets.results.link"), custom_budget_heading_result_path(@budget, heading_id: @budget.headings.first.to_param), class: "is-active"  %>
+        <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget), class: "is-active"  %>
       </li>
       <li class="tabs-title">
         <%= link_to t("budgets.stats.link"), custom_budget_stats_path(@budget)%>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -43,7 +43,7 @@
 
       <% if @budget.finished? %>
         <%= link_to t("budgets.show.see_results"),
-                    custom_budget_heading_result_path(@budget, heading_id: @budget.headings.first),
+                    custom_budget_results_path(@budget),
                     class: "button margin-top expanded" %>
       <% end %>
     </div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -43,7 +43,7 @@
 
       <% if @budget.finished? %>
         <%= link_to t("budgets.show.see_results"),
-                    custom_budget_results_path(@budget, heading_id: @budget.headings.first),
+                    custom_budget_heading_result_path(@budget, heading_id: @budget.headings.first),
                     class: "button margin-top expanded" %>
       <% end %>
     </div>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -25,7 +25,7 @@
           <% if @budget.finished? %>
             <li class="tabs-title">
               <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-              <%= link_to t("budgets.results.link"), custom_budget_heading_result_path(@budget, heading_id: @budget.headings.first.to_param) %>
+              <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget) %>
             </li>
           <% end %>
           <li class="tabs-title is-active">

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -25,7 +25,7 @@
           <% if @budget.finished? %>
             <li class="tabs-title">
               <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-              <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget, heading_id: @budget.headings.first.to_param) %>
+              <%= link_to t("budgets.results.link"), custom_budget_heading_result_path(@budget, heading_id: @budget.headings.first.to_param) %>
             </li>
           <% end %>
           <li class="tabs-title is-active">

--- a/app/views/pages/more_info/budgets/_welcome_header_finished.html.erb
+++ b/app/views/pages/more_info/budgets/_welcome_header_finished.html.erb
@@ -16,8 +16,8 @@
                         class: "button expanded large city" %>
           </div>
           <div class="small-12 medium-6 column">
-            <%= link_to "Ver estadísticas de participación",
-                        custom_budget_stats_path(id: Budget.last.to_param),
+            <%= link_to "Ejecución de proyectos 2016",
+                        "/system/budgets/2016/estado-propuestas-2016.xlsx",
                         class: "button expanded large stats" %>
           </div>
         </div>

--- a/app/views/pages/more_info/budgets/_welcome_header_finished.html.erb
+++ b/app/views/pages/more_info/budgets/_welcome_header_finished.html.erb
@@ -4,7 +4,7 @@
       <h1>Resultados<br>Presupuestos participativos 2017</h1>
       <div class="small-12 medium-11">
         <p class="lead">
-           Mira qué proyectos ciudadanos se ejecutarán a partir de 2018 con los <strong>100 millones</strong> de los presupuestos participativos.
+           Mira qué proyectos ciudadanos se ejecutarán a partir de 2018 con los <strong>100 millones de euros</strong> de los presupuestos participativos.
         </p>
       </div>
 

--- a/app/views/pages/more_info/budgets/_welcome_header_finished.html.erb
+++ b/app/views/pages/more_info/budgets/_welcome_header_finished.html.erb
@@ -11,8 +11,8 @@
       <div class="small-12">
         <div class="row margin-top">
           <div class="small-12 medium-6 column">
-            <%= link_to "Ver proyectos",
-                        "budgets_results_path",
+            <%= link_to t("budgets.show.see_results"),
+                        custom_budget_results_path(Budget.finished.first),
                         class: "button expanded large city" %>
           </div>
           <div class="small-12 medium-6 column">

--- a/app/views/pages/more_info/budgets/welcome.html.erb
+++ b/app/views/pages/more_info/budgets/welcome.html.erb
@@ -20,7 +20,7 @@
     <%= render "pages/more_info/budgets/welcome_header_balloting" %>
   <% elsif Budget.reviewing_ballots.any? %>
     <%= render "pages/more_info/budgets/welcome_header_reviewing" %>
-  <% else %>
+  <% elsif Budget.finished.any? %>
     <%= render "pages/more_info/budgets/welcome_header_finished" %>
   <% end %>
 

--- a/app/views/welcome/_budgets_module_finished.html.erb
+++ b/app/views/welcome/_budgets_module_finished.html.erb
@@ -7,8 +7,10 @@
       <br>
       <p class="lead-title"><%= t("welcome.budgets.title_finished_html") %></p>
       <p><%= t("welcome.budgets.text_finished_html") %></p>
-      <div class="small-12 medium-6 small-centered">
-        <%= link_to t("welcome.budgets.button_finished"), budgets_welcome_path, class: "button expanded large" %>
+      <div class="small-12 medium-8 column small-centered">
+        <div class="small-12 medium column ">
+          <%= link_to t("welcome.budgets.button_finished"), custom_budget_results_path(Budget.last.to_param), class: "button expanded large" %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/welcome/_budgets_module_finished.html.erb
+++ b/app/views/welcome/_budgets_module_finished.html.erb
@@ -6,11 +6,9 @@
       </span>
       <br>
       <p class="lead-title"><%= t("welcome.budgets.title_finished_html") %></p>
-      <p><%= t("welcome.budgets.text_finished_html") %></p>
-      <div class="small-12 medium-8 column small-centered">
-        <div class="small-12 medium column ">
-          <%= link_to t("welcome.budgets.button_finished"), custom_budget_results_path(Budget.finished.last.to_param), class: "button expanded large" %>
-        </div>
+      <p class="lead"><%= t("welcome.budgets.text_finished_html") %></p>
+      <div class="small-12 medium-9 large-6 column small-centered">
+        <%= link_to t("welcome.budgets.button_finished"), custom_budget_results_path(Budget.finished.last.to_param), class: "button expanded large" %>
       </div>
     </div>
   </div>

--- a/app/views/welcome/_budgets_module_finished.html.erb
+++ b/app/views/welcome/_budgets_module_finished.html.erb
@@ -9,7 +9,7 @@
       <p><%= t("welcome.budgets.text_finished_html") %></p>
       <div class="small-12 medium-8 column small-centered">
         <div class="small-12 medium column ">
-          <%= link_to t("welcome.budgets.button_finished"), custom_budget_results_path(Budget.last.to_param), class: "button expanded large" %>
+          <%= link_to t("welcome.budgets.button_finished"), custom_budget_results_path(Budget.finished.last.to_param), class: "button expanded large" %>
         </div>
       </div>
     </div>

--- a/app/views/welcome/_budgets_module_reviewing.html.erb
+++ b/app/views/welcome/_budgets_module_reviewing.html.erb
@@ -9,7 +9,7 @@
       <p><%= t("welcome.budgets.text_reviewing_html") %></p>
       <div class="row">
         <div class="small-12 medium-6 column">
-          <%= link_to t("welcome.budgets.button_stats"), custom_budget_stats_path(id: Budget.last.to_param), class: "button expanded large" %>
+          <%= link_to t("welcome.budgets.button_stats"), custom_budget_stats_path(id: Budget.reviewing_ballots.last.to_param), class: "button expanded large" %>
         </div>
         <div class="small-12 medium-6 column">
           <%= link_to t("welcome.budgets.button_reviewing"), budgets_welcome_path, class: "button expanded large" %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -5,7 +5,7 @@
   <%= render "shared/canonical", href: root_url %>
 <% end %>
 
-<% cache ["welcome_index_20170630", user_signed_in?] do %>
+<% cache ["welcome_index_20170712", user_signed_in?] do %>
   <div class="welcome">
 
     <h1 class="show-for-sr"><%= t("welcome.title") %></h1>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -15,7 +15,7 @@
         <%= render "budgets_module_balloting" %>
       <% elsif Budget.reviewing_ballots.any? %>
         <%= render "budgets_module_reviewing" %>
-      <% else %>
+      <% elsif Budget.finished.any? %>
         <%= render "budgets_module_finished" %>
       <% end %>
     </div>

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -145,7 +145,7 @@ en:
       button_reviewing: "See projects"
       button_stats: "See statistics"
       title_finished_html: "Know the winning projects of the participatory budgets"
-      text_finished_html: "These are the citizen projects that will be financed with <strong>100 million euros</strong> of the municipal budget in 2018"
+      text_finished_html: "These are the citizen projects that will be financed with<br><strong>100 million euros</strong> of the municipal budget in 2018"
       label_finished: "The citizens of Madrid have decided"
       button_finished: "See projects"
       stats:

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -147,7 +147,7 @@ es:
       title_finished_html: "Conoce los proyectos ganadores de los presupuestos participativos"
       text_finished_html: "Estos son los proyectos ciudadanos que se financiarán con <strong>100 millones de euros</strong> del presupuesto municipal en 2018."
       label_finished: "La ciudadanía madrileña ha decidido"
-      button_finished: "Ver proyectos"
+      button_finished: "Ver Resultados"
       stats:
         label: "Estadísticas"
         title: "Datos de la votación de presupuestos"

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -145,7 +145,7 @@ es:
       button_reviewing: "Ver proyectos"
       button_stats: "Ver estadísticas"
       title_finished_html: "Conoce los proyectos ganadores de los presupuestos participativos"
-      text_finished_html: "Estos son los proyectos ciudadanos que se financiarán con <strong>100 millones de euros</strong> del presupuesto municipal en 2018."
+      text_finished_html: "Estos son los proyectos ciudadanos que se financiarán con<br><strong>100 millones de euros</strong> del presupuesto municipal en 2018."
       label_finished: "La ciudadanía madrileña ha decidido"
       button_finished: "Ver Resultados"
       stats:

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -129,7 +129,7 @@ en:
     results:
       link: Results
       page_title: "%{budget} - Results"
-      heading: "Participatory budget results"
+      heading: "Results"
       heading_selection_title: "By district"
       spending_proposal: Proposal title
       ballot_lines_count: Times selected

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -129,7 +129,7 @@ es:
     results:
       link: Resultados
       page_title: "%{budget} - Resultados"
-      heading: "Resultados presupuestos participativos"
+      heading: "Resultados"
       heading_selection_title: "Ámbito de actuación"
       spending_proposal: Título
       ballot_lines_count: Votos

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
   get 'presupuestos', to: 'pages#show', id: 'more_info/budgets/welcome',  as: 'budgets_welcome'
   get "presupuestos/:id/estadisticas", to: "budgets/stats#show", as: 'custom_budget_stats'
   get "presupuestos/:id/resultados", to: "budgets/results#show", as: 'custom_budget_results'
+  get "presupuestos/:id/resultados/:heading_id", to: "budgets/results#show", as: 'custom_budget_heading_result'
 
   resources :budgets, only: [:show, :index], path: 'presupuestos' do
     resources :groups, controller: "budgets/groups", only: [:show], path: 'grupo'

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -685,7 +685,7 @@ feature 'Admin budget investments' do
         check "budget_investment_visible_to_valuators"
       end
 
-      login_as(valuator.user)
+      login_as(valuator.user.reload)
       visit root_path
       click_link "Valuation"
 
@@ -697,7 +697,7 @@ feature 'Admin budget investments' do
       expect(page).to_not have_content investment2.title
     end
 
-    scenario "Unmark as visible to valuator", :js do
+    scenario "Unmark as visible to valuator", :js, do
       Setting['feature.budgets.valuators_allowed'] = true
 
       valuator = create(:valuator)
@@ -715,7 +715,7 @@ feature 'Admin budget investments' do
         uncheck "budget_investment_visible_to_valuators"
       end
 
-      login_as(valuator.user)
+      login_as(valuator.user.reload)
       visit root_path
       click_link "Valuation"
 
@@ -723,7 +723,7 @@ feature 'Admin budget investments' do
         click_link "Evaluate"
       end
 
-      expect(page).to_not have_content investment1.title
+      expect(page).not_to have_content investment1.title
       expect(page).to     have_content investment2.title
     end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -697,7 +697,7 @@ feature 'Admin budget investments' do
       expect(page).to_not have_content investment2.title
     end
 
-    scenario "Unmark as visible to valuator", :js, do
+    scenario "Unmark as visible to valuator", :js do
       Setting['feature.budgets.valuators_allowed'] = true
 
       valuator = create(:valuator)

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -50,7 +50,7 @@ feature 'Results' do
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)
 
-    visit custom_budget_results_path(budget)
+    visit custom_budget_heading_result_path(budget)
 
     within("#budget-investments-compatible") do
       expect(page).to have_content investment1.title
@@ -63,7 +63,7 @@ feature 'Results' do
     visit budget_path(budget)
     expect(page).not_to have_link "See results"
 
-    visit custom_budget_results_path(budget, heading_id: budget.headings.first)
+    visit custom_budget_heading_result_path(budget, heading_id: budget.headings.first)
     expect(page).to have_content "You do not have permission to carry out the action"
   end
 

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -50,7 +50,7 @@ feature 'Results' do
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)
 
-    visit custom_budget_heading_result_path(budget)
+    visit custom_budget_results_path(budget)
 
     within("#budget-investments-compatible") do
       expect(page).to have_content investment1.title


### PR DESCRIPTION
What
====
- Adds custom budget heading result's path 
`/presupuestos-participativos-2017/resultados/arganzuela`
- Marks first heading as selected when going to 
`/presupuestos-participativos-2017/resultados`

How
===
- Adding a custom route for heading results
- Using an instance variable instead of params to know what is the current heading

Screenshots
===========
- Custom heading route
![url](https://user-images.githubusercontent.com/4169/28115359-e717f020-6704-11e7-9f0e-de5862e1d10a.png)

- Mark first heading as selected
![first heading selected](https://user-images.githubusercontent.com/4169/28115361-ea555f34-6704-11e7-90e8-e8f48e910859.png)
