### PR TITLE
Canonical href en procesos

### DIFF
--- a/app/views/legislation/processes/index.html.erb
+++ b/app/views/legislation/processes/index.html.erb
@@ -4,7 +4,7 @@
 <% provide :meta_description, t("meta_tags.processes.description") %>
 <% provide :tracking_page_number, "32" %>
 <% content_for :canonical do %>
-  <%= render "shared/canonical", href: legislation_processes_url %>
+  <%= render "shared/canonical", href: processes_url %>
 <% end %>
 
 <%= render "custom/legislation/processes_header" %>


### PR DESCRIPTION
Qué
====

Mejorar el SEO haciendo que el enlace canonical de la página principal de procesos apunte a sí misma.

Cómo
===

Cambiado:

`<link rel="canonical" href="https://decide.madrid.es/legislation/processes">`

a:

`<link rel="canonical" href="https://decide.madrid.es/procesos">`

