### PR TITLE
Spending Proposal url redirect to Budget Investments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,9 +105,10 @@ Rails.application.routes.draw do
 
   get "presupuestos/:budget_id/:id/:heading_id", to: "budgets/investments#index", as: 'custom_budget_investments'
   get "presupuestos/:budget_id/:id", to: "budgets/groups#show", as: 'custom_budget_group'
+  get "participatory_budget/investment_projects/:id", to: "budgets/investments#redirect_to_new_url", as: 'spending_proposals_to_budget_investments'
 
   scope '/participatory_budget' do
-    resources :spending_proposals, only: [:index, :show, :destroy], path: 'investment_projects' do #[:new, :create] temporary disabled
+    resources :spending_proposals, only: [:index, :destroy], path: 'investment_projects', controller: "budgets/investments" do #[:new, :create] temporary disabled
       get :welcome, on: :collection
       get :stats, on: :collection
       post :vote, on: :member

--- a/lib/migrate_spending_proposals_to_investments.rb
+++ b/lib/migrate_spending_proposals_to_investments.rb
@@ -67,9 +67,9 @@ class MigrateSpendingProposalsToInvestments
 
     investment.valuators = sp.valuation_assignments.map(&:valuator)
 
-    votes = ActsAsVotable::Vote.where(votable_type: 'SpendingProposal', votable_id: sp.id)
-
-    votes.each {|v| investment.vote_by(voter: v.voter, vote: 'yes') }
+    # For now we avoind replicating votes
+    # votes = ActsAsVotable::Vote.where(votable_type: 'SpendingProposal', votable_id: sp.id)
+    # votes.each {|v| investment.vote_by(voter: v.voter, vote: 'yes') }
 
     # Spending proposals are not commentable in Consul so we can not test this
     Comment.where(commentable_type: 'SpendingProposal', commentable_id: sp.id).update_all(

--- a/lib/migrate_spending_proposals_to_investments.rb
+++ b/lib/migrate_spending_proposals_to_investments.rb
@@ -80,6 +80,8 @@ class MigrateSpendingProposalsToInvestments
     # Spending proposals have ballot_lines in Madrid, but not in consul, so we
     # can not test this either
 
+    sp.update_column(:explanations_log, investment.id) # Backwards reference to unfeasibility_explanation
+
     investment
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -752,4 +752,20 @@ feature 'Admin budget investments' do
     end
   end
 
+  context "Redirects old Spending Proposal urls to correct Budget Investment" do
+
+    let(:spending_proposal) { create(:spending_proposal) }
+    let(:budget_investment) { create(:budget_investment) }
+
+    before do
+      budget_investment.update_column(:unfeasibility_explanation, spending_proposal.id)
+    end
+
+    scenario "Spending Proposal with associated Budget Investment" do
+      visit "/participatory_budget/investment_projects/#{spending_proposal.id}"
+
+      expect(current_path).to eq("/presupuestos/#{budget_investment.budget.slug}/proyecto/#{budget_investment.id}")
+    end
+
+  end
 end

--- a/spec/features/ballots_spec.rb
+++ b/spec/features/ballots_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'Ballots' do
 
   background do
+    skip 'Spending Proposals now redirects to its associated Budget Investment'
     Setting["feature.spending_proposals"] = true
     Setting['feature.spending_proposal_features.phase3'] = true
     Setting['feature.spending_proposal_features.final_voting_allowed'] ||= true

--- a/spec/features/comments/spending_proposals_spec.rb
+++ b/spec/features/comments/spending_proposals_spec.rb
@@ -6,6 +6,8 @@ feature 'Commenting spending_proposals' do
   let(:spending_proposal) { create :spending_proposal }
 
   background do
+    skip 'Spending Proposals now redirects to its associated Budget Investment'
+
     Setting["feature.spending_proposals"] = true
     Setting['feature.spending_proposal_features.voting_allowed'] = true
   end

--- a/spec/features/official_positions_spec.rb
+++ b/spec/features/official_positions_spec.rb
@@ -73,6 +73,8 @@ feature 'Official positions' do
     context "Spending proposals" do
 
       background do
+        skip 'Spending Proposals now redirects to its associated Budget Investment'
+
         Setting["feature.spending_proposals"] = true
         @spending_proposal1 = create(:spending_proposal, author: @user1)
         @spending_proposal2 = create(:spending_proposal, author: @user2)

--- a/spec/features/spending_proposals_spec.rb
+++ b/spec/features/spending_proposals_spec.rb
@@ -15,6 +15,7 @@ feature 'Spending proposals' do
   end
 
   scenario 'Index' do
+    skip 'Spending Proposals now redirects to its associated Budget Investment'
     spending_proposals = [create(:spending_proposal), create(:spending_proposal), create(:spending_proposal, feasible: true)]
     unfeasible_spending_proposal = create(:spending_proposal, feasible: false)
 
@@ -31,6 +32,10 @@ feature 'Spending proposals' do
   end
 
   context("Search") do
+    before do
+      skip 'Spending Proposals now redirects to its associated Budget Investment'
+    end
+
     scenario 'Search by text' do
       spending_proposal1 = create(:spending_proposal, title: "Get Schwifty")
       spending_proposal2 = create(:spending_proposal, title: "Schwifty Hello")
@@ -54,6 +59,10 @@ feature 'Spending proposals' do
   end
 
   context("Filters") do
+    before do
+      skip 'Spending Proposals now redirects to its associated Budget Investment'
+    end
+
     scenario 'by unfeasibility' do
       geozone1 = create(:geozone)
       spending_proposal1 = create(:spending_proposal, feasible: false, valuation_finished: true)
@@ -76,6 +85,9 @@ feature 'Spending proposals' do
   end
 
   context("Orders") do
+    before do
+      skip 'Spending Proposals now redirects to its associated Budget Investment'
+    end
 
     scenario "Default order is random" do
       per_page = Kaminari.config.default_per_page
@@ -205,6 +217,7 @@ feature 'Spending proposals' do
   end
 
   scenario "Show" do
+    skip 'Spending Proposals now redirects to its associated Budget Investment'
     spending_proposal = create(:spending_proposal,
                                 geozone: create(:geozone),
                                 association_name: 'People of the neighbourhood')
@@ -222,6 +235,7 @@ feature 'Spending proposals' do
   end
 
   scenario "Show (feasible spending proposal)" do
+    skip 'Spending Proposals now redirects to its associated Budget Investment'
     user = create(:user)
     login_as(user)
 
@@ -238,6 +252,8 @@ feature 'Spending proposals' do
   end
 
   scenario "Show (unfeasible spending proposal)" do
+    skip 'Spending Proposals now redirects to its associated Budget Investment'
+
     user = create(:user)
     login_as(user)
 
@@ -270,6 +286,9 @@ feature 'Spending proposals' do
   end
 
   context "Badge" do
+    before do
+      skip 'Spending Proposals now redirects to its associated Budget Investment'
+    end
 
     scenario "Spending proposal created by a Foum" do
       forum = create(:forum)
@@ -302,6 +321,7 @@ feature 'Spending proposals' do
   context "Phase 3 - Final Voting" do
 
     background do
+      skip 'Spending Proposals now redirects to its associated Budget Investment'
       Setting["feature.spending_proposal_features.phase3"] = true
     end
 
@@ -619,6 +639,7 @@ feature 'Spending proposals' do
   context "Stats" do
 
     before(:each) do
+      skip 'Spending Proposals now redirects to its associated Budget Investment'
       Setting["feature.spending_proposal_features.open_results_page"] = true
     end
 

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -376,6 +376,8 @@ feature 'Votes' do
 
     context "Verified User" do
       background do
+        skip 'Spending Proposals now redirects to its associated Budget Investment'
+
         login_as(@manuela)
         Setting["feature.spending_proposal_features.phase2"] = true
       end
@@ -455,6 +457,8 @@ feature 'Votes' do
     context "Forum" do
 
       background do
+        skip 'Spending Proposals now redirects to its associated Budget Investment'
+
         @user = create(:user)
         forum = create(:forum, user: @user)
 

--- a/spec/lib/migrate_spending_proposals_to_investments_spec.rb
+++ b/spec/lib/migrate_spending_proposals_to_investments_spec.rb
@@ -52,6 +52,8 @@ describe MigrateSpendingProposalsToInvestments do
       expect(inv2.heading).to eq(inv1.heading)
       expect(inv1.unfeasibility_explanation).to eq(sp1.id.to_s)
       expect(inv2.unfeasibility_explanation).to eq(sp2.id.to_s)
+      expect(sp1.explanations_log).to eq(inv1.id)
+      expect(sp2.explanations_log).to eq(inv2.id)
     end
 
     it "Imports feasibility correctly" do

--- a/spec/lib/migrate_spending_proposals_to_investments_spec.rb
+++ b/spec/lib/migrate_spending_proposals_to_investments_spec.rb
@@ -78,6 +78,7 @@ describe MigrateSpendingProposalsToInvestments do
     end
 
     it "Imports votes" do
+      skip
       sp = create(:spending_proposal)
       votes = create_list(:vote, 4, votable: sp)
       voters = votes.map(&:voter).sort_by(&:id)


### PR DESCRIPTION
What
====
Spending Proposal urls are all around the internet, and as well at decide.madrid.es with multiple references. We need to keep those urls alive even if we move towards Budget Investments, but keeping in mind all Spending Proposals code will sooner or later disappear to cleanup the codebase.

How
===
Redirecting the #show action for a spending proposal custom url path (translated to spanish) to Budget investment's controller with a special action that avoids trying to load budget/investment resources (and authorization).

We then use the `unfeasibility_explanation` column of Budget Investments table to find which one corresponds with the requested Spending Proposal id and redirect to the same controller show action as usual.

As a Bonus we're removing the votes migration from spending proposal to budget investements as its something not needed right now and quite critical to be touch without lots of testing behind.

Screenshots
===========
No need

Test
====
Covered the redirect and the backwards reference for double security. Manually tested in PRE environment with success!

Deployment
==========
As usual

Warnings
========
I feel there should be a cleaner way to do this (obviously on spending proposal controller but since that file will be deleted its not an option) but 🤔  seems good enough for now and doesn't tie things or prevent future improvements