### PR TITLE
Hunt the flaky - Emails Users without email should not receive emails

### DIFF
--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -506,11 +506,15 @@ feature 'Emails' do
   end
 
   context "Users without email" do
-    scenario "should not receive emails", :js do
+    scenario "should not receive emails" do
       user = create(:user, :verified, email_on_comment: true)
       proposal = create(:proposal, author: user)
+
+      user_commenting = create(:user)
+      comment = create(:comment, commentable: proposal, user: user_commenting)
       user.update(email: nil)
-      comment_on(proposal)
+
+      Mailer.comment(comment).deliver_now
 
       expect { open_last_email }.to raise_error "No email has been sent!"
     end


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1176

What
====
Hunt the flaky that appears in `spec/features/emails_spec.rb:509`.

How
===
### Explain why the test is flaky, or under which conditions/scenario it fails randomly

In the error provided in the issue, there was a problem when creating a comment from the UI. My thoughts about this were focused in JavaScript, because the comments use it to be published, so, at first, I tried fixing that function.
But, as the guide sais:

> That means you've to think "What are we testing here?" and "Can we test the same thing in another way?" or "Are we already testing this somewhere else at least partially?".


So I changed my approach for this flaky. The test that fails is "Emails Users without email should not receive emails", so what we need is a test that doesn't send emails to users that don't have an email. Instead of using the comment_on function (that was the one throwing the error), I generated a coment and send an email directly in the test. This way, we ensure that the test always sends an email. When I say send, I mean that it tries to send it without relying in JS to do so (because publishing a comment using the form requires it, and I think that it was the first cause of failing).

### Explain why your PR fixes it

In order to send the email, the test is not relying on the function that uses the form to publish a comment. A comment is created using FactoryGirl, and then an email is send "manually", so we ensure that the email is always send (or, at least, the test tries to send it. It won't be able to do so because the user's email is nil).

Screenshots
===========
There aren't.

Test
====
It has been rewriten to avoid the use of JS.

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply
