### PR TITLE
Readme alert about fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⚠️ WARNING ❌: DO NOT USE THIS REPO IF WANT TO INSTALL YOUR OWN CONSUL. Instead fork https://github.com/consul/consul
+
 ![Logo of Consul](https://raw.githubusercontent.com/consul/consul/master/public/consul_logo.png)
 
 # Consul

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,3 +1,5 @@
+# ⚠️ CUIDADO ❌: NO USES ESTE REPOSITORIO COMO BASE PARA UNA INSTALACIÓN DE CONSUL. Haz un fork de https://github.com/consul/consul
+
 ![Logotipo de Consul](https://raw.githubusercontent.com/consul/consul/master/public/consul_logo.png)
 
 # Consul


### PR DESCRIPTION
What
====
- People keep forking this repo instead of consul repo

How
===
- Add big alert on readme. In my opinion README should just state something like "This is a fork of CONSUL and here some badges and contributors and stuff.."
