### PR TITLE
Budget heading order

### DIFF
--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -65,7 +65,7 @@
         <% @budget.groups.each do |group| %>
           <h2><%= group.name %></h2>
           <ul class="no-bullet">
-            <% group.headings.each do |heading| %>
+            <% group.headings.order(name: :asc).each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
                 <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
                   <%= heading.name %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -83,19 +83,17 @@
       </div>
 
       <p>
-        <!--
         <%= link_to budget_url(@budget) do %>
           <small><%= t("budgets.index.investment_proyects") %></small>
         <% end %><br>
-        -->
+
         <%= link_to budget_url(@budget, filter: 'unfeasible') do %>
           <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
         <% end %><br>
-        <!--
+
         <%= link_to budget_url(@budget, filter: 'unselected') do %>
           <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
         <% end %>
-        -->
       </p>
 
       <div id="all_phases">

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -65,7 +65,7 @@
         <% @budget.groups.each do |group| %>
           <h2><%= group.name %></h2>
           <ul class="no-bullet">
-            <% group.headings.order(name: :asc).each do |heading| %>
+            <% group.headings.order_by_group_name.each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
                 <%= link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
                   <%= heading.name %>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -78,7 +78,7 @@
         <% @budget.groups.each do |group| %>
           <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
           <ul class="no-bullet">
-            <% group.headings.each do |heading| %>
+            <% group.headings.order(name: :asc).each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
                 <%# link_to budget_investments_path(@budget.id, heading_id: heading.id) do %>
                   <span class="heading-info">


### PR DESCRIPTION
What
====
This PR:

- Orders budgets groups headings by name.
- Adds this new order to custom budget index.
- Removes unnecessary comments (we don't use budget/index page)
