### PR TITLE
[WIP] Scope budget admin tags by budget

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -81,7 +81,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_tags
-      @tags = Budget::Investment.tags_on(:valuation).order(:name).uniq
+      @tags = Budget::Investment.by_budget(@budget).tags_on(:valuation).order(:name).uniq
     end
 
     def load_ballot

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -41,8 +41,8 @@ module BudgetsHelper
     Budget::Ballot.where(user: current_user, budget: @budget).first
   end
 
-  def investment_tags_select_options
-    Budget::Investment.tags_on(:valuation).order(:name).select(:name).distinct
+  def investment_tags_select_options(budget)
+    Budget::Investment.where(budget_id: budget).tags_on(:valuation).order(:name).select(:name).distinct
   end
 
   def budget_published?(budget)

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -42,7 +42,7 @@ module BudgetsHelper
   end
 
   def investment_tags_select_options(budget)
-    Budget::Investment.where(budget_id: budget).tags_on(:valuation).order(:name).select(:name).distinct
+    Budget::Investment.by_budget(budget).tags_on(:valuation).order(:name).select(:name).distinct
   end
 
   def budget_published?(budget)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -73,6 +73,7 @@ class Budget
     scope :by_admin,    -> (admin_id)    { where(administrator_id: admin_id) }
     scope :by_tag,      -> (tag_name)    { tagged_with(tag_name) }
     scope :by_valuator, -> (valuator_id) { where("budget_valuator_assignments.valuator_id = ?", valuator_id).joins(:valuator_assignments) }
+    scope :by_budget,   ->(budget)       { where(budget: budget) }
 
     scope :for_render, -> { includes(:heading) }
 

--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -28,7 +28,7 @@
 
     <div class="small-12 medium-3 column">
       <%= select_tag :tag_name,
-                     options_for_select(investment_tags_select_options, params[:tag_name]),
+                     options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
                      { prompt: t("admin.budget_investments.index.tags_filter_all"),
                        label: false,
                        class: "js-submit-on-change" } %>

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -294,7 +294,7 @@ feature 'Admin budget investments' do
 
     scenario "Filtering by tag, display only valuation tags of the current budget" do
       new_budget = create(:budget)
-      investment1 = create(:budget_investment, budget: @budget, tag_list: 'Roads')
+      investment1 = create(:budget_investment, budget: budget, tag_list: 'Roads')
       investment2 = create(:budget_investment, budget: new_budget, tag_list: 'Accessibility')
 
       investment1.set_tag_list_on(:valuation, 'Roads')
@@ -303,7 +303,7 @@ feature 'Admin budget investments' do
       investment1.save
       investment2.save
 
-      visit admin_budget_budget_investments_path(budget_id: @budget.id)
+      visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       expect(page).to have_select("tag_name", options: ["All tags", "Roads"])
       expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
@@ -509,11 +509,14 @@ feature 'Admin budget investments' do
     end
 
     scenario "Adds existing valuation tags", :js do
-      budget_investment1 = create(:budget_investment)
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+
+      budget_investment1 = create(:budget_investment, heading: heading)
       budget_investment1.set_tag_list_on(:valuation, 'Education, Health')
       budget_investment1.save
 
-      budget_investment2 = create(:budget_investment)
+      budget_investment2 = create(:budget_investment, heading: heading)
 
       visit edit_admin_budget_budget_investment_path(budget_investment2.budget, budget_investment2)
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -546,6 +546,33 @@ feature 'Admin budget investments' do
       end
     end
 
+    scenario "Display valuation tags scoped by budget" do
+      budget1 = create(:budget)
+      budget2 = create(:budget)
+
+      group1 = create(:budget_group, budget: budget1)
+      group2 = create(:budget_group, budget: budget2)
+
+      heading1 = create(:budget_heading, group: group1)
+      heading2 = create(:budget_heading, group: group2)
+
+      budget_investment1 = create(:budget_investment, heading: heading1)
+      budget_investment1.set_tag_list_on(:valuation, 'Education 2017')
+      budget_investment1.save
+
+      budget_investment2 = create(:budget_investment, heading: heading2)
+      budget_investment2.set_tag_list_on(:valuation, 'Education 2018')
+      budget_investment2.save
+
+      visit admin_budget_budget_investment_path(budget1, budget_investment1)
+      click_link 'Edit classification'
+
+      within(".tags") do
+        expect(page).to have_content "Education 2017"
+        expect(page).to_not have_content "Education 2018"
+      end
+    end
+
     scenario "Changes valuation and user generated tags" do
       budget_investment = create(:budget_investment, tag_list: 'Park')
       budget_investment.set_tag_list_on(:valuation, 'Education')

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -292,6 +292,23 @@ feature 'Admin budget investments' do
       expect(page).to have_select("tag_name", options: ["All tags", "Hospitals", "Teachers"])
     end
 
+    scenario "Filtering by tag, display only valuation tags of the current budget" do
+      new_budget = create(:budget)
+      investment1 = create(:budget_investment, budget: @budget, tag_list: 'Roads')
+      investment2 = create(:budget_investment, budget: new_budget, tag_list: 'Accessibility')
+
+      investment1.set_tag_list_on(:valuation, 'Roads')
+      investment2.set_tag_list_on(:valuation, 'Accessibility')
+
+      investment1.save
+      investment2.save
+
+      visit admin_budget_budget_investments_path(budget_id: @budget.id)
+
+      expect(page).to have_select("tag_name", options: ["All tags", "Roads"])
+      expect(page).not_to have_select("tag_name", options: ["All tags", "Accessibility"])
+    end
+
     scenario "Limiting by max number of investments per heading", :js do
       group_1 = create(:budget_group, budget: budget)
       group_2 = create(:budget_group, budget: budget)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -280,7 +280,31 @@ describe Budget::Investment do
     end
   end
 
-  describe "by_admin" do
+  describe "#by_budget" do
+
+    it "returns investments scoped by budget" do
+      budget1 = create(:budget)
+      budget2 = create(:budget)
+
+      group1 = create(:budget_group, budget: budget1)
+      group2 = create(:budget_group, budget: budget2)
+
+      heading1 = create(:budget_heading, group: group1)
+      heading2 = create(:budget_heading, group: group2)
+
+      investment1 = create(:budget_investment, heading: heading1)
+      investment2 = create(:budget_investment, heading: heading1)
+      investment3 = create(:budget_investment, heading: heading2)
+
+      investments_by_budget = Budget::Investment.by_budget(budget1)
+
+      expect(investments_by_budget).to include investment1
+      expect(investments_by_budget).to include investment2
+      expect(investments_by_budget).to_not include investment3
+    end
+  end
+
+  describe "#by_admin" do
     it "returns investments assigned to specific administrator" do
       investment1 = create(:budget_investment, administrator_id: 33)
       create(:budget_investment)
@@ -292,7 +316,7 @@ describe Budget::Investment do
     end
   end
 
-  describe "by_valuator" do
+  describe "#by_valuator" do
     it "returns investments assigned to specific valuator" do
       investment1 = create(:budget_investment)
       investment2 = create(:budget_investment)


### PR DESCRIPTION
Included PR
=====
Scope budget admin tags by budget https://github.com/consul/consul/issues/2368

What
====
Additionally to the original PR:
- Add scope `by_budget`
- Display only a budget's valuation tags when editing an investment 

Deployment
==========
- As usual

Warnings
========
- None

Pending
=== 
- Backport of tweaks
- Add specs for by_budget
- Review spec (use tags scoped by valuation)
- Add integration specs when editing valuation tags
