### PR TITLE
Fix: Admin investments table not showing up properly

### DIFF
--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -28,7 +28,7 @@
 
     <div class="small-12 medium-3 column">
       <%= select_tag :tag_name,
-                     options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
+                     options_for_select(investment_tags_select_options, params[:tag_name]),
                      { prompt: t("admin.budget_investments.index.tags_filter_all"),
                      label: false,
                      class: "js-submit-on-change" } %>

--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -28,10 +28,10 @@
 
     <div class="small-12 medium-3 column">
       <%= select_tag :tag_name,
-                     options_for_select(investment_tags_select_options, params[:tag_name]),
+                     options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
                      { prompt: t("admin.budget_investments.index.tags_filter_all"),
-                       label: false,
-                       class: "js-submit-on-change" } %>
+                     label: false,
+                     class: "js-submit-on-change" } %>
     </div>
 
     <div class="small-12 medium-3 column float-right">


### PR DESCRIPTION
Included PR
===
https://github.com/consul/consul/pull/2398

What
====
- Fix: Admin investments table not showing up properly
- Note: the original issue seems to have been solved already in merge conflict with Madrid

Deployment
==========
- As usual

Warnings
========
- None
