### PR TITLE
[WIP] Clean up Travis logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_script:
 - for i in config/*.example; do cp "$i" "${i/.example}"; done
 - bundle exec rake db:setup
 script:
-- bundle exec rake assets:precompile RAILS_ENV=test
-- bin/knapsack_pro_rspec
+  - "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
+  - "bin/knapsack_pro_rspec"
 env:
   global:
   - KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ before_script:
 - for i in config/*.example; do cp "$i" "${i/.example}"; done
 - bundle exec rake db:setup
 script:
-  - "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
-  - "bin/knapsack_pro_rspec"
+- "bundle exec rake assets:precompile RAILS_ENV=test > /dev/null 2>&1"
+- "bin/knapsack_pro_rspec"
 env:
   global:
   - KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+  - KNAPSACK_PRO_LOG_LEVEL=info
   - KNAPSACK_PRO_CI_NODE_TOTAL=2
   - secure: KTKnEVkT28dxldpq7CBCF2Vd0AiQFDgwsVMhq82vw+CTJibQKnOSts+x7azcXWfCnTTklybmocUowb/NWV4vpo3tyAZrZfnO8nzK/Ztu/Ki2x2ranLRxSXvuNkyF5z1E3xeGL/XOcKN8b/CAR1ZPE2OsEko8S/qSY/Y4dPjMH+bFEpEqBvkTpn5Ze4uW7IsmGsEUsElk9fDZPuDElNiVhMAYL8/cpEI/EucSqYrGqu0ulHHeUICG1bkoCQziCrvU+LdFQRh5OXyhSO5/OmYJwjcNuI/jS97VK50GFyxlssTJHChiTSWhT/8afM5pM/uu/cDJKDL0zDmAce+Fy/xSjFCby4jN7vscNpbZ6lGyIW2uqBFX/Ri4jZVyzu9qgwEeKhsrsfsfSMEjx9JMvUiuyAn15SFrN8+bzztU2GVbYd189L8hEa/8T899zE8z80oyRs8Keq+qVgk4MwfvAz3dHh7Z2/OKS2d6Vru0nZLGT11ucm4X1JnuRAe4pDAsJ5kvXKRr3qeF2qRoVOtrEqJHjY30Ipx6mGJfbMmxEQQgWGnHHS8ogRiXG4vIXvyqzlnsTJTUxu7ASuBWxVBAgZalxD1kcyF2ZZ3jCzXSJphPQGiZNDzHgZeR7AwK61c9uwqEB/XoswoXZO5RlMiIVZIGp/tZDkDcHlrPmFdMgxboP8Y=
   - secure: G/lHi3kzYucmNDGTvQmzUM4OPiokHLX8lOSFoZXGIq5bCG77dT5bYi6WRc7+wimozrdQxAGEgX++c8yxJcxNU7JzhpRwNukQ7ic0pwSwHDdRjFwSLznlJOmoSxiBGjy+C/O3XRHN/8SaU7trcUp7nGQiIZIp4LyHFw6REA0o+ZrDoQ/EjmnraF0udJcR/t8Y3MvxlWjausUxjbciaf8xQi9HlBUWnJpNg5HeUAG2aSejlya1/PQhBRN8KcqCsKphK9D39ulOQOmWPdsE4RkG3e3l3670e5Nw4s4coGzOxfVPo6EK6iJ/XREhGbJ6F/YpfseybJICA/m0KUAIGhmvcUuEOE/fM0hUMjbueA1lZDD7pstnvu+EUH2fuIBOAltg9KaSgrIy5Hpbf7j0gQobDWRvl5VA/OIBMT3MOZq/FXeugqM3MM6Ub4djdvpVt2DzY9ckPPUBHM4uPcDhuk0rQFdpC6DeKYyyGizELCpll892I6vmXece4uTcCtPLVGdNmMNfTVDWHKWX0lAfarVVEmvzmhj04YJ62bPsuWtOBJNRzZ9UA3pRAj/XCXAP2BGAC0nBfIg2S7NjTaF7WAZZ6FPncB8ubMhMd2AiAQTIZq8PF+fLRN+aPWDqpTDieK1wwzN2klZBJ5STexZ3XwdqOuVp330NWbfiGGNW3DiBcC0=

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -30,7 +30,7 @@ feature "Voter" do
         expect(page).not_to have_link(answer_yes.title)
       end
 
-      expect(find(:css, ".js-token-message")).to be_visible
+      expect(page).to have_css(".js-token-message", visible: true)
       token = find(:css, ".js-question-answer")[:href].gsub(/.+?(?=token)/, '').gsub('token=', '')
 
       expect(page).to have_content "You can write down this vote identifier, to check your vote on the final results: #{token}"

--- a/spec/lib/tasks/dev_seed_spec.rb
+++ b/spec/lib/tasks/dev_seed_spec.rb
@@ -2,13 +2,7 @@ require 'rails_helper'
 require 'rake'
 
 describe 'rake db:dev_seed' do
-  before do
-    Rake.application.rake_require('tasks/db')
-    Rake::Task.define_task(:environment)
-  end
-
   let :run_rake_task do
-    Rake::Task['db:dev_seed'].reenable
     Rake.application.invoke_task('db:dev_seed')
   end
 


### PR DESCRIPTION
Included PR
=====
- Clean up Travis logs - https://github.com/consul/consul/pull/2357

What
====
- Remove asset precompilation output from travis logs
- Reduce travis' knapsack log level to info
- Fix RSpec's `should` deprecation warning
- Remove duplicate dev_seed execution

Deployment
==========
- As usual

Warnings
========
- None
