### PR TITLE
Hide Document upload on Proposal/Investment

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -4,7 +4,7 @@
     <div class="small-12 medium-9 column">
       <%= back_link_to budget_investments_path(investment.budget, heading_id: investment.heading) %>
 
-      <% if false && can?(:create, @document) && investment.documents.size < Budget::Investment.max_documents_allowed %>
+      <% if Setting['feature.document_on_show'] && can?(:create, @document) && investment.documents.size < Budget::Investment.max_documents_allowed %>
         <%= link_to t("documents.upload_document"),
                     new_document_path(documentable_id:investment, documentable_type: investment.class.name, from: request.url),
                     class: 'button hollow float-right' %>

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -4,7 +4,7 @@
     <div class="small-12 medium-9 column">
       <%= back_link_to budget_investments_path(investment.budget, heading_id: investment.heading) %>
 
-      <% if can?(:create, @document) && investment.documents.size < Budget::Investment.max_documents_allowed %>
+      <% if false && can?(:create, @document) && investment.documents.size < Budget::Investment.max_documents_allowed %>
         <%= link_to t("documents.upload_document"),
                     new_document_path(documentable_id:investment, documentable_type: investment.class.name, from: request.url),
                     class: 'button hollow float-right' %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -121,7 +121,7 @@
           <div class="sidebar-divider"></div>
           <h2><%= t("proposals.show.author") %></h2>
           <div class="show-actions-menu">
-            <% if can_create_document?(@document, @proposal) %>
+            <% if false && can_create_document?(@document, @proposal) %>
               <%= link_to new_document_path(documentable_id: @proposal, documentable_type: @proposal.class.name, from: request.url),
                           class: 'button hollow expanded' do %>
                           <span class="icon-document"></span>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -121,7 +121,7 @@
           <div class="sidebar-divider"></div>
           <h2><%= t("proposals.show.author") %></h2>
           <div class="show-actions-menu">
-            <% if false && can_create_document?(@document, @proposal) %>
+            <% if Setting['feature.document_on_show'] && can_create_document?(@document, @proposal) %>
               <%= link_to new_document_path(documentable_id: @proposal, documentable_type: @proposal.class.name, from: request.url),
                           class: 'button hollow expanded' do %>
                           <span class="icon-document"></span>

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -51,6 +51,8 @@ Setting.create(key: 'feature.human_rights.closed', value: 'true')
 Setting.create(key: 'feature.signature_sheets', value: "true")
 Setting.create(key: 'feature.legislation', value: "true")
 Setting.create(key: 'feature.community', value: "true")
+Setting.create(key: 'feature.document_on_show', value: "false")
+
 Setting.create(key: 'per_page_code_head', value: "")
 Setting.create(key: 'per_page_code_body', value: "")
 Setting.create(key: 'comments_body_max_length', value: '1000')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -80,6 +80,7 @@ Setting['feature.budgets'] = true
 Setting['feature.signature_sheets'] = true
 Setting['feature.legislation'] = true
 Setting['feature.community'] = true
+Setting['feature.document_on_show'] = false
 
 # Spending proposals feature flags
 Setting['feature.spending_proposal_features.phase1'] = true

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -10,11 +10,16 @@ shared_examples "documentable" do |documentable_factory_name, documentable_path,
   let!(:documentable_dom_name)  { documentable_factory_name.parameterize }
 
   before do
+    Setting['feature.document_on_show'] = 'true'
     create(:administrator, user: administrator)
 
     documentable_path_arguments.each do |argument_name, path_to_value|
       arguments.merge!("#{argument_name}": documentable.send(path_to_value))
     end
+  end
+
+  after do
+    Setting['feature.document_on_show'] = nil
   end
 
   context "Show" do

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -9,11 +9,16 @@ shared_examples "nested documentable" do |documentable_factory_name, path, docum
   let!(:documentable)           { create(documentable_factory_name, author: user) }
 
   before do
+    Setting['feature.document_on_show'] = 'true'
     create(:administrator, user: administrator)
 
     documentable_path_arguments&.each do |argument_name, path_to_value|
         arguments.merge!("#{argument_name}": documentable.send(path_to_value))
     end
+  end
+
+  after do
+    Setting['feature.document_on_show'] = nil
   end
 
   describe "at #{path}" do


### PR DESCRIPTION
What
====
For now we have to prevent users from uploading documents to proposals and investments (only on creation will be possible to attach a document)

How
===
- Creating a new `Setting['feature.document_on_show']` with a default `false` value to easy enable/disable the feature both on views and specs
- Adding  `Setting['feature.document_on_show'] &&` to the if conditions that check if the link should be rendered... Maybe bit obscure but its short and effective compared to commenting out blocks
- Setting a `true` value on the before blocks of the documentable specs, and resetting it to `false` on the after block.

Screenshots
===========
## Proposal show (from a proposal I just created)

![screen shot 2017-09-21 at 22 38 38](https://user-images.githubusercontent.com/983242/30717604-b7b4e152-9f1d-11e7-8caa-fe12aadc0f9a.jpg)

## Investment show (for a just created one)
![screen shot 2017-09-21 at 22 42 22](https://user-images.githubusercontent.com/983242/30717755-2f75d8f4-9f1e-11e7-8a21-530567f036f5.jpg)


Test
====
Probably will fail, but we don't care :D

Deployment
==========
To pre to check and merge to stable before deploying it to pro.  I wonder if capistrano will set the new setting by running db/seeds.rb or we'll have to do it through console.

Warnings
========
Devs should run again `bundle exec rake db:dev_seed` to get that new flag