### PR TITLE
Scope heading search by budget

### DIFF
--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -18,7 +18,7 @@ module Budgets
     end
 
     def load_group
-      @group = Budget::Group.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+      @group = @budget.groups.find_by(slug: params[:id]) || @budget.groups.find_by(id: params[:id])
     end
 
   end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -162,6 +162,26 @@ feature 'Budgets' do
       expect(page).to have_link "See investments not selected for balloting phase"
     end
 
+    scenario "Take into account headings with the same name from a different budget" do
+      group1 = create(:budget_group, budget: budget, name: "New York")
+      heading1 = create(:budget_heading, group: group1, name: "Brooklyn")
+      heading2 = create(:budget_heading, group: group1, name: "Queens")
+
+      budget2 = create(:budget)
+      group2 = create(:budget_group, budget: budget2, name: "New York")
+      heading3 = create(:budget_heading, group: group2, name: "Brooklyn")
+      heading4 = create(:budget_heading, group: group2, name: "Queens")
+
+      visit budget_path(budget)
+      click_link "New York"
+
+      expect(page).to have_css("#budget_heading_#{heading1.id}")
+      expect(page).to have_css("#budget_heading_#{heading2.id}")
+
+      expect(page).to_not have_css("#budget_heading_#{heading3.id}")
+      expect(page).to_not have_css("#budget_heading_#{heading4.id}")
+    end
+
   end
 
   context "In Drafting phase" do


### PR DESCRIPTION
What
===
- Scope heading search by budget

Why
===
As we are searching for headings by slug and there can be multiple headings with the same slug for different budgets, we were displaying headings from a past budget

Test
====
- Make sure we see the current budget headings and not the previous budget headings [here](https://decidepre.madrid.es/presupuestos/presupuestos-cuquis-2018/distritos) ✅ 

Deployment
==========
- As usual

Warnings
========
- None
