### PR TITLE
Create proposal redirect

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -25,7 +25,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     set_process
     @phase = :debate_phase
 
-    if @process.debate_phase.started? || current_user.administrator?
+    if @process.debate_phase.started? || (current_user && current_user.administrator?)
       render :debate
     else
       render :phase_not_open
@@ -87,7 +87,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     set_process
     @phase = :proposals_phase
 
-    if @process.proposals_phase.started? || current_user.administrator?
+    if @process.proposals_phase.started? || (current_user && current_user.administrator?)
       set_legislation_proposal_votes(@process.proposals)
       render :proposals
     else

--- a/app/views/legislation/processes/proposals.html.erb
+++ b/app/views/legislation/processes/proposals.html.erb
@@ -22,9 +22,13 @@
       <div class="small-12 medium-3 column">
         <% if @process.proposals_phase.open? %>
           <% if @process.id == 24 %>
-            <p><%= link_to t("proposals.index.start_proposal_question"), new_legislation_process_proposal_path(@process), class: 'button expanded' %></p>
+            <p><%= link_to t("proposals.index.start_proposal_question"),
+                            (user_signed_in? ? new_legislation_process_proposal_path(@process) : new_user_session_path),
+                            class: 'button expanded', id: 'create-new-proposal' %></p>
           <% else %>
-            <p><%= link_to t("proposals.index.start_proposal"), new_legislation_process_proposal_path(@process), class: 'button expanded' %></p>
+            <p><%= link_to t("proposals.index.start_proposal"),
+                            (user_signed_in? ? new_legislation_process_proposal_path(@process) : new_user_session_path),
+                            class: 'button expanded', id: 'create-new-proposal' %></p>
           <% end %>
         <% end %>
         <%= render 'legislation/proposals/categories', taggable: @process %>

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -193,5 +193,44 @@ feature 'Legislation' do
 
       include_examples "not published permissions", :result_publication_legislation_process_path
     end
+
+    context 'proposals phase' do
+      scenario 'not open' do
+        process = create(:legislation_process, proposals_phase_start_date: Date.current + 1.day, proposals_phase_end_date: Date.current + 2.days)
+
+        visit legislation_process_proposals_path(process)
+
+        expect(page).to have_content("This phase is not open yet")
+      end
+
+      scenario 'open' do
+        process = create(:legislation_process, proposals_phase_start_date: Date.current - 1.day, proposals_phase_end_date: Date.current + 2.days, proposals_phase_enabled: true)
+
+        visit legislation_process_proposals_path(process)
+
+        expect(page).to have_content("There are no proposals")
+      end
+
+      scenario 'create proposal button leads to create proposal path if user is logged in' do
+        process = create(:legislation_process, proposals_phase_start_date: Date.current - 1.day, proposals_phase_end_date: Date.current + 2.days, proposals_phase_enabled: true)
+
+        login_as create(:user)
+        visit legislation_process_proposals_path(process)
+
+        expect(page).to have_content("Crea una propuesta")
+        expect(find("#create-new-proposal")[:href]).to have_content("/legislation/processes/#{process.id}/proposals/new")
+      end
+
+      scenario 'create proposal button leads to register path if user is not logged in' do
+        process = create(:legislation_process, proposals_phase_start_date: Date.current - 1.day, proposals_phase_end_date: Date.current + 2.days, proposals_phase_enabled: true)
+
+        visit legislation_process_proposals_path(process)
+
+        expect(page).to have_content("Crea una propuesta")
+        expect(find("#create-new-proposal")[:href]).to have_content("/users/sign_in")
+      end
+
+      include_examples "not published permissions", :legislation_process_proposals_path
+    end
   end
 end


### PR DESCRIPTION
What
====
In Legislation Proposals index:
Added logic to redirect not logged in users to sign in path if they click the "Create proposal" button.

Test
====
As usual.

Deployment
==========
As usual.
