### PR TITLE
Invert budget groups order at investment form

### DIFF
--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -13,5 +13,9 @@ class Budget
     def to_param
       name.parameterize
     end
+
+    def single_heading_group?
+      headings.count == 1
+    end
   end
 end

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -19,7 +19,7 @@ class Budget
     end
 
     def name_scoped_by_group
-      "#{group.name}: #{name}"
+      group.single_heading_group? ? name : "#{group.name}: #{name}"
     end
 
     def to_param

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -14,7 +14,9 @@ class Budget
 
     delegate :budget, :budget_id, to: :group, allow_nil: true
 
-    scope :order_by_group_name, -> { includes(:group).order('budget_groups.name', 'budget_headings.name') }
+    scope :order_by_group_name, -> do
+      includes(:group).order('budget_groups.name DESC', 'budget_headings.name')
+    end
 
     def name_scoped_by_group
       "#{group.name}: #{name}"

--- a/app/views/budgets/investments/_banners.html.erb
+++ b/app/views/budgets/investments/_banners.html.erb
@@ -1,5 +1,5 @@
 <% if @heading.present? %>
-  <% if @heading.group.headings.count == 1 %>
+  <% if @heading.group.single_heading_group? %>
     <%= render "banner_city" %>
   <% else %>
     <%= render "banner_district" %>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -67,7 +67,7 @@
         <% @budget.groups.each do |group| %>
           <tr>
             <td>
-              <% if group.headings.count == 1 %>
+              <% if group.single_heading_group? %>
                 <%= link_to group.name,
                       custom_budget_investments_path(@budget, group,
                         heading_id: group.headings.first.to_param,

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -415,6 +415,20 @@ feature 'Budget Investments' do
         expect(page).not_to have_content('My ballot')
       end
     end
+
+    scenario "Heading options are correctly ordered" do
+      city_group = create(:budget_group, name: "Toda la ciudad", budget: budget)
+      create(:budget_heading, name: "Toda la ciudad", price: 333333, group: city_group)
+
+      login_as(author)
+
+      visit new_budget_investment_path(budget_id: budget.id)
+
+      select_options = find('#budget_investment_heading_id').all('option').collect(&:text)
+      expect(select_options.first).to eq('')
+      expect(select_options.second).to eq('Toda la ciudad: Toda la ciudad')
+      expect(select_options.third).to eq('Health: More hospitals')
+    end
   end
 
   scenario "Show" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -289,7 +289,7 @@ feature 'Budget Investments' do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  'Health: More hospitals', from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'I am a bot'
       fill_in 'budget_investment_subtitle', with: 'This is the honeypot'
       fill_in 'budget_investment_description', with: 'This is the description'
@@ -308,7 +308,7 @@ feature 'Budget Investments' do
       login_as(author)
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  'Health: More hospitals', from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'I am a bot'
       fill_in 'budget_investment_description', with: 'This is the description'
       check   'budget_investment_terms_of_service'
@@ -324,7 +324,7 @@ feature 'Budget Investments' do
 
       visit new_budget_investment_path(budget_id: budget.id)
 
-      select  'Health: More hospitals', from: 'budget_investment_heading_id'
+      select  heading.name, from: 'budget_investment_heading_id'
       fill_in 'budget_investment_title', with: 'Build a skyscraper'
       fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
       fill_in 'budget_investment_location', with: 'City center'
@@ -419,6 +419,7 @@ feature 'Budget Investments' do
     scenario "Heading options are correctly ordered" do
       city_group = create(:budget_group, name: "Toda la ciudad", budget: budget)
       create(:budget_heading, name: "Toda la ciudad", price: 333333, group: city_group)
+      create(:budget_heading, name: "More health professionals", price: 999999, group: group)
 
       login_as(author)
 
@@ -426,8 +427,9 @@ feature 'Budget Investments' do
 
       select_options = find('#budget_investment_heading_id').all('option').collect(&:text)
       expect(select_options.first).to eq('')
-      expect(select_options.second).to eq('Toda la ciudad: Toda la ciudad')
-      expect(select_options.third).to eq('Health: More hospitals')
+      expect(select_options.second).to eq('Toda la ciudad')
+      expect(select_options.third).to eq('Health: More health professionals')
+      expect(select_options.fourth).to eq('Health: More hospitals')
     end
   end
 

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -65,7 +65,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
     check   'budget_investment_terms_of_service'
@@ -84,7 +84,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in_ckeditor 'budget_investment_description', with: 'If I had a gym near my place I could go do Zumba'
     check 'budget_investment_terms_of_service'
@@ -109,7 +109,7 @@ feature 'Tags' do
     visit budget_path(budget)
     click_link "Create a budget investment"
 
-    select  'Health: More hospitals', from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in_ckeditor 'budget_investment_description', with: 'If I had a gym near my place I could go do Zumba'
     check   'budget_investment_terms_of_service'
@@ -134,7 +134,7 @@ feature 'Tags' do
     visit budget_investments_path(budget, heading_id: heading.id)
     click_link "Create a budget investment"
 
-    select  'Health: More hospitals', from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in_ckeditor 'budget_investment_description', with: 'If I had a gym near my place I could go do Zumba'
     check   'budget_investment_terms_of_service'
@@ -155,7 +155,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
     check   'budget_investment_terms_of_service'
@@ -173,7 +173,7 @@ feature 'Tags' do
 
     visit new_budget_investment_path(budget_id: budget.id)
 
-    select  "#{group.name}: #{heading.name}", from: 'budget_investment_heading_id'
+    select  heading.name, from: 'budget_investment_heading_id'
     fill_in 'budget_investment_title', with: 'Build a skyscraper'
     fill_in 'budget_investment_description', with: 'I want to live in a high tower over the clouds'
     check   'budget_investment_terms_of_service'


### PR DESCRIPTION
What
====
"Toda la ciudad: Toda la ciudad" should be first option at heading selection on Investment form

How
===
Just order Budget Groups by name but descending, so always "Toda la ciudad" will be above "Distritos", and that will make the heading "Toda la ciudad" always be on top of any other heading.

As a bonus we're removing the Budget::Group name from the option text when it only has one heading.

Screenshots
===========
![screen shot 2018-01-22 at 19 49 47](https://user-images.githubusercontent.com/983242/35238334-6b4f8876-ffad-11e7-83b3-99f0825585fe.jpg)

Test
====
Increased investment feature spec adding an scenario for this particular change on madrid's codebase and avoid mixing it with other scenarios that should be equal to consul's ones.

Deployment
==========
As usual

Warnings
========
None