### PR TITLE
Fix social images meta tags

### DIFF
--- a/app/views/budgets/recommendations/index.html.erb
+++ b/app/views/budgets/recommendations/index.html.erb
@@ -4,7 +4,7 @@
 <meta name="twitter:site" content="@abriendomadrid" />
 <meta name="twitter:title" content="Presupuestos Participativos en Madrid" />
 <meta name="twitter:description" content="Proyectos de gasto recomendados por <%= @user.name %>" />
-<meta name="twitter:image" content="<%= image_url '/social_media_budgets_twitter.png' %>" />
+<meta name="twitter:image" content="<%= image_url 'social_media_budgets_twitter.png' %>" />
 <!-- Facebook OG -->
 <meta id="ogtitle" property="og:title" content="Presupuestos Participativos en Madrid"/>
 <% if setting['url'] %>
@@ -16,7 +16,7 @@
 <meta property="og:type" content="article"/>
 <% og_url = current_budget.present? ? budget_recommendations_url(budget_id: current_budget.slug, user_id: @user.id) : budgets_url %>
 <meta id="ogurl" property="og:url" content="<%= og_url %>"/>
-<meta id="ogimage" property="og:image" content="<%= image_url '/social_media_budgets.png' %>"/>
+<meta id="ogimage" property="og:image" content="<%= image_url 'social_media_budgets.png' %>"/>
 <meta property="og:site_name" content="Decide Madrid"/>
 <meta id="ogdescription" property="og:description" content="Proyectos de gasto recomendados por <%= @user.name %>"/>
 <meta property="fb:app_id" content="1662598980652932"/>

--- a/app/views/pages/landings/blas_bonilla.html.erb
+++ b/app/views/pages/landings/blas_bonilla.html.erb
@@ -6,13 +6,13 @@
 <!-- Facebook OG -->
 <meta property="og:url"           content="<%= request.url %>haz-propuestas" />
 <meta property="og:title"         content="Haz propuestas en Decide Madrid" />
-<meta property="og:image"         content="<%= image_url '/social_media_blas.jpg' %>" />
+<meta property="og:image"         content="<%= image_url 'social_media_blas.jpg' %>" />
 <meta property="og:description"   content="Haz caso a Blas Bonilla y presenta tus propuestas para que Madrid sea una ciudad mejor. Entra, regístrate y participa en https://decide.madrid.es/haz-propuestas" />
 <!-- Twitter -->
 <meta name="twitter:card"          content="summary" />
 <meta name="twitter:site"          content="@decideMadrid" />
 <meta name="twitter:title"         content="Haz propuestas en Decide Madrid" />
-<meta name="twitter:image"         content="<%= image_url '/social_media_blas.jpg' %>" />
+<meta name="twitter:image"         content="<%= image_url 'social_media_blas.jpg' %>" />
 <meta name="twitter:description"   content="Haz caso a Blas Bonilla y presenta tus propuestas para que Madrid sea una ciudad mejor. Entra, regístrate y participa en https://decide.madrid.es/haz-propuestas" />
 
 <% end %>

--- a/app/views/pages/landings/budgets_materials_2017.html.erb
+++ b/app/views/pages/landings/budgets_materials_2017.html.erb
@@ -7,13 +7,13 @@
 <!-- Facebook OG -->
 <meta property="og:url"           content="<%= request.url %>presupuestos-participativos-2017-materiales" />
 <meta property="og:title"         content="Materiales para difundir los presupuestos participativos 2017" />
-<meta property="og:image"         content="<%= image_url '/social_media_budgets_materials_2017.png' %>" />
+<meta property="og:image"         content="<%= image_url 'social_media_budgets_materials_2017.png' %>" />
 <meta property="og:description"   content="Materiales para descargar sobre los presupuestos participativos 2017. Incluye un cartel, un díptico y una imagen de cada distrito de Madrid." />
 <!-- Twitter -->
 <meta name="twitter:card"          content="summary" />
 <meta name="twitter:site"          content="@decideMadrid" />
 <meta name="twitter:title"         content="Materiales para difundir los presupuestos participativos 2017" />
-<meta name="twitter:image"         content="<%= image_url '/social_media_budgets_materials_2017.png' %>" />
+<meta name="twitter:image"         content="<%= image_url 'social_media_budgets_materials_2017.png' %>" />
 <meta name="twitter:description"   content="Materiales para descargar sobre los presupuestos participativos 2017. Incluye un cartel, un díptico y una imagen de cada distrito de Madrid." />
 <% end %>
 

--- a/app/views/pages/landings/budgets_videos_2017.html.erb
+++ b/app/views/pages/landings/budgets_videos_2017.html.erb
@@ -6,13 +6,13 @@
 <!-- Facebook OG -->
 <meta property="og:url"           content="<%= request.url %>presupuestos-participativos-2017-videos" />
 <meta property="og:title"         content="Vídeos de proyectos de presupuestos participativos 2017" />
-<meta property="og:image"         content="<%= image_url '/social_media_budgets_videos_2017.png' %>" />
+<meta property="og:image"         content="<%= image_url 'social_media_budgets_videos_2017.png' %>" />
 <meta property="og:description"   content="Las personas y colectivos que cuentan con proyectos de presupuestos participativos de 2017 en la votación final de decide.madrid.es, nos explican de primera mano en qué consisten sus propuestas" />
 <!-- Twitter -->
 <meta name="twitter:card"          content="summary" />
 <meta name="twitter:site"          content="@decideMadrid" />
 <meta name="twitter:title"         content="Vídeos de proyectos de presupuestos participativos 2017" />
-<meta name="twitter:image"         content="<%= image_url '/social_media_budgets_videos_2017.png' %>" />
+<meta name="twitter:image"         content="<%= image_url 'social_media_budgets_videos_2017.png' %>" />
 <meta name="twitter:description"   content="Las personas y colectivos que cuentan con proyectos de presupuestos participativos de 2017 en la votación final de decide.madrid.es, nos explican de primera mano en qué consisten sus propuestas" />
 <% end %>
 

--- a/app/views/pages/landings/first_voting.html.erb
+++ b/app/views/pages/landings/first_voting.html.erb
@@ -5,13 +5,13 @@
   <!-- Facebook -->
   <meta property="og:url"            content="<%= first_voting_url %>" />
   <meta property="og:title"          content="<%= t("first_2017_poll.meta_tags.title") %>" />
-  <meta property="og:image"          content="<%= image_url '/social_media_vota.png' %>" />
+  <meta property="og:image"          content="<%= image_url 'social_media_vota.png' %>" />
   <meta property="og:description"    content="<%= t("first_2017_poll.meta_tags.description") %>" />
   <!-- Twitter -->
   <meta name="twitter:card"          content="summary" />
   <meta name="twitter:site"          content="@DecideMadrid" />
   <meta name="twitter:title"         content="<%= t("first_2017_poll.meta_tags.title") %>" />
-  <meta name="twitter:image"         content="<%= image_url '/social_media_vota_twitter.png' %>" />
+  <meta name="twitter:image"         content="<%= image_url 'social_media_vota_twitter.png' %>" />
   <meta name="twitter:description"   content="<%= t("first_2017_poll.meta_tags.description") %>" />
 <% end %>
 

--- a/app/views/pages/landings/geocraft.html.erb
+++ b/app/views/pages/landings/geocraft.html.erb
@@ -9,13 +9,13 @@
 <!-- Facebook OG -->
 <meta property="og:url"           content="<%= geocraft_url %>" />
 <meta property="og:title"         content="Haz Madrid - Presupuestos participativos" />
-<meta property="og:image"         content="<%= image_url '/social_media_haz_madrid.jpg' %>" />
+<meta property="og:image"         content="<%= image_url 'social_media_haz_madrid.jpg' %>" />
 <meta property="og:description"   content="Imagina y crea tu propio Madrid en este entorno que recrea la Plaza Santa Ana de Madrid." />
 <!-- Twitter -->
 <meta name="twitter:card"          content="summary" />
 <meta name="twitter:site"          content="@decideMadrid" />
 <meta name="twitter:title"         content="Haz Madrid - Presupuestos participativos" />
-<meta name="twitter:image"         content="<%= image_url '/social_media_haz_madrid_twitter.jpg' %>" />
+<meta name="twitter:image"         content="<%= image_url 'social_media_haz_madrid_twitter.jpg' %>" />
 <meta name="twitter:description"   content="Imagina y crea tu propio Madrid en este entorno que recrea la Plaza Santa Ana de Madrid." />
 
 <% end %>

--- a/app/views/pages/landings/plazas_abiertas.html.erb
+++ b/app/views/pages/landings/plazas_abiertas.html.erb
@@ -9,13 +9,13 @@
 <!-- Facebook OG -->
 <meta property="og:url"           content="<%= request.url %>plazas-abiertas" />
 <meta property="og:title"         content="Plazas Abiertas - Debate de Presupuestos participativos" />
-<meta property="og:image"         content="<%= image_url '/social_media_plazas_abiertas.png' %>" />
+<meta property="og:image"         content="<%= image_url 'social_media_plazas_abiertas.png' %>" />
 <meta property="og:description"   content="La ciudadanía de Madrid debate sobre los presupuestos participativos del Ayuntamiento de Madrid en plazas de los 21 distritos de la ciudad el 18 de junio." />
 <!-- Twitter -->
 <meta name="twitter:card"          content="summary" />
 <meta name="twitter:site"          content="@decideMadrid" />
 <meta name="twitter:title"         content="Plazas Abiertas - Debate de Presupuestos participativos" />
-<meta name="twitter:image"         content="<%= image_url '/social_media_plazas_abiertas.png' %>" />
+<meta name="twitter:image"         content="<%= image_url 'social_media_plazas_abiertas.png' %>" />
 <meta name="twitter:description"   content="La ciudadanía de Madrid debate sobre los presupuestos participativos del Ayuntamiento de Madrid en plazas de los 21 distritos de la ciudad el 18 de junio." />
 <% end %>
 

--- a/app/views/pages/processes/once_plazas/index.html.erb
+++ b/app/views/pages/processes/once_plazas/index.html.erb
@@ -7,13 +7,13 @@
 <!-- Facebook OG -->
 <meta property="og:url"           content="<%= once_plazas_url %>" />
 <meta property="og:title"         content="Plan MAD-RE: Remodelación de 11 plazas en la periferia de Madrid" />
-<meta property="og:image"         content="<%= image_url '/social_media_once_plazas.png' %>" />
+<meta property="og:image"         content="<%= image_url 'social_media_once_plazas.png' %>" />
 <meta property="og:description"   content="Participa en el debate del concurso de ideas previo a la remodelación de 11 plazas públicas en los distritos de la periferia de Madrid." />
 <!-- Twitter -->
 <meta name="twitter:card"          content="summary" />
 <meta name="twitter:site"          content="@decideMadrid" />
 <meta name="twitter:title"         content="Plan MAD-RE: Remodelación de 11 plazas en la periferia de Madrid" />
-<meta name="twitter:image"         content="<%= image_url '/social_media_once_plazas_twitter.png' %>" />
+<meta name="twitter:image"         content="<%= image_url 'social_media_once_plazas_twitter.png' %>" />
 <meta name="twitter:description"   content="Participa en el debate del concurso de ideas previo a la remodelación de 11 plazas públicas en los distritos de la periferia de Madrid." />
 <% end %>
 

--- a/app/views/polls/info_2017.html.erb
+++ b/app/views/polls/info_2017.html.erb
@@ -7,13 +7,13 @@
   <!-- Facebook -->
   <meta property="og:url"            content="<%= primera_votacion_info_url %>" />
   <meta property="og:title"          content="<%= t("first_2017_poll.results.title") %>" />
-  <meta property="og:image"          content="<%= image_url '/social_media_polls_results.png' %>" />
+  <meta property="og:image"          content="<%= image_url 'social_media_polls_results.png' %>" />
   <meta property="og:description"    content="<%= t("first_2017_poll.results.description") %>" />
   <!-- Twitter -->
   <meta name="twitter:card"          content="summary" />
   <meta name="twitter:site"          content="@DecideMadrid" />
   <meta name="twitter:title"         content="<%= t("first_2017_poll.results.title") %>" />
-  <meta name="twitter:image"         content="<%= image_url '/social_media_polls_results_twitter.png' %>" />
+  <meta name="twitter:image"         content="<%= image_url 'social_media_polls_results_twitter.png' %>" />
   <meta name="twitter:description"   content="<%= t("first_2017_poll.results.description") %>" />
 <% end %>
 <div class="polls-results">

--- a/app/views/polls/results_2017.html.erb
+++ b/app/views/polls/results_2017.html.erb
@@ -7,13 +7,13 @@
   <!-- Facebook -->
   <meta property="og:url"            content="<%= first_voting_url %>" />
   <meta property="og:title"          content="<%= t("first_2017_poll.results.title") %>" />
-  <meta property="og:image"          content="<%= image_url '/social_media_polls_results.png' %>" />
+  <meta property="og:image"          content="<%= image_url 'social_media_polls_results.png' %>" />
   <meta property="og:description"    content="<%= t("first_2017_poll.results.description") %>" />
   <!-- Twitter -->
   <meta name="twitter:card"          content="summary" />
   <meta name="twitter:site"          content="@DecideMadrid" />
   <meta name="twitter:title"         content="<%= t("first_2017_poll.results.title") %>" />
-  <meta name="twitter:image"         content="<%= image_url '/social_media_polls_results_twitter.png' %>" />
+  <meta name="twitter:image"         content="<%= image_url 'social_media_polls_results_twitter.png' %>" />
   <meta name="twitter:description"   content="<%= t("first_2017_poll.results.description") %>" />
 <% end %>
 

--- a/app/views/polls/stats_2017.html.erb
+++ b/app/views/polls/stats_2017.html.erb
@@ -7,13 +7,13 @@
   <!-- Facebook -->
   <meta property="og:url"            content="<%= primera_votacion_stats_url %>" />
   <meta property="og:title"          content="<%= t("first_2017_poll.stats.title") %>" />
-  <meta property="og:image"          content="<%= image_url '/social_media_polls_results.png' %>" />
+  <meta property="og:image"          content="<%= image_url 'social_media_polls_results.png' %>" />
   <meta property="og:description"    content="<%= t("first_2017_poll.stats.description") %>" />
   <!-- Twitter -->
   <meta name="twitter:card"          content="summary" />
   <meta name="twitter:site"          content="@DecideMadrid" />
   <meta name="twitter:title"         content="<%= t("first_2017_poll.stats.title") %>" />
-  <meta name="twitter:image"         content="<%= image_url '/social_media_polls_results_twitter.png' %>" />
+  <meta name="twitter:image"         content="<%= image_url 'social_media_polls_results_twitter.png' %>" />
   <meta name="twitter:description"   content="<%= t("first_2017_poll.stats.description") %>" />
 <% end %>
 <% cache ["stats:polls_2017:rake_task:#{Stat.named('polls_2017_cache', 'keys', 'stats').value}"] do %>

--- a/app/views/shared/_social_media_meta_tags_participatory_budget.html.erb
+++ b/app/views/shared/_social_media_meta_tags_participatory_budget.html.erb
@@ -3,7 +3,7 @@
 <meta name="twitter:site" content="@abriendomadrid" />
 <meta name="twitter:title" content="Presupuestos Participativos en Madrid" />
 <meta name="twitter:description" content="Tú decides cómo invertir 100 millones de euros para tu ciudad" />
-<meta name="twitter:image" content="<%= image_url '/social_media_budgets_twitter.png' %>" />
+<meta name="twitter:image" content="<%= image_url 'social_media_budgets_twitter.png' %>" />
 <!-- Facebook OG -->
 <meta id="ogtitle" property="og:title" content="Presupuestos Participativos en Madrid"/>
 <% if setting['url'] %>
@@ -14,7 +14,7 @@
 <% end %>
 <meta property="og:type" content="article"/>
 <meta id="ogurl" property="og:url" content="<%= budgets_welcome_url %>"/>
-<meta id="ogimage" property="og:image" content="<%= image_url '/social_media_budgets.png' %>"/>
+<meta id="ogimage" property="og:image" content="<%= image_url 'social_media_budgets.png' %>"/>
 <meta property="og:site_name" content="Decide Madrid"/>
 <meta id="ogdescription" property="og:description" content="Tú decides cómo invertir 100 millones de euros para tu ciudad"/>
 <meta property="fb:app_id" content="1662598980652932"/>

--- a/app/views/shared/_social_media_meta_tags_plaza_espana.html.erb
+++ b/app/views/shared/_social_media_meta_tags_plaza_espana.html.erb
@@ -3,7 +3,7 @@
   <meta name="twitter:site" content="@abriendomadrid" />
   <meta name="twitter:title" content="Resultados encuesta de Plaza España" />
   <meta name="twitter:description" content="Lo que se ha decidido mayoritariamente será incorporado al pliego del concurso internacional de ideas." />
-  <meta name="twitter:image" content="<%= image_url '/social-media-plazaesp.png' %>" />
+  <meta name="twitter:image" content="<%= image_url 'social-media-plazaesp.png' %>" />
   <!-- Facebook OG -->
   <meta id="ogtitle" property="og:title" content="Resultados encuesta de Plaza España"/>
   <% if setting['url'] %>
@@ -14,7 +14,7 @@
   <% end %>
   <meta property="og:type" content="article"/>
   <meta id="ogurl" property="og:url" content="<%= request.url %>encuesta-plaza-espana-resultados"/>
-  <meta id="ogimage" property="og:image" content="<%= image_url '/social-media-plazaesp.png' %>"/>
+  <meta id="ogimage" property="og:image" content="<%= image_url 'social-media-plazaesp.png' %>"/>
   <meta property="og:site_name" content="Decide Madrid"/>
   <meta id="ogdescription" property="og:description" content="Lo que se ha decidido mayoritariamente será incorporado al pliego del concurso internacional de ideas."/>
   <meta property="fb:app_id" content="1662598980652932"/>


### PR DESCRIPTION
What
====
This PR removes unnecesary `/` on `og:image` and `twitter:image` meta tags.

This tags sin some pages:

```html
<meta property="og:image"  content="<%= image_url '/social_media_polls_results.png' %>" />`
<meta name="twitter:image" content="<%= image_url '/social_media_polls_results_twitter.png' %>" />`
```

Was generating a broken links:

```html
<meta property="og:image"  .../images/%2Fsocial_media_polls_results.png" />
```
```html
<meta name="twitter:image" .../images/%2Fsocial_media_polls_results_twitter.png" />
```

This PR fix that! 