### PR TITLE
Touch budget after phase update

### DIFF
--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -41,6 +41,14 @@ class Budget
       prev_phase&.enabled? ? prev_phase : prev_phase&.prev_enabled_phase
     end
 
+    def invalid_dates_range?
+      if starts_at.present? && ends_at.present? && starts_at >= ends_at
+        errors.add(:starts_at, I18n.t('budgets.phases.errors.dates_range_invalid'))
+      end
+    end
+
+    private
+
     def adjust_date_ranges
       if enabled?
         next_enabled_phase&.update_column(:starts_at, ends_at)
@@ -49,14 +57,6 @@ class Budget
         next_enabled_phase&.update_column(:starts_at, starts_at)
       end
     end
-
-    def invalid_dates_range?
-      if starts_at.present? && ends_at.present? && starts_at >= ends_at
-        errors.add(:starts_at, I18n.t('budgets.phases.errors.dates_range_invalid'))
-      end
-    end
-
-    private
 
     def touch_budget
       budget.touch

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -19,6 +19,7 @@ class Budget
     before_validation :sanitize_description
 
     after_save :adjust_date_ranges
+    after_save :touch_budget
 
     scope :enabled,           -> { where(enabled: true) }
     scope :published,         -> { enabled.where.not(kind: 'drafting') }
@@ -56,6 +57,10 @@ class Budget
     end
 
     private
+
+    def touch_budget
+      budget.touch
+    end
 
     def prev_phase_dates_valid?
       if enabled? && starts_at.present? && prev_enabled_phase.present?


### PR DESCRIPTION
What
====
Budget's phases changes are not reflected at /budget page a the cache keys only take into account the budget itself. We need to "touch" the budget object after updating any of its phases so caches will be cleared as expected.

How
===
Just an after_save callback that calls touch over budget.

BONUS: Making next_enabled_phase? method private, as it should be

Screenshots
===========
No need

Test
====
No need? Hard to tests cache related stuff on tests environment... will do so on preproduction server

Deployment
==========
As usual

Warnings
========
This is a candidate to be backported to consul