### PR TITLE
Show original Spending Proposal ID for migrated to Investment object

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -80,7 +80,7 @@ module Budgets
     end
 
     def redirect_to_new_url
-      investment = Budget::Investment.where(unfeasibility_explanation: params['id']).first
+      investment = Budget::Investment.where(original_spending_proposal_id: params['id']).first
       redirect_to budget_investment_path(investment.budget, investment) if investment.present?
     end
 

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -30,7 +30,7 @@
       <%= render_image(investment.image, :large, true) if investment.image.present? %>
 
       <p id="investment_code">
-        <%= t("budgets.investments.show.code_html", code: investment.id) %>
+        <%= t("budgets.investments.show.code_html", code: investment.original_spending_proposal_id || investment.id) %>
       </p>
 
       <% if investment.location.present? %>

--- a/db/migrate/20171219110528_add_spending_id_to_budget_invesment.rb
+++ b/db/migrate/20171219110528_add_spending_id_to_budget_invesment.rb
@@ -1,0 +1,5 @@
+class AddSpendingIdToBudgetInvesment < ActiveRecord::Migration
+  def change
+    add_column :budget_investments, :original_spending_proposal_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215152244) do
+ActiveRecord::Schema.define(version: 20171219110528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,38 +163,39 @@ ActiveRecord::Schema.define(version: 20171215152244) do
     t.string   "title"
     t.text     "description"
     t.string   "external_url"
-    t.integer  "price",                      limit: 8
-    t.string   "feasibility",                limit: 15, default: "undecided"
+    t.integer  "price",                         limit: 8
+    t.string   "feasibility",                   limit: 15, default: "undecided"
     t.text     "price_explanation"
     t.text     "unfeasibility_explanation"
     t.text     "internal_comments"
-    t.boolean  "valuation_finished",                    default: false
-    t.integer  "valuator_assignments_count",            default: 0
-    t.integer  "price_first_year",           limit: 8
+    t.boolean  "valuation_finished",                       default: false
+    t.integer  "valuator_assignments_count",               default: 0
+    t.integer  "price_first_year",              limit: 8
     t.string   "duration"
     t.datetime "hidden_at"
-    t.integer  "cached_votes_up",                       default: 0
-    t.integer  "comments_count",                        default: 0
-    t.integer  "confidence_score",                      default: 0,           null: false
-    t.integer  "physical_votes",                        default: 0
+    t.integer  "cached_votes_up",                          default: 0
+    t.integer  "comments_count",                           default: 0
+    t.integer  "confidence_score",                         default: 0,           null: false
+    t.integer  "physical_votes",                           default: 0
     t.tsvector "tsv"
-    t.datetime "created_at",                                                  null: false
-    t.datetime "updated_at",                                                  null: false
+    t.datetime "created_at",                                                     null: false
+    t.datetime "updated_at",                                                     null: false
     t.integer  "heading_id"
     t.string   "responsible_name"
     t.integer  "budget_id"
     t.integer  "group_id"
-    t.boolean  "selected",                              default: false
+    t.boolean  "selected",                                 default: false
     t.string   "location"
     t.string   "organization_name"
     t.datetime "unfeasible_email_sent_at"
     t.string   "label"
     t.integer  "previous_heading_id"
-    t.boolean  "visible_to_valuators",                  default: false
-    t.integer  "ballot_lines_count",                    default: 0
-    t.boolean  "winner",                                default: false
-    t.boolean  "incompatible",                          default: false
+    t.boolean  "visible_to_valuators",                     default: false
+    t.integer  "ballot_lines_count",                       default: 0
+    t.boolean  "winner",                                   default: false
+    t.boolean  "incompatible",                             default: false
     t.integer  "community_id"
+    t.integer  "original_spending_proposal_id"
   end
 
   add_index "budget_investments", ["administrator_id"], name: "index_budget_investments_on_administrator_id", using: :btree

--- a/lib/migrate_spending_proposals_to_investments.rb
+++ b/lib/migrate_spending_proposals_to_investments.rb
@@ -33,7 +33,7 @@ class MigrateSpendingProposalsToInvestments
       price: sp.price,
       feasibility: feasibility,
       price_explanation: sp.price_explanation,
-      unfeasibility_explanation: sp.id, # MIGRATE THIS correctly
+      unfeasibility_explanation: nil, # FIND VALUE FOR THIS ONE
       internal_comments: sp.internal_comments,
       valuation_finished: sp.valuation_finished,
       valuator_assignments_count: sp.valuation_assignments_count,
@@ -62,7 +62,8 @@ class MigrateSpendingProposalsToInvestments
       winner: false, # FIND VALUE FOR THIS ONE
       incompatible: !sp.compatible, # Is it really the opposite?
       community_id: community.id,
-      terms_of_service: "1"
+      terms_of_service: "1",
+      original_spending_proposal_id: sp.id
     )
 
     investment.valuators = sp.valuation_assignments.map(&:valuator)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -758,7 +758,7 @@ feature 'Admin budget investments' do
     let(:budget_investment) { create(:budget_investment) }
 
     before do
-      budget_investment.update_column(:unfeasibility_explanation, spending_proposal.id)
+      budget_investment.update_column(:original_spending_proposal_id, spending_proposal.id)
     end
 
     scenario "Spending Proposal with associated Budget Investment" do

--- a/spec/lib/migrate_spending_proposals_to_investments_spec.rb
+++ b/spec/lib/migrate_spending_proposals_to_investments_spec.rb
@@ -50,8 +50,8 @@ describe MigrateSpendingProposalsToInvestments do
       inv2 = importer.import(sp2)
 
       expect(inv2.heading).to eq(inv1.heading)
-      expect(inv1.unfeasibility_explanation).to eq(sp1.id.to_s)
-      expect(inv2.unfeasibility_explanation).to eq(sp2.id.to_s)
+      expect(inv1.original_spending_proposal_id).to eq(sp1.id)
+      expect(inv2.original_spending_proposal_id).to eq(sp2.id)
       expect(sp1.explanations_log).to eq(inv1.id)
       expect(sp2.explanations_log).to eq(inv2.id)
     end


### PR DESCRIPTION
What
====
Using `original_spending_proposal_id` instead of `unfeasibility_explanation` (actually used for some proposals) to avoid messing data so much, and having a clear way to find correspondent investment given a spending id request

Also we actually need to show the original Spending ID instead of the Budget Investment ID in case the investment has been migrated from a spending proposal 

How
===
Migration, update specs and show original id if present instead of current id

Screenshots
===========
From Pre environment
![screen shot 2017-12-19 at 12 44 55](https://user-images.githubusercontent.com/983242/34156310-ede2b40e-e4bc-11e7-9426-cdf74aafdbc0.jpg)

Test
====
Updated and tested manually in pre

Deployment
==========
We'll need to run through console at pro:
```
Budget.where(name: '2016').first.investments.each { |i| i.update_column(:original_spending_proposal_id, i.unfeasibility_explanation) }
Budget.where(name: '2016').first.investments.each { |i| i.update_column(:unfeasibility_explanation, nil) if i.unfeasibility_explanation == i.original_spending_proposal_id.to_s }
```
To populate values and cleanup old ones

Warnings
========
None