### PR TITLE
Does not allow Open Plenary votes in the show view

### DIFF
--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -93,19 +93,27 @@
         </div>
       </div>
 
-      <aside class="small-12 medium-3 column">
-        <div class="sidebar-divider"></div>
-        <h2><%= t("votes.supports") %></h2>
-        <div id="<%= dom_id(@proposal) %>_votes">
-          <%= render 'votes',
-                    { proposal: @proposal, vote_url: vote_legislation_process_proposal_path(@proposal.legislation_process_id, @proposal, value: 'yes') } %>
-        </div>
-        <%= render partial: 'shared/social_share', locals: {
-          share_title: t("proposals.show.share"),
-          title: @proposal.title,
-          url: proposal_url(@proposal)
-        } %>
-      </aside>
+      <!-- hotfix for th Open Plenay 2017
+           This aims to avoid lobbies from skewing the voting.
+           
+           By only allowing voting in the index of Proposals,
+           hopefully citizens will see other interesting proposals 
+           to vote for -->
+      <% unless @process.id == 24 %>
+        <aside class="small-12 medium-3 column">
+          <div class="sidebar-divider"></div>
+          <h2><%= t("votes.supports") %></h2>
+          <div id="<%= dom_id(@proposal) %>_votes">
+            <%= render 'votes',
+                      { proposal: @proposal, vote_url: vote_legislation_process_proposal_path(@proposal.legislation_process_id, @proposal, value: 'yes') } %>
+          </div>
+          <%= render partial: 'shared/social_share', locals: {
+            share_title: t("proposals.show.share"),
+            title: @proposal.title,
+            url: proposal_url(@proposal)
+          } %>
+        </aside>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
What
====
- Does not allow voting in the show view of an Open Plenary proposal

Why
=====
To avoid pressure groups from sharing their proposals in social networks and skewing the process.
By allowing citizens to vote only the index view, hopefully the process will be more transparent and equitable

How
===
- Hardcoding the Open Plenary id 😱 

Warnings
========
- Left a comment in the code explaining this hotfix. Remove once the Open Plenary is over and implement a more robust solution, maybe using a boolean for this special Processes.
