### PR TITLE
Create Poll Question Answers for still existing valid_answers

### DIFF
--- a/lib/tasks/polls.rake
+++ b/lib/tasks/polls.rake
@@ -198,12 +198,12 @@ puts document
     YAML.load(File.read("#{Rails.root}/public/main_squares/config.yml"))
   end
 
-desc "Set correct order to answers on new Plazas Polls"
-  task set_answers_order: :environment do
-    Poll::Question::Answer.where(title: 'Sí').each { |answer| answer.update_attribute(:given_order, 1)}
-    Poll::Question::Answer.where(title: 'No').each { |answer| answer.update_attribute(:given_order, 2)}
-    Poll::Question::Answer.where(title: 'En blanco').each { |answer| answer.update_attribute(:given_order, 3)}
-    Poll::Question::Answer.where('title LIKE ?', 'Proyecto X:%').each { |answer| answer.update_attribute(:given_order, 1)}
-    Poll::Question::Answer.where('title LIKE ?', 'Proyecto Y:%').each { |answer| answer.update_attribute(:given_order, 2)}
+desc "Create Poll Question Answer for each Poll Question still with valid_answers values"
+  task migrate_poll_question_valid_answers: :environment do
+    Poll::Question.all.each do |question|
+      question.valid_answers.each do |valid_answer|
+        Poll::Question::Answer.create(question: question, title: valid_answer, description: '')
+      end
+    end
   end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2072
* **Related PR's:** 
  - https://github.com/consul/consul/pull/2073
  - https://github.com/consul/consul/pull/2074

What
====
PR https://github.com/consul/consul/pull/2074 will remove `valid_answers` attribute for all Poll::Question, we need to migrate existing values for old Polls to new usage `Poll::Question::Answer`

How
===
Loop through existing Poll::Question without associated `Poll::Question::Answer` and create one for each `valid_answers` value.

Screenshots
===========
No need

Test
====
No need

Deployment
==========
Before  https://github.com/consul/consul/pull/2074  is merged! running `bin/rake polls:migrate_poll_question_valid_answers RAILS_ENV=ENV`


Warnings
========
None