### PR TITLE
Redirect to budget's index when no filter params

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -5,6 +5,7 @@ class BudgetsController < ApplicationController
 
   before_action :load_budget
   load_and_authorize_resource
+  before_action :redirect_if_no_filter, only: :show
   before_action :set_default_budget_filter, only: :show
   has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: :show
 
@@ -24,6 +25,12 @@ class BudgetsController < ApplicationController
 
   def load_budget
     @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+  end
+
+  def redirect_if_no_filter
+    unless params[:filter].present?
+      redirect_to budgets_path
+    end
   end
 
 end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -180,6 +180,17 @@ feature 'Budgets' do
 
       expect(page).to_not have_css("#budget_heading_#{heading3.id}")
       expect(page).to_not have_css("#budget_heading_#{heading4.id}")
+
+    scenario "Display budget's show when filter params present" do
+      visit budget_path(budget, filter: "unfeasible")
+
+      expect(page).to have_current_path(budget_path(budget, filter: "unfeasible"))
+    end
+
+    scenario "Redirect to budget's index when no filter params present" do
+      visit budget_path(budget)
+
+      expect(page).to have_current_path(budgets_path)
     end
 
   end


### PR DESCRIPTION
Why
===
We still need to figure out how to nicely navigate between feasible, unfeasible and selected projects

Currently the budget’s show page displays a budget’s groups but in a very minimal way. The budget’s groups are also displayed in the budget’s index page in a much nicer way

What
===
Thus, we want users to navigate from the nicer budget’s index page if possible. The only case that it is not possible is if they want to filter by unfeasible or selected projects. Therefore, if the url has
filter params we display the budget’s show page, otherwise we redirect them to the budget’s index page


Screenshots
===========
- Budget's Index

![budgets index](https://user-images.githubusercontent.com/4169/35245522-f28c24e6-ffc3-11e7-956d-1c907b6954c2.png)

- Budgets's show

![budgets show](https://user-images.githubusercontent.com/4169/35245525-f553efc4-ffc3-11e7-91b4-29f3703f922b.png)

Test
====
- Manually test in staging environment

Deployment
==========
- As usual

Warnings
========
- None
