### PR TITLE
Link a ver proyectos

### DIFF
--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -56,6 +56,9 @@
       <% @questions.each do |question| %>
         <%= render 'polls/questions/question', question: question, token: @token %>
       <% end %>
+      <div class="callout primary text-center">
+        <%= link_to t("poll_questions.show.see_projects"), "#poll_more_info_answers", class: "lead" %>
+      </div>
 
       <% if poll_voter_token(@poll, current_user).empty? %>
         <div class="callout token-message js-token-message" style="display: none">
@@ -63,7 +66,7 @@
         </div>
       <% end %>
 
-      <div class="callout primary text-center">
+      <div class="text-center">
         <%= link_to t("polls.show.participate_in_other_polls"), polls_path %>
       </div>
     </div>
@@ -85,7 +88,7 @@
     </div>
   </div>
 
-  <div class="expanded poll-more-info-answers">
+  <div id="poll_more_info_answers" class="expanded poll-more-info-answers">
     <div class="row padding">
 
       <% @poll.questions.map(&:question_answers).flatten.each do |answer| %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -531,6 +531,7 @@ en:
       vote_answer: "Vote %{answer}"
       voted: "You have voted %{answer}"
       voted_token: "You can write down this vote identifier, to check your vote on the final results:"
+      see_projects: "See projects"
   proposal_notifications:
     new:
       title: "Send message"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -532,6 +532,7 @@ es:
       vote_answer: "Votar %{answer}"
       voted: "Has votado %{answer}"
       voted_token: "Puedes apuntar este identificador de voto, para comprobar tu votación en el resultado final:"
+      see_projects: "Ver proyectos"
   proposal_notifications:
     new:
       title: "Enviar mensaje"


### PR DESCRIPTION
Qué
===
- Añade un pequeño link a "Ver proyectos" en `polls/show` que hace scroll a la parte de la descripción de las respuestas para que el usuario no se pierda esa información.

Imágenes
===
<img width="930" alt="see_projects" src="https://user-images.githubusercontent.com/631897/31320503-de6b94d4-ac75-11e7-8c20-9e3b16aab717.png">
