### PR TITLE
Skip invalid map markers

### DIFF
--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -12,6 +12,7 @@ App.Map =
           App.Map.toogleMap()
 
   initializeMap: (element) ->
+    App.Map.cleanInvestmentCoordinates(element)
 
     mapCenterLatitude        = $(element).data('map-center-latitude')
     mapCenterLongitude       = $(element).data('map-center-longitude')
@@ -88,9 +89,22 @@ App.Map =
 
     if addMarkerInvestments
       for i in addMarkerInvestments
-        add_marker=createMarker(i.lat , i.long)
-        add_marker.bindPopup(contentPopup(i.investment_title, i.investment_id, i.budget_id))
+        if App.Map.validCoordinates(i)
+          add_marker=createMarker(i.lat , i.long)
+          add_marker.bindPopup(contentPopup(i.investment_title, i.investment_id, i.budget_id))
 
   toogleMap: ->
       $('.map').toggle()
       $('.js-location-map-remove-marker').toggle()
+
+  cleanInvestmentCoordinates: (element) ->
+    markers = $(element).attr('data-marker-investments-coordinates')
+    if markers?
+      clean_markers = markers.replace(/-?(\*+)/g, null)
+      $(element).attr('data-marker-investments-coordinates', clean_markers)
+
+  validCoordinates: (coordinates) ->
+    App.Map.isNumeric(coordinates.lat) && App.Map.isNumeric(coordinates.long)
+
+  isNumeric: (n) ->
+    !isNaN(parseFloat(n)) && isFinite(n)

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -117,6 +117,58 @@ feature 'Budgets' do
     expect(page).to have_css(".phase.active", count: 1)
   end
 
+  context "Index map" do
+
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading) { create(:budget_heading, group: group) }
+
+    before do
+      Setting['feature.map'] = true
+    end
+
+    scenario "Display investment's map location markers" , :js do
+      investment1 = create(:budget_investment, heading: heading)
+      investment2 = create(:budget_investment, heading: heading)
+      investment3 = create(:budget_investment, heading: heading)
+
+      investment1.create_map_location(longitude: 40.1234, latitude: 3.1234)
+      investment2.create_map_location(longitude: 40.1235, latitude: 3.1235)
+      investment3.create_map_location(longitude: 40.1236, latitude: 3.1236)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 3)
+      end
+    end
+
+    scenario "Skip invalid map markers" , :js do
+      map_locations = []
+      map_locations << { longitude: 40.123456789, latitude: 3.12345678 }
+      map_locations << { longitude: 40.123456789, latitude: "*******" }
+      map_locations << { longitude: "**********", latitude: 3.12345678 }
+
+      budget_map_locations = map_locations.map do |map_location|
+        {
+          lat: map_location[:latitude],
+          long: map_location[:longitude],
+          investment_title: "#{rand(999)}",
+          investment_id: "#{rand(999)}",
+          budget_id: budget.id
+        }
+      end
+
+      allow_any_instance_of(BudgetsHelper).
+      to receive(:current_budget_map_locations).and_return(budget_map_locations)
+
+      visit budgets_path
+
+      within ".map_location" do
+        expect(page).to have_css(".map-icon", count: 1)
+      end
+    end
+  end
+
   context 'Show' do
 
     scenario "List all groups" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2380
* **Related PR's:** https://github.com/consul/consul/pull/2381

Why
===
Sometimes the latitude or longitude it passed to the map as ********* instead of the actual latitude or longitud. The asterisks are not a string, breaking the whole array

What
===
This commits skips invalid markers and displays the rest

How
===
- Substituting the mysterious asterisks for null (cleanInvestmentCoordinates)
- Validating the coordinates are numbers before trying to paint them (validCoordinates)
- Adding a numeric function to validate the latitude and longitude (isNumeric)

Screenshots
===========
- Asterisks instead of numeric value
<img width="1163" alt="map asterisks" src="https://user-images.githubusercontent.com/4169/35410378-8e1bfa00-0215-11e8-8221-6191f33b0b9c.png">

Test
====
- Added tests to simulate gracefully handling asterisks

Deployment
==========
- As usual

Warnings
========
- Some map points might not be displayed

Update
===
- This is not the final solution, we need to find out why those asterisks are showing up
- The problem has been reproduced in staging environment with this map location
```
 #<MapLocation id: 695, latitude: 40.4098302091514, longitude: -3.6883619427682, 
               zoom: 12, proposal_id: nil, investment_id: 8467> 
```
By update the longitude to any other number, for example -3.6883619427681 or -3.6883619427683 the problem gets solved

Unfortunately it does not seem to be related to having the exact same location as another proposal, only one proposal has this exact or very similar coordinates
