### PR TITLE
Fix access to community without communitable

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -7,6 +7,7 @@ class CommunitiesController < ApplicationController
   skip_authorization_check
 
   def show
+    raise ActionController::RoutingError, 'Not Found' unless communitable_exists?
     redirect_to root_path if Setting['feature.community'].blank?
   end
 
@@ -30,5 +31,9 @@ class CommunitiesController < ApplicationController
 
   def valid_order?
     params[:order].present? && TOPIC_ORDERS.include?(params[:order])
+  end
+
+  def communitable_exists?
+    @community.proposal.blank? && @community.investment.blank?
   end
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -34,6 +34,6 @@ class CommunitiesController < ApplicationController
   end
 
   def communitable_exists?
-    @community.proposal.blank? && @community.investment.blank?
+    @community.proposal.present? || @community.investment.present?
   end
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -28,7 +28,7 @@ class Community < ActiveRecord::Base
   end
 
   def author_from_community
-    from_proposal? ? User.where(id: proposal.author_id) : User.where(id: investment.author_id)
+    from_proposal? ? User.where(id: proposal&.author_id) : User.where(id: investment&.author_id)
   end
 
 end

--- a/spec/features/communities_spec.rb
+++ b/spec/features/communities_spec.rb
@@ -145,6 +145,14 @@ feature 'Communities' do
       expect(page).to have_current_path(root_path)
     end
 
+    scenario "Accesing a community without associated communitable" do
+      proposal = create(:proposal)
+      community = proposal.community
+      proposal.really_destroy!
+      community.reload
+
+      expect { visit community_path(community) }.to raise_error(ActionController::RoutingError)
+    end
   end
 
 end


### PR DESCRIPTION
What
====

Somehow we're seeing communities without proposals at production. We
must find why and fix it, but first we need to throw a 404 at the user
instead of a 500 internal server error

How
===
First catching the scenario of non-existent communitable at the
controller and raising a 404 error. Secondly preventing the author_id
access over a possibly nil object, this is a smell but it can't be
easily fixed right now... we need to correctly implement a relation
between Community and communitable and avoid the multiple occurences of
`community.from_proposal?` in the codebase that makes it impossible to
extend to a fourth communitable model.

Screenshots
===========
No need

Test
====
Increased to cover the bug, then covered the spec with code

Deployment
==========
Asap to PRO

Warnings
========
This PR is a candidate to make a backport to consul as it has same issue