### PR TITLE
Improve budget heading style

### DIFF
--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -20,8 +20,8 @@
   <% else %>
     <tr>
       <th><%= t("admin.budgets.form.table_heading") %></th>
-      <th><%= t("admin.budgets.form.table_amount") %></th>
-      <th><%= t("admin.budgets.form.table_population") %></th>
+      <th class="text-right"><%= t("admin.budgets.form.table_amount") %></th>
+      <th class="text-right"><%= t("admin.budgets.form.table_population") %></th>
       <th><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>

--- a/app/views/admin/budgets/_heading.html.erb
+++ b/app/views/admin/budgets/_heading.html.erb
@@ -2,10 +2,10 @@
   <td>
     <%= heading.name %>
   </td>
-  <td>
+  <td class="text-right">
     <%= heading.budget.formatted_heading_price(heading) %>
   </td>
-  <td>
+  <td class="text-right">
     <%= heading.population %>
   </td>
   <td>

--- a/app/views/admin/budgets/_heading.html.erb
+++ b/app/views/admin/budgets/_heading.html.erb
@@ -3,7 +3,7 @@
     <%= heading.name %>
   </td>
   <td>
-    <%= heading.price %>
+    <%= heading.budget.formatted_heading_price(heading) %>
   </td>
   <td>
     <%= heading.population %>

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -191,16 +191,19 @@ feature 'Admin budgets' do
       budget = create(:budget, phase: 'reviewing_ballots')
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, price: 4)
-      unselected_investment = create(:budget_investment, :unselected, heading: heading, price: 1, ballot_lines_count: 3)
-      winner_investment = create(:budget_investment, :winner, heading: heading, price: 3, ballot_lines_count: 2)
-      selected_investment = create(:budget_investment, :selected, heading: heading, price: 2, ballot_lines_count: 1)
+      unselected = create(:budget_investment, :unselected, heading: heading, price: 1,
+                                                           ballot_lines_count: 3)
+      winner = create(:budget_investment, :winner, heading: heading, price: 3,
+                                                   ballot_lines_count: 2)
+      selected = create(:budget_investment, :selected, heading: heading, price: 2,
+                                                       ballot_lines_count: 1)
 
       visit edit_admin_budget_path(budget)
       click_link 'Calculate Winner Investments'
       expect(page).to have_content 'Winners being calculated, it may take a minute.'
-      expect(page).to have_content winner_investment.title
-      expect(page).not_to have_content unselected_investment.title
-      expect(page).not_to have_content selected_investment.title
+      expect(page).to have_content winner.title
+      expect(page).not_to have_content unselected.title
+      expect(page).not_to have_content selected.title
     end
 
     scenario 'For a finished Budget' do

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -270,7 +270,7 @@ feature 'Admin budgets' do
         expect(page).not_to have_content 'This group has no assigned heading.'
 
         expect(page).to have_content 'District 9 reconstruction'
-        expect(page).to have_content '6785'
+        expect(page).to have_content '€6,785'
         expect(page).to have_content '100500'
       end
     end
@@ -293,7 +293,7 @@ feature 'Admin budgets' do
       end
 
       expect(page).to have_content 'District 2'
-      expect(page).to have_content '10000'
+      expect(page).to have_content '€10,000'
       expect(page).to have_content '6000'
     end
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -924,13 +924,13 @@ feature 'Budget Investments' do
 
       within("#budget_group_#{global_group.id}") do
         expect(page).to have_content sp1.title
-        expect(page).to have_content sp1.price
+        expect(page).to have_content "€#{sp1.price}"
 
         expect(page).to have_content sp2.title
-        expect(page).to have_content sp2.price
+        expect(page).to have_content "€#{sp2.price}"
 
         expect(page).not_to have_content sp3.title
-        expect(page).not_to have_content sp3.price
+        expect(page).not_to have_content "#{sp3.price}"
       end
 
       within("#budget_group_#{group.id}") do


### PR DESCRIPTION
Where
===
This is a PR coming from Consul consul#2370

What
====
I find hard to read currencies without format, as well as amounts without a right indentation. This table has both issues and I think fixing them makes UI better.

How
===
- Formatting heading price https://github.com/consul/consul/commit/1f85e4e65ef85a2a31ac9e345d1958253fce9312 in the same way we're doing it at the frontend https://github.com/consul/consul/blob/master/app/helpers/budgets_helper.rb#L6

Screenshots
===========
## BEFORE
![screen shot 2018-01-24 at 00 57 59](https://user-images.githubusercontent.com/983242/35307307-86449324-00a2-11e8-92d3-802ec21f4386.jpg)

## AFTER
![screen shot 2018-01-24 at 11 14 31](https://user-images.githubusercontent.com/983242/35326748-e30dfffa-00f7-11e8-935c-30e9c34f29f1.jpg)

Test
====
- Updated Heading & Group management spec scenario accordingly https://github.com/consul/consul/commit/bd64c4749f8706d855ba38e781598523ea73afa8

- Boyscout-rubocop linelenght cleanup https://github.com/consul/consul/commit/2a500a14bc4bc9d776de73f200489b377bfd1030

Deployment
==========
As usual

Warnings
========
None?