### PR TITLE
Probe show comments

### DIFF
--- a/app/views/custom/probe_options/_comments.html.erb
+++ b/app/views/custom/probe_options/_comments.html.erb
@@ -2,7 +2,6 @@
   <section class="row-full comments">
     <div class="row">
       <div id="comments" class="small-12 column">
-        <a name="comments"></a>
         <h2>
           <%= t("shared.comments.title") %>
           <span class="js-comments-count">(<%= @commentable.comments_count %>)</span>


### PR DESCRIPTION
Qué
====
El atributo `name` está obsoleto. Esta PR elimina un enlace vacío con dicho atributo. El funcionamiento de los comentarios sigue siendo el correcto.

<img width="876" alt="warning" src="https://user-images.githubusercontent.com/631897/29713152-9db8356e-899d-11e7-852e-3c22144464be.png">
