### PR TITLE
Add missing config to secrets example

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,7 +1,7 @@
 default: &default
   secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
-  nvotes_shared_key: ""
-  nvotes_server_url: ""
+  nvotes_server_url: "https://nvotes.madrid.es/"
+  nvotes_shared_key: "e0a1d9618412bb619e67e312b8df68"
 
 maps: &maps
   map_tiles_provider: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,5 +1,7 @@
 default: &default
   secret_key_base: 56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4
+  nvotes_shared_key: ""
+  nvotes_server_url: ""
 
 maps: &maps
   map_tiles_provider: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/spec/features/polls/nvotes_spec.rb
+++ b/spec/features/polls/nvotes_spec.rb
@@ -7,8 +7,8 @@ feature 'Nvotes' do
   end
 
   scenario "Check correct configuration" do
-    expect(Rails.application.secrets["nvotes_shared_key"]).to eq("")
-    expect(Rails.application.secrets["nvotes_server_url"]).to eq("")
+    expect(Rails.application.secrets["nvotes_shared_key"]).not_to eq("")
+    expect(Rails.application.secrets["nvotes_server_url"]).not_to eq("")
   end
 
   scenario "Send vote", :selenium do

--- a/spec/features/polls/nvotes_spec.rb
+++ b/spec/features/polls/nvotes_spec.rb
@@ -6,6 +6,11 @@ feature 'Nvotes' do
     skip "this feature is currently disabled"
   end
 
+  scenario "Check correct configuration" do
+    expect(Rails.application.secrets["nvotes_shared_key"]).to eq("")
+    expect(Rails.application.secrets["nvotes_server_url"]).to eq("")
+  end
+
   scenario "Send vote", :selenium do
     user = create(:user, :level_two, id: rand(9999999))
     poll = create(:poll, published: true, nvotes_poll_id: 128)

--- a/spec/models/poll/nvote_spec.rb
+++ b/spec/models/poll/nvote_spec.rb
@@ -92,7 +92,7 @@ describe Poll::Nvote do
 
       expect(nvote.url).to start_with("https://")
       expect(nvote.url.length).to be > 64
-      expect(nvote.url).to include "https://prevotsecdecide.madrid.es"
+      expect(nvote.url).to include "https://nvotes.madrid.es"
       expect(nvote.url).to include "booth/1234"
       expect(nvote.url).to include "vote/#{Poll::Nvote.generate_hash(nvote.generate_message)}/#{nvote.generate_message}"
     end


### PR DESCRIPTION
Where
=====
* **Related Issue:** None

What
====
- As you can see in the image, the tests fails because the key attribute is null, There are two fields missing in secrets.yml, missing nvotes_shared_key and nvotes_server_url, Test enviroment gets secrets.yml from secrets.yml.example so I added the missing fields to secrets.yml.example

How
===
- Added more fields to secrets.yml.example

Screenshots
===========
![screenshot from 2018-02-05 10 54 32](https://user-images.githubusercontent.com/33748390/35801907-595501ca-0a6e-11e8-9cf3-b67bc95112bd.png)


Test
====
- Added one test to ensure the existence of the elements

Deployment
==========
- none

Warnings
========
- none
