### PR TITLE
Temp fix for budget recommendation metatags

### DIFF
--- a/app/views/budgets/recommendations/index.html.erb
+++ b/app/views/budgets/recommendations/index.html.erb
@@ -14,7 +14,9 @@
   <meta property="article:author" content="https://www.facebook.com/<%= setting['facebook_handle'] %>"/>
 <% end %>
 <meta property="og:type" content="article"/>
-<meta id="ogurl" property="og:url" content="<%= budget_recommendations_url(budget_id: Budget.current.last.slug, user_id: @user.id) %>"/>
+<% budget = Budget.current.last %>
+<% og_url = budget.present? ? budget_recommendations_url(budget_id: budget.slug, user_id: @user.id) : budgets_url %>
+<meta id="ogurl" property="og:url" content="<%= og_url %>"/>
 <meta id="ogimage" property="og:image" content="<%= image_url '/social_media_budgets.png' %>"/>
 <meta property="og:site_name" content="Decide Madrid"/>
 <meta id="ogdescription" property="og:description" content="Proyectos de gasto recomendados por <%= @user.name %>"/>


### PR DESCRIPTION
# Where

*   **Related Rollbar Issue:** https://rollbar.com/voodoorai2000/Participacion/items/1211/

# What

*   When there is no current budget, code fails with a 500 internal server error.

# How

*   Simple fix, sending budgets url instead of budget url for now. Needs some thinking and create an issue to describe a possible "current budget" feature.

# Screenshots

No need

# Test

Don't think og metatags deserve a feature test.

# Deployment

*   Remember to close the rollbar issue afterwards

# Warnings

None