### PR TITLE
Rake tasks to print author emails for winner/selected/proposed

### DIFF
--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -11,6 +11,49 @@ namespace :budgets do
       Budget.last.email_unselected
     end
 
+    desc "Get emails from last Budget's winner investments authors"
+    task winner_investments_emails: :environment do
+      puts winner_emails
+    end
+
+    desc "Get emails from last Budget's selected but not winner investments authors"
+    task selected_investments_emails: :environment do
+      puts selected_emails
+    end
+
+    desc "Get emails from last Budget's proposed but not selected investments authors"
+    task proposed_non_selected_investments_emails: :environment do
+      puts proposed_non_selected_emails
+    end
+
   end
 
+end
+
+def investments_author_emails(investments)
+  User.where(id: investments.pluck(:author_id).uniq).pluck(:email).uniq
+end
+
+def winner_investments
+  Budget::Investment.winners.where(budget: Budget.last)
+end
+
+def selected_non_winner_investments
+  Budget::Investment.selected.where(budget: Budget.last).where.not(id: winner_investments.pluck(:id))
+end
+
+def non_selected_non_winner_investments
+  Budget::Investment.where(budget: Budget.last).where.not(id: Budget::Investment.selected.pluck(:id))
+end
+
+def winner_emails
+  investments_author_emails(winner_investments)
+end
+
+def selected_emails
+  investments_author_emails(selected_non_winner_investments) - winner_emails
+end
+
+def proposed_non_selected_emails
+  investments_author_emails(non_selected_non_winner_investments) - selected_emails
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1012

What
====
We where asked to get the list of emails for winner/selected/proposed investments on last Budget

How
===
Just adding 3 rake tasks, this could be done at Consul in a much better way, but I would do it after we finally get Notifications to be global to send the emails from the admin panel, or at least a view at the admin panel to get the 3 email lists.

Screenshots
===========
No need

Test
====
No need, manually tested rakes on local machine
```
bin/rake budgets:email:winner_investments_emails
bin/rake budgets:email:selected_investments_emails
bin/rake budgets:email:proposed_non_selected_investments_emails
```

Deployment
==========
As soon as possible to pre and pro to return an Excell to comunication team

Warnings
========
As stated at **How** this could be a cool feature to have at the admin panel... if someone else agrees as well, I'll create an issue at Consul