### PR TITLE
Display links to finished budget results

### DIFF
--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -133,27 +133,26 @@
       </ul>
 
       <div class="budget-investments-list">
-        <% @budgets.each do |budget| %>
-          <% if budget_published?(budget) %>
-            <div class="budget-investment clear">
-              <div class="panel past-budgets">
-                <div class="row" data-equalizer data-equalizer-on="medium">
-                  <div class="small-12 medium-9 column table" data-equalizer-watch>
-                    <div class="table-cell align-middle">
-                      <h3><%= budget.name %></h3>
-                    </div>
+        <% @budgets.finished.each do |budget| %>
+          <div class="budget-investment clear">
+            <div class="panel past-budgets">
+              <div class="row" data-equalizer data-equalizer-on="medium">
+                <div class="small-12 medium-9 column table" data-equalizer-watch>
+                  <div class="table-cell align-middle">
+                    <h3><%= budget.name %></h3>
                   </div>
-                  <div class="small-12 medium-3 column table" data-equalizer-watch>
-                    <div class="table-cell align-middle">
-                      <%= link_to t("budgets.index.see_results"),
-                                  budget_results_path(budget.id),
-                                  class: "button expanded" %>
-                    </div>
+                </div>
+                <div class="small-12 medium-3 column table" data-equalizer-watch>
+                  <div id="budget_<%= budget.id %>_results"
+                       class="table-cell align-middle">
+                    <%= link_to t("budgets.index.see_results"),
+                                budget_results_path(budget.id),
+                                class: "button expanded" %>
                   </div>
                 </div>
               </div>
             </div>
-          <% end %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -145,9 +145,15 @@
                 <div class="small-12 medium-3 column table" data-equalizer-watch>
                   <div id="budget_<%= budget.id %>_results"
                        class="table-cell align-middle">
-                    <%= link_to t("budgets.index.see_results"),
-                                budget_results_path(budget.id),
-                                class: "button expanded" %>
+                    <% if budget.name == "Presupuestos Participativos 2016" %>
+                      <%= link_to t("budgets.index.see_results"),
+                                    participatory_budget_results_path,
+                                    class: "button expanded" %>
+                    <% else %>
+                      <%= link_to t("budgets.index.see_results"),
+                                  budget_results_path(budget.id),
+                                  class: "button expanded" %>
+                    <% end %>
                   </div>
                 </div>
               </div>

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -83,4 +83,24 @@ feature 'Results' do
     expect(page).not_to have_content "Incompatibles"
   end
 
+  context "Index" do
+
+    scenario "Display links to finished budget results" do
+      (Budget::Phase::PHASE_KINDS - ['finished']).each do |phase|
+        budget = create(:budget, phase: phase)
+        expect(page).to_not have_css("#budget_#{budget.id}_results", text: "See results")
+      end
+
+      finished_budget1 = create(:budget, phase: "finished")
+      finished_budget2 = create(:budget, phase: "finished")
+      finished_budget3 = create(:budget, phase: "finished")
+
+      visit budgets_path
+
+      expect(page).to have_css("#budget_#{finished_budget1.id}_results", text: "See results")
+      expect(page).to have_css("#budget_#{finished_budget2.id}_results", text: "See results")
+      expect(page).to have_css("#budget_#{finished_budget3.id}_results", text: "See results")
+    end
+  end
+
 end


### PR DESCRIPTION
What
====
- Display links to finished budget results

Why
===
We were displaying links to all budgets, even if they were in a phase
other than finished

Test
====
- Add specs to display links to see results from budget's index

Deployment
==========
- As usual

Warnings
========
- Backport to Consul
