### PR TITLE
Investment budget spending urls

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -4,8 +4,9 @@ module Budgets
     include CommentableActions
     include FlagActions
 
-    before_action :authenticate_user!, except: [:index, :show]
-    before_action :load_budget
+    before_action :authenticate_user!, except: [:index, :show, :redirect_to_new_url]
+    before_action :load_budget, except: :redirect_to_new_url
+    before_action :load_investment, only: [:show]
 
     load_and_authorize_resource :budget, except: :redirect_to_new_url
     load_and_authorize_resource :investment, through: :budget, class: "Budget::Investment", except: :redirect_to_new_url
@@ -81,7 +82,7 @@ module Budgets
 
     def redirect_to_new_url
       investment = Budget::Investment.where(original_spending_proposal_id: params['id']).first
-      redirect_to budget_investment_path(investment.budget, investment) if investment.present?
+      redirect_to budget_investment_path(investment.budget, params['id']) if investment.present?
     end
 
     private
@@ -123,6 +124,11 @@ module Budgets
                       image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                       documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                       map_location_attributes: [:latitude, :longitude, :zoom])
+      end
+
+      def load_investment
+        @investment = @budget.investments.where(original_spending_proposal_id: params['id']).first
+        @investment ||= @budget.investments.find(params['id'])
       end
 
       def load_ballot

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -752,20 +752,4 @@ feature 'Admin budget investments' do
     end
   end
 
-  context "Redirects old Spending Proposal urls to correct Budget Investment" do
-
-    let(:spending_proposal) { create(:spending_proposal) }
-    let(:budget_investment) { create(:budget_investment) }
-
-    before do
-      budget_investment.update_column(:original_spending_proposal_id, spending_proposal.id)
-    end
-
-    scenario "Spending Proposal with associated Budget Investment" do
-      visit "/participatory_budget/investment_projects/#{spending_proposal.id}"
-
-      expect(current_path).to eq("/presupuestos/#{budget_investment.budget.slug}/proyecto/#{budget_investment.id}")
-    end
-
-  end
 end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1061,4 +1061,38 @@ feature 'Budget Investments' do
     end
 
   end
+
+  context "Spending Proposal url redirection to associated Budget Investment" do
+    let!(:investment_with_same_id) { create(:budget_investment, id: 9999, title: 'Investment with same Spending ID Proposal') }
+    let!(:spending_proposal) { create(:spending_proposal, id: 9999, title: 'Le Spending Proposal') }
+    let!(:associated_budget_investment) do
+      create(:budget_investment, id: 8888, title: 'Budget Investment child', original_spending_proposal_id: spending_proposal.id)
+    end
+
+    scenario "Old Spending Proposal url redirects to associated Budget Investment with original spending proposal ID" do
+      visit "/participatory_budget/investment_projects/#{spending_proposal.id}"
+
+      expect(current_path).to eq("/presupuestos/#{associated_budget_investment.budget.slug}/proyecto/#{spending_proposal.id}")
+      expect(page).to have_content("Investment project code: #{spending_proposal.id}")
+      expect(page).to have_content("Budget Investment child")
+    end
+
+    scenario "New Budget Investment url with original spending proposal ID shows correctly" do
+      visit "/presupuestos/#{associated_budget_investment.budget.slug}/proyecto/#{spending_proposal.id}"
+
+      expect(current_path).to eq("/presupuestos/#{associated_budget_investment.budget.slug}/proyecto/#{spending_proposal.id}")
+      expect(page).to have_content("Investment project code: #{spending_proposal.id}")
+      expect(page).to have_content("Budget Investment child")
+    end
+
+    scenario "Budget Investment not associated to an Spending, and with same ID as migrated Spending proposal shows correctly" do
+      visit "/presupuestos/#{investment_with_same_id.budget.slug}/proyecto/#{investment_with_same_id.id}"
+
+      expect(current_path).to eq("/presupuestos/#{investment_with_same_id.budget.slug}/proyecto/#{investment_with_same_id.id}")
+      expect(page).to have_content("Investment project code: #{investment_with_same_id.id}")
+      expect(page).to have_content("Investment with same Spending ID Proposal")
+    end
+
+  end
+
 end


### PR DESCRIPTION
What
====
We need to keep old spending proposals url's working exactly the same, even though "underneath" those will be handled by the budget investment controller and they will load the associated budget investment.

There's a catch since there could be a SpendingProposal with ID 9999  (with an associated Investment with ID 8888)... but another Budget Investment from a different Budget with the same ID 9999... and both urls need to be valid (the only difference will be the budget_id or budget_slug.

How
===
Explicitly loading the investment, first trying to figure out if there is a Budget Investment with a reference to an old Spending Proposal for the given `params['id']` value, if not just looking for the investment with that id.

Screenshots
===========
No need

Test
====
Moved to correct file, and increased to the 3 scenarios I could imagine:
- Visiting old url for a spending proposal
- Visiting "new" url for a spending proposal 
- Visiting an investment url with same id as an old spending proposal

Deployment
==========
As usual

Warnings
========
None