### PR TITLE
Removed officer alert in admin section

### DIFF
--- a/app/views/layouts/_officing_booth.html.erb
+++ b/app/views/layouts/_officing_booth.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.poll_officer? %>
+  <div id="officing-booth" class="callout info">
+    <%= t("admin.officing_booth.title", booth: try(:current_booth).try(:location)) %>
+  </div>
+<% end %>

--- a/app/views/layouts/_officing_booth.html.erb
+++ b/app/views/layouts/_officing_booth.html.erb
@@ -1,5 +1,0 @@
-<% if current_user.poll_officer? %>
-  <div id="officing-booth" class="callout info">
-    <%= t("admin.officing_booth.title", booth: try(:current_booth).try(:location)) %>
-  </div>
-<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -44,7 +44,6 @@
 
             <div class="admin-content small-12 medium-9 column" data-equalizer-watch>
               <%= render 'layouts/flash' %>
-              <%= render 'layouts/officing_booth' if session[:booth_id].present? %>
               <%= yield %>
             </div>
           </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -44,7 +44,7 @@
 
             <div class="admin-content small-12 medium-9 column" data-equalizer-watch>
               <%= render 'layouts/flash' %>
-              <%= render 'layouts/officing_booth' if controller.class.parent == "Officing" && session[:booth_id].present? %>
+              <%= render 'layouts/officing_booth' if controller.class.parent == Officing && session[:booth_id].present? %>
               <%= yield %>
             </div>
           </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -44,6 +44,7 @@
 
             <div class="admin-content small-12 medium-9 column" data-equalizer-watch>
               <%= render 'layouts/flash' %>
+              <%= render 'layouts/officing_booth' if controller.class.parent == "Officing" && session[:booth_id].present? %>
               <%= yield %>
             </div>
           </div>


### PR DESCRIPTION
What
====
~Removed alert appearing in admin section when an admin user **also poll officer** is in this section, as requested.~

Made alert for poll officers just appear in the Officing section (http://localhost:3000/officing) instead all over admin section.

Test
====
As usual.

Deployment
==========
As usual.
