### PR TITLE
Officer menu

### DIFF
--- a/app/views/admin/shared/_admin_shortcuts.html.erb
+++ b/app/views/admin/shared/_admin_shortcuts.html.erb
@@ -1,10 +1,12 @@
-<li>
-  <%= link_to admin_stats_path, title: t("admin.menu.stats") do %>
-    <span class="icon-stats"></span>
-  <% end %>
-</li>
-<li>
-  <%= link_to admin_settings_path, title: t("admin.menu.settings") do %>
-    <span class="icon-settings"></span>
-  <% end %>
-</li>
+<% if current_user.administrator? %>
+  <li>
+    <%= link_to admin_stats_path, title: t("admin.menu.stats") do %>
+      <span class="icon-stats"></span>
+    <% end %>
+  </li>
+  <li>
+    <%= link_to admin_settings_path, title: t("admin.menu.settings") do %>
+      <span class="icon-settings"></span>
+    <% end %>
+  </li>
+<% end %>

--- a/app/views/officing/dashboard/index.html.erb
+++ b/app/views/officing/dashboard/index.html.erb
@@ -3,9 +3,3 @@
 
   <p><%= t("officing.dashboard.index.info") %></p>
 </div>
-
-<% if false %>
-  <div class="callout warning">
-    <%= t("officing.dashboard.index.not_allowed") %>
-  </div>
-<% end %>

--- a/app/views/officing/dashboard/index.html.erb
+++ b/app/views/officing/dashboard/index.html.erb
@@ -4,7 +4,7 @@
   <p><%= t("officing.dashboard.index.info") %></p>
 </div>
 
-<% unless current_booth.present? %>
+<% if false %>
   <div class="callout warning">
     <%= t("officing.dashboard.index.not_allowed") %>
   </div>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,9 +1,9 @@
 <% if show_admin_menu? %>
   <li>
     <% if current_user.poll_officer? && Poll.current.any? && !current_user.administrator? %>
-      <%= link_to t("layouts.header.officing"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+      <%= link_to t("layouts.header.officing"), "#", rel: "nofollow" %>
     <% else %>
-      <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+      <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow" %>
     <% end %>
     <ul class="menu">
       <% if current_user.administrator? %>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -1,6 +1,10 @@
 <% if show_admin_menu? %>
   <li>
-    <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+    <% if current_user.poll_officer? && Poll.current.any? && !current_user.administrator? %>
+      <%= link_to t("layouts.header.officing"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+    <% else %>
+      <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+    <% end %>
     <ul class="menu">
       <% if current_user.administrator? %>
         <li>

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -7,7 +7,6 @@ en:
       index:
         title: Poll officing
         info: Here you can validate user documents and store voting results
-        not_allowed: "You don't have officing shifts today"
     menu:
       voters: Validate document
       letters: "Validate document"

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -7,7 +7,6 @@ es:
       index:
         title: Presidir mesa de votaciones
         info: Aquí puedes validar documentos de ciudadanos y guardar los resultados de las urnas
-        not_allowed: "Hoy no tienes turnos de presidente de mesa"
     menu:
       voters: "Validar documento y votar"
       letters: "Validar documento"


### PR DESCRIPTION
Qué
=====
- Muestra el menú `Presidente de mesa` en vez de `Admin` a los _officers_.
- Muestra el dropdown en tamaño móvil (estaba oculto) 😬 
- Muestra los links de `settings` y `stats` solo a admins.
- Oculta el mensaje de "Hoy no tienes turnos" (los menús del sidebar no dejan entrar si no hay turnos)