### PR TITLE
Fix i18n texts

### DIFF
--- a/app/views/admin/budget_phases/_form.html.erb
+++ b/app/views/admin/budget_phases/_form.html.erb
@@ -22,21 +22,6 @@
 
     <div class="row margin-top">
       <div class="small-12 medium-12 column">
-        <%= f.label :summary, t("admin.budget_phases.edit.summary") %>
-
-        <p class="help-text" id="phase-summary-help-text">
-          <%= t("admin.budget_phases.edit.summary_help_text") %>
-        </p>
-
-        <%= f.cktext_area :summary,
-                          maxlength: Budget::Phase::SUMMARY_MAX_LENGTH,
-                          ckeditor: { language: I18n.locale },
-                          label: false %>
-      </div>
-    </div>
-
-    <div class="row margin-top">
-      <div class="small-12 medium-12 column">
         <%= f.label :description, t("admin.budget_phases.edit.description") %>
 
         <p class="help-text" id="phase-description-help-text">
@@ -45,6 +30,21 @@
 
         <%= f.cktext_area :description,
                           maxlength: Budget::Phase::DESCRIPTION_MAX_LENGTH,
+                          ckeditor: { language: I18n.locale },
+                          label: false %>
+      </div>
+    </div>
+
+    <div class="row margin-top">
+      <div class="small-12 medium-12 column">
+        <%= f.label :summary, t("admin.budget_phases.edit.summary") %>
+
+        <p class="help-text" id="phase-summary-help-text">
+          <%= t("admin.budget_phases.edit.summary_help_text") %>
+        </p>
+
+        <%= f.cktext_area :summary,
+                          maxlength: Budget::Phase::SUMMARY_MAX_LENGTH,
                           ckeditor: { language: I18n.locale },
                           label: false %>
       </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -127,9 +127,9 @@ en:
         start_date: Start date
         end_date: End date
         summary: Summary
-        summary_help_text: This text will appear in the header when the phase is active
+        summary_help_text: This text will inform the user about the phase. To show it even if the phase is not active, select the checkbox below
         description: Description
-        description_help_text: This text will inform the user about the phase. To show it even if the phase is not active, select the checkbox below
+        description_help_text: This text will appear in the header when the phase is active
         enabled: Phase enabled
         enabled_help_text: This phase will be public in the budget's phases timeline, as well as active for any other purpose
         save_changes: Save changes

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -127,9 +127,9 @@ es:
         start_date: Fecha de Inicio
         end_date: Fecha de fin
         summary: Resumen
-        summary_help_text: Este texto aparecerá en la cabecera cuando la fase esté activa
+        summary_help_text: Este texto informará al usuario sobre la fase. Para mostrarlo aunque la fase no esté activa, marca la opción de más abajo.
         description: Descripción
-        description_help_text: Este texto informará al usuario sobre la fase. Para mostrarlo aunque la fase no esté activa, marca la opción de más abajo.
+        description_help_text: Este texto aparecerá en la cabecera cuando la fase esté activa
         enabled: Fase habilitada
         enabled_help_text: Esta fase será pública en el calendario de fases del presupuesto y estará activa para otros propósitos
         save_changes: Guardar cambios

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -24,10 +24,10 @@ es:
     groups:
       show:
         title: Selecciona una opción
-        unfeasible_title: Propuestas inviables
-        unfeasible: Ver propuestas inviables
-        unselected_title: Propuestas no seleccionadas para la votación final
-        unselected: Ver las propuestas no seleccionadas para la votación final
+        unfeasible_title: Proyectos inviables
+        unfeasible: Ver proyectos inviables
+        unselected_title: Proyectos no seleccionados para la votación final
+        unselected: Ver los proyectos no seleccionados para la votación final
     phase:
       drafting: Borrador (No visible para el público)
       accepting: Presentación de proyectos
@@ -87,11 +87,11 @@ es:
         sidebar:
           my_ballot: Mis votos
           voted_html:
-            one: "<strong>Has votado una proyecto por un valor de %{amount_spent}</strong>"
+            one: "<strong>Has votado un proyecto por un valor de %{amount_spent}</strong>"
             other: "<strong>Has votado %{count} proyectos por un valor de %{amount_spent}</strong>"
           voted_info: Puedes %{link} en cualquier momento hasta el cierre de esta fase. No hace falta que gastes todo el dinero disponible.
           voted_info_link: cambiar tus votos
-          different_heading_assigned_html: 'Ya apoyaste propuestas de otra sección del presupuesto: %{heading_link}'
+          different_heading_assigned_html: 'Ya apoyaste proyectos de otra sección del presupuesto: %{heading_link}'
           change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
           check_ballot_link: "revisar mis votos"
           zero: Todavía no has votado ningún proyecto de gasto en este ámbito del presupuesto.
@@ -105,8 +105,8 @@ es:
           feasible: Ver los proyectos viables
           unfeasible: Ver los proyectos inviables
         orders:
-          random: Aleatorias
-          confidence_score: Mejor valoradas
+          random: Aleatorios
+          confidence_score: Mejor valorados
           price: Por coste
       show:
         author_deleted: Usuario eliminado
@@ -139,7 +139,7 @@ es:
         give_support: Apoyar
       header:
         check_ballot: Revisar mis votos
-        different_heading_assigned_html: 'Ya apoyaste propuestas de otra sección del presupuesto: %{heading_link}'
+        different_heading_assigned_html: 'Ya apoyaste proyectos de otra sección del presupuesto: %{heading_link}'
         change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
         check_ballot_link: "revisar mis votos"
         price: "Esta partida tiene un presupuesto de"
@@ -149,10 +149,10 @@ es:
     show:
       group: Grupo
       phase: Fase actual
-      unfeasible_title: Propuestas inviables
-      unfeasible: Ver las propuestas inviables
-      unselected_title: Propuestas no seleccionadas para la votación final
-      unselected: Ver las propuestas no seleccionadas para la votación final
+      unfeasible_title: Proyectos inviables
+      unfeasible: Ver las proyectos inviables
+      unselected_title: Proyectos no seleccionados para la votación final
+      unselected: Ver los proyectos no seleccionados para la votación final
       see_results: Ver resultados
     results:
       link: Resultados


### PR DESCRIPTION
What
====
This PR:

- Fixes textarea and label order on admin budgets phases form (it was upside down)

- Updates Spanish translations of budgets (`propuesta de inversión` to `proyecto de gasto`)

