### PR TITLE
Revert redirect when no filter passed to a budget

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -5,7 +5,6 @@ class BudgetsController < ApplicationController
 
   before_action :load_budget
   load_and_authorize_resource
-  before_action :redirect_if_no_filter, only: :show
   before_action :set_default_budget_filter, only: :show
   has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: :show
 
@@ -25,12 +24,6 @@ class BudgetsController < ApplicationController
 
   def load_budget
     @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
-  end
-
-  def redirect_if_no_filter
-    unless params[:filter].present?
-      redirect_to budgets_path
-    end
   end
 
 end

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -180,19 +180,6 @@ feature 'Budgets' do
 
       expect(page).to_not have_css("#budget_heading_#{heading3.id}")
       expect(page).to_not have_css("#budget_heading_#{heading4.id}")
-
-    end
-
-    scenario "Display budget's show when filter params present" do
-      visit budget_path(budget, filter: "unfeasible")
-
-      expect(page).to have_current_path(budget_path(budget, filter: "unfeasible"))
-    end
-
-    scenario "Redirect to budget's index when no filter params present" do
-      visit budget_path(budget)
-
-      expect(page).to have_current_path(budgets_path)
     end
 
   end


### PR DESCRIPTION
Reverted PR
===
https://github.com/AyuntamientoMadrid/consul/pull/1144

Why
===
The reverted PR had broken many tests

It has many implications that need to be addressed calmly
We should think of a better way to navigate projects by filter (feasible, unfeasible and selected for final voting)
