### PR TITLE
BudgetPoll responses output via rake task

### DIFF
--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -28,6 +28,28 @@ namespace :budgets do
 
   end
 
+  desc "Get Budget Polls results to fill an excell"
+  task budget_polls_results: :environment do
+    require 'csv'
+
+    csv_string = CSV.generate(col_sep: "^", row_sep: "*****") do |csv|
+      BudgetPoll.all.each do |budget_poll|
+        csv << [
+          budget_poll.name,
+          budget_poll.email,
+          budget_poll.preferred_subject,
+          budget_poll.collective ? 'Si' : 'No',
+          budget_poll.public_worker ? 'Si' : 'No',
+          budget_poll.proposal_author ? 'Si' : 'No',
+          budget_poll.selected_proposal_author ? 'Si' : 'No'
+        ]
+      end
+    end
+
+    csv_string.delete!("\t")
+    headers = "nombre^email^tema^colectivo^funcionario^autor^seleccionado*****"
+    puts "#{headers}#{csv_string}"
+  end
 end
 
 def investments_author_emails(investments)


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1011

What
====
Get into a excel file the BudgetPoll responses we added at https://github.com/AyuntamientoMadrid/consul/issues/993

How
===
Just a rake task that as usual composes a string in the console like:
`nombre^email^tema^colectivo^funcionario^autor^seleccionado*****marlo^brando@carlo.com^Fase de informes^Si^No^No^Si*****juan^cho@juan.com^ns/nc^Si^No^No^No*****`

We'll need to execute `bin/rake budgets:budget_polls_results RAILS_ENV=environment` obviously replacing **environment** for the correct them, then:

1. Copy and paste the full text into our editor
2. Replace `*****` for a new line on our editor
3. Save the file as a `.csv` one
4. Open it with openoffice (check that the caret character `^` is being selected as delimiter for data
5. Save the document as Excel file and send it to whomever requests it
6. Be Free

Screenshots
===========
No need

Test
====
Tested manually in localhost

Deployment
==========
As usual

Warnings
========
None