### PR TITLE
Solution for the flakies on spec/features/api/csv_exporter_spec.rb 428 and 443

### DIFF
--- a/spec/features/api/csv_exporter_spec.rb
+++ b/spec/features/api/csv_exporter_spec.rb
@@ -426,10 +426,11 @@ feature 'CSV Exporter' do
     end
 
     scenario "Uppercase and lowercase tags work ok together for proposals" do
-      create(:tag, name: "Health")
-      create(:tag, name: "health")
-      create(:proposal, tag_list: "health")
-      create(:proposal, tag_list: "Health")
+      proposal1 = create(:proposal)
+      proposal2 = create(:proposal)
+      proposal1.tags << create(:tag, name: "Health")
+      proposal2.tags << create(:tag, name: "health")
+
       @csv_exporter.export
 
       visit csv_path_for("tags")
@@ -440,10 +441,11 @@ feature 'CSV Exporter' do
     end
 
     scenario "Uppercase and lowercase tags work ok together for debates" do
-      create(:tag, name: "Health")
-      create(:tag, name: "health")
-      create(:debate, tag_list: "Health")
-      create(:debate, tag_list: "health")
+      debate1 = create(:debate)
+      debate2 = create(:debate)
+      debate1.tags << create(:tag, name: "Health")
+      debate2.tags << create(:tag, name: "health")
+
       @csv_exporter.export
 
       visit csv_path_for("tags")


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1181

What
====
- It repairs a flaky test on spec/features/api/csv_exporter_spec.rb 428 and 443 

How
===
- The images show the id's of the proposals when they are created and the content of the csv converted into string
As seen in the images when delegating the inclusion of the tags in the tag list and letting the test run in Travis, the action created by the taglist creates new proposals as well (as seen in the ids of the images) due to the operation of the variables created with let, the solution consists of not delegating and assigning the tags to their corresponding variable

Screenshots
===========
- List of object id's running the test locally
![csv_exporter_remote_id](https://user-images.githubusercontent.com/33748390/35797029-af89009c-0a5e-11e8-8efe-b0142589d92c.png)

- List of object id's running the test on travis
![csv_exporter_local_ids](https://user-images.githubusercontent.com/33748390/35797028-af6adec8-0a5e-11e8-980c-7ce756d4ae39.png)

Test
====
- Its a fix for a test!

Deployment
==========
- none

Warnings
========
- none
