### PR TITLE
Hotfix to display correct link to 2016 Budget Results

### DIFF
--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -126,7 +126,7 @@
                   </div>
                   <div class="small-12 medium-3 column table" data-equalizer-watch>
                     <div class="table-cell align-middle">
-                      <% if budget.name == "Presupuestos participativos 2016" %>
+                      <% if budget.name == "Presupuestos Participativos 2016" %>
                         <%= link_to t("budgets.index.see_results"),
                                     participatory_budget_results_path,
                                     class: "button expanded" %>


### PR DESCRIPTION
What
====
- Fix link to 2016's Budget Results

Test
====
- This is a hotfix, tests coming soon!

Deployment
==========
- As usual

Warnings
========
- None
