### PR TITLE
fixes more info polls pages routes

### DIFF
--- a/app/views/pages/more_info/polls/february_2017.html.erb
+++ b/app/views/pages/more_info/polls/february_2017.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row margin-top">
   <div class="small-12 medium-3 column">
-    <%= back_link_to more_info_path %>
+    <%= back_link_to %>
 
     <ul class="menu vertical margin-top">
       <li><a href="#i"><strong>Información sobre las votaciones</strong></a></li>

--- a/app/views/pages/more_info/polls/index.html.erb
+++ b/app/views/pages/more_info/polls/index.html.erb
@@ -12,7 +12,7 @@
 
     <ul class="menu vertical margin-top">
       <li><a href="#i"><strong>Información sobre las votaciones</strong></a></li>
-      <li><a href="#ii"><strong>Cómo votar</strong></a></li>
+      <li><a href="#ii"><strong>Más información</strong></a></li>
     </ul>
   </div>
 

--- a/app/views/pages/more_info/polls/index.html.erb
+++ b/app/views/pages/more_info/polls/index.html.erb
@@ -1,0 +1,47 @@
+<% provide :title do %><%= t("pages.titles.more_info", org_name: setting['org_name']) %><% end %>
+
+<% provide :tracking_page_number, "34" %>
+
+<% content_for :canonical do %>
+  <%= render "shared/canonical", href: more_info_url %>
+<% end %>
+
+<div class="row margin-top">
+  <div class="small-12 medium-3 column">
+    <%= back_link_to more_info_path %>
+
+    <ul class="menu vertical margin-top">
+      <li><a href="#i"><strong>Información sobre las votaciones</strong></a></li>
+      <li><a href="#ii"><strong>Cómo votar</strong></a></li>
+    </ul>
+  </div>
+
+  <div class="small-12 medium-9 column more-info-text">
+    <h2 id="i">Información sobre las votaciones</h2>
+    <p>Regístrate para poder votar propuestas ciudadanas y las cuestiones que pregunta a sus vecinos el Ayuntamiento de Madrid. Toma decisiones municipales de forma directa.</p>
+
+    <p>Las votaciones se convocan cuando una propuesta ciudadana alcanza el 1% de apoyos del censo con derecho a voto, o cuando el Ayuntamiento de Madrid decide someter cuestiones a decisión directa de la ciudadanía.</p>
+
+    <p>Para participar en la próxima votación tienes que registrarte en Decide Madrid y verificar tu cuenta. Pueden votar todas las personas empadronadas en la ciudad mayores de 16 años. Los resultados de todas las votaciones son vinculantes para el gobierno.
+
+    <p>Algunas cuestiones que se han votado son:</p>
+
+    <ul>
+      <li>Las propuestas ciudadanas "Madrid 100% sostenible" y "Billete único de transporte público"; diferentes actuaciones que se planteaban llevar a cabo en la Gran Vía como la ampliación de las aceras o la preferencia del transporte público; los proyectos finalistas para la reforma de Plaza de España; diversas cuestiones en seis distritos de Madrid como sus planes de actuación, los nombres de parques o del propio distrito, y la protección de edificios históricos.</li>
+
+      <li>La remodelación de 11 plazas periféricas de la ciudad. Respecto a cada plaza se ha decidido si se remodelaría o no y qué proyecto se llevaría a cabo entre dos finalistas en caso de remodelarse.</li>
+    </ul>
+
+    <p>Los resultados de todas las votaciones son vinculantes para el gobierno. Pueden votar todas las personas empadronadas en Madrid mayores de 16 años.</p>
+
+    <h2 id="ii">Más información</h2>
+    <ul>
+      <li>
+        <%= link_to "Explicación detallada del proceso de propuestas ciudadanas y preguntas frecuentes", more_info_proposals_path %>
+      </li>
+      <li>
+        <%= link_to "Hechos sobre participación ciudadana y democracia directa (para perderle el miedo)", participation_facts_path %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/pages/more_info/polls/october_2017.html.erb
+++ b/app/views/pages/more_info/polls/october_2017.html.erb
@@ -8,7 +8,7 @@
 
 <div class="row margin-top">
   <div class="small-12 medium-3 column">
-    <%= back_link_to more_info_path %>
+    <%= back_link_to %>
 
     <ul class="menu vertical margin-top">
       <li><a href="#i"><strong>Información sobre las votaciones</strong></a></li>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -48,7 +48,7 @@
       <p><%= t("polls.index.section_footer.help_text_3") %></p>
       <p><%= t("polls.index.section_footer.help_text_4") %></p>
       <p><%= t("polls.index.section_footer.help_text_5") %></p>
-      <p><%= link_to t("polls.index.section_footer.help_text_6"), more_info_polls_path %></p>
+      <p><%= link_to t("polls.index.section_footer.help_text_6"), more_info_polls_october %></p>
     </div>
   </div>
 </div>

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -48,7 +48,7 @@
       <p><%= t("polls.index.section_footer.help_text_3") %></p>
       <p><%= t("polls.index.section_footer.help_text_4") %></p>
       <p><%= t("polls.index.section_footer.help_text_5") %></p>
-      <p><%= link_to t("polls.index.section_footer.help_text_6"), more_info_polls_october %></p>
+      <p><%= link_to t("polls.index.section_footer.help_text_6"), more_info_polls_october_path %></p>
     </div>
   </div>
 </div>

--- a/app/views/polls/info_2017.html.erb
+++ b/app/views/polls/info_2017.html.erb
@@ -27,7 +27,7 @@
         </h1>
 
         <div class="more-info">
-          <%= link_to t("polls.more_poll_info"), more_info_february_path %>
+          <%= link_to t("polls.more_poll_info"), more_info_polls_february_path %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -615,8 +615,9 @@ Rails.application.routes.draw do
 
   # more information pages
   get 'mas-informacion',                             to: 'pages#show', id: 'more_info/index',                 as: 'more_info'
-  get 'mas-informacion/votaciones/febrero-2017',     to: 'pages#show', id: 'more_info/polls/february_2017',   as: 'more_info_february'
-  get 'mas-informacion/votaciones',                  to: 'pages#show', id: 'more_info/polls/october_2017',    as: 'more_info_polls'
+  get 'mas-informacion/votaciones',                  to: 'pages#show', id: 'more_info/polls/index',           as: 'more_info_polls'
+  get 'mas-informacion/votaciones/febrero-2017',     to: 'pages#show', id: 'more_info/polls/february_2017',   as: 'more_info_polls_february'
+  get 'mas-informacion/votaciones/octubre-2017',     to: 'pages#show', id: 'more_info/polls/october_2017',    as: 'more_info_polls_october'
   get 'mas-informacion/como-usar',                   to: 'pages#show', id: 'more_info/how_to_use/index',      as: 'how_to_use'
   get 'mas-informacion/faq',                         to: 'pages#show', id: 'more_info/faq/index',             as: 'faq'
   get 'mas-informacion/propuestas',                  to: 'pages#show', id: 'more_info/proposals/index',       as: 'more_info_proposals'


### PR DESCRIPTION
Qué
====
- Arregla las rutas de las páginas de más información de votaciones:

`mas-informacion/votaciones`: información genérica (linkada desde más información).
`mas-informacion/votaciones/febrero-2017`:  información sobre la pasada votación.
`mas-informacion/votaciones/octubre-2017`: información sobre la votación en curso.