### PR TITLE
Fix for `voting comments` flaky specs

### DIFF
--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -418,15 +418,17 @@ feature 'Commenting Budget::Investments' do
   end
 
   feature 'Voting comments' do
-
     background do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @investment = create(:budget_investment)
       @comment = create(:comment, commentable: @investment)
       @budget = @investment.budget
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -470,14 +472,13 @@ feature 'Commenting Budget::Investments' do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -426,12 +426,15 @@ feature 'Commenting debates' do
 
   feature 'Voting comments' do
     background do
-      @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @debate = create(:debate)
       @comment = create(:comment, commentable: @debate)
-
+      @manuela = create(:user, verified_at: Time.current)
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -475,14 +478,13 @@ feature 'Commenting debates' do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -500,8 +500,11 @@ feature 'Commenting legislation questions' do
       @pablo = create(:user)
       @legislation_annotation = create(:legislation_annotation)
       @comment = create(:comment, commentable: @legislation_annotation)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -531,9 +534,8 @@ feature 'Commenting legislation questions' do
                                                               @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
-        find(".in_favor a").click
-
         within(".in_favor") do
+          first('a').click
           expect(page).to have_content "1"
         end
 
@@ -551,14 +553,13 @@ feature 'Commenting legislation questions' do
                                                               @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -433,14 +433,16 @@ feature 'Commenting polls' do
   end
 
   feature 'Voting comments' do
-
     background do
-      @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @poll = create(:poll)
       @comment = create(:comment, commentable: @poll)
-
+      @manuela = create(:user, verified_at: Time.current)
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -484,14 +486,13 @@ feature 'Commenting polls' do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -462,15 +462,17 @@ feature 'Commenting topics from proposals' do
   end
 
   feature 'Voting comments' do
-
     background do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @proposal = create(:proposal)
       @topic = create(:topic, community: @proposal.community)
       @comment = create(:comment, commentable: @topic)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -514,14 +516,13 @@ feature 'Commenting topics from proposals' do
       visit community_topic_path(@proposal.community, @topic)
 
       within("#comment_#{@comment.id}_votes") do
-        find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
+          first('a').click
           expect(page).to have_content "0"
         end
 
         within('.against') do
+          first('a').click
           expect(page).to have_content "1"
         end
 


### PR DESCRIPTION
Where
=====
* **Related Issues:** #1173, #1174, #1177, #1192, #1201

What
====
* Mitigate the flaky specs that were affecting voting comments specs on certain commentable models

How
===
* The tests were failing under the `update` scenario with certain seeds (`44140` for `debates_spec`, `59824` for `investments_spec` and `19087` for `legislation_annotations_spec`)

* An `after` hook to logout was added under the `Voting comments` feature on all affected scenarios to ensure a clean state before each example

* `debates#update`, `budget_investments#update` and `legislation_annotations#update` scenarios were tested more than 30 times with the aforementioned seeds without failures. Several Travis builds have shown that the proposed changes have successfully mitigated all four (4) issues

Notes
========
* Once merged, it will ported to upstream to ensure consistency and to avoid future flakys