### PR TITLE
Duplicated </thead>

### DIFF
--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -187,7 +187,6 @@
               <th scope="col" class="tiny"><%= t("budgets.stats.percent_total_participants_html") %></th>
               <th scope="col" class="tiny"><%= t("budgets.stats.percent_heading_census_html") %></th>
             </tr>
-            </thead>
           </thead>
           <tbody>
             <% @budget.headings.order('id ASC').each do |heading| %>


### PR DESCRIPTION
Qué
====
Borra una tag `</thead>` duplicada en la página de estadísticas de presupuestos participativos.

<img width="384" alt="thead" src="https://user-images.githubusercontent.com/631897/29133177-efe30426-7d32-11e7-8927-96e6a7b46507.png">
