### PR TITLE
Migrated Spending proposals on Admin panel

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -60,7 +60,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_investment
-      @investment = Budget::Investment.where(budget_id: @budget.id).find params[:id]
+      @investment = @budget.investments.where(original_spending_proposal_id: params[:id]).first
+      @investment ||= @budget.investments.find(params['id'])
     end
 
     def load_admins

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -25,12 +25,16 @@
   </thead>
 
   <% @investments.each do |investment| %>
+    <% investment_id = investment.original_spending_proposal_id || investment.id %>
     <tr id="<%= dom_id(investment) %>" class="budget_investment">
       <td class="text-right">
-        <strong><%= investment.id %></strong>
+        <strong><%= investment_id %></strong>
       </td>
       <td>
-        <%= link_to investment.title, admin_budget_budget_investment_path(budget_id: @budget.id, id: investment.id, params: Budget::Investment.filter_params(params)), target: "_blank" %>
+        <%= link_to investment.title,
+                    admin_budget_budget_investment_path(budget_id: @budget.id,
+                                                       id: investment_id,
+                                                       params: Budget::Investment.filter_params(params)), target: "_blank" %>
       </td>
       <td class="text-center">
         <%= investment.total_votes %>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -752,4 +752,34 @@ feature 'Admin budget investments' do
     end
   end
 
+  context "Spending Proposals migrated to Budget Investments should keep the original IDs on lists & urls" do
+    let(:spending_proposal) { create(:spending_proposal, id: 9999, title: 'Le Spending Proposal') }
+    let(:spending_proposal_migrated_to_budget_investment_path) { "/admin/budgets/#{budget.id}/budget_investments/#{spending_proposal.id}" }
+    let!(:associated_budget_investment) do
+      create(:budget_investment, id: 8888, budget: budget, title: 'Budget Investment child',
+                                 original_spending_proposal_id: spending_proposal.id)
+    end
+
+    scenario "A Budget Investment generated from a Spending Proposal should be listed & linked with original Spending Proposal id" do
+      visit admin_budget_budget_investments_path(budget)
+
+      within("#budget_investment_#{associated_budget_investment.id}") do
+        expect(page).to have_link("Budget Investment child", href: spending_proposal_migrated_to_budget_investment_path)
+      end
+    end
+
+    scenario "A Budget Investment generated from a Spending Proposal should be accesible by original Spending Proposal id" do
+      visit admin_budget_budget_investment_path(budget_id: budget.id, id: spending_proposal.id)
+
+      expect(current_path).to eq(spending_proposal_migrated_to_budget_investment_path)
+      expect(page).to have_content("Budget Investment child")
+    end
+
+    scenario "A Budget Investment generated from a Spending Proposal should be accesible by its own id" do
+      visit admin_budget_budget_investment_path(budget_id: budget.id, id: associated_budget_investment.id)
+
+      expect(page).to have_content("Budget Investment child")
+    end
+  end
+
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1082

What
====
We need to both list and link budget investments generated from a migrated spending proposal with the spending proposal id

How
===
Similar to the fix done on the frontend for final user, finding first if a investment with a `original_spending_proposal_id` value exists, and falling back to a normal `.find`.

Screenshots
===========
No need.

Test
====
Added scenario to check correct listing, url link and access by original spending id and investment id

Deployment
==========
As usual

Warnings
========
None