### PR TITLE
Removes basic http authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include HasOrders
   include Analytics
 
-  before_action :authenticate_http_basic, if: :http_basic_auth_site?
+  # before_action :authenticate_http_basic, if: :http_basic_auth_site?
 
   before_action :ensure_signup_complete
   before_action :set_locale


### PR DESCRIPTION
What
====
- Removes basic http authentication

How
===
- Commenting out the corresponding line in `application_controller`. We will have to reactivate in the next couple of days