### PR TITLE
Enlace duplicado en más información

### DIFF
--- a/app/views/pages/more_info/_other.html.erb
+++ b/app/views/pages/more_info/_other.html.erb
@@ -3,7 +3,6 @@
 <ul class="features">
   <li><%= link_to t("pages.titles.kit_decide"), kit_decide_path %></li>
   <li><%= link_to "Hojas de firmas para recoger apoyos", more_info_proposals_path(anchor: "iii") %></li>
-  <li><%= link_to t("pages.more_info.other.how_to_use", org_name: setting['org_name']), faq_path %></li>
   <li><%= link_to " Participación Ciudadana, Transparencia y Gobierno Abierto", participation_open_government_path %></li>
   <li><%= link_to "¿Qué significa trabajar con enfoque de derechos humanos? ", more_info_human_rights_path %></li>
   <li><%= link_to t("pages.more_info.other.facts"), participation_facts_path %></li>


### PR DESCRIPTION
Elimina el enlace duplicado "Utiliza Decide Madrid en tu municipio" en la sección de "Otra información de interés" en la página de "/mas-informacion".

Este enlace además llevaba a la sección de "faq" (ya enlazada en el sidebar de esa misma página)