### PR TITLE
Google Tag Manager Event

### DIFF
--- a/app/views/polls/questions/answer.js.erb
+++ b/app/views/polls/questions/answer.js.erb
@@ -1,3 +1,6 @@
 <% token = poll_voter_token(@question.poll, current_user) %>
 $("#<%= dom_id(@question) %>_answers").html('<%= j render("polls/questions/answers", question: @question, token: token) %>');
 App.Tracks.render_analytics('<%= j render("/layouts/analytics") %>')
+if (typeof dataLayer !== 'undefined') {
+    dataLayer.push({ 'event': 'voto_ok' });
+}

--- a/app/views/polls/questions/answer.js.erb
+++ b/app/views/polls/questions/answer.js.erb
@@ -1,6 +1,8 @@
 <% token = poll_voter_token(@question.poll, current_user) %>
 $("#<%= dom_id(@question) %>_answers").html('<%= j render("polls/questions/answers", question: @question, token: token) %>');
 App.Tracks.render_analytics('<%= j render("/layouts/analytics") %>')
+
+// Google Tag Manager event trigger
 if (typeof dataLayer !== 'undefined') {
-    dataLayer.push({ 'event': 'voto_ok' });
+  dataLayer.push({ 'event': 'voto_ok' });
 }


### PR DESCRIPTION
What
====
- Adds a event for Google Tag Manager (GTM) after voting a poll

How
===
- Adding the corresponding call to GMT in the rendered js partial

Test
====
- Make sure build passes
- Manually verified the call is sent using Google Chrome Inspector (Network tab)
- Marketing has approved the implemetation in the Preproduction environment
- Should manually verify event is being registered in GTM

Deployment
==========
- As usual

Warnings
========
- No tests... :( This is a fire situation, we have launch this campaign ASAP. 
Look into writting specific tests for this or next campaign.
As long as the build passes I think it's ok not to write tests for this one, now.
