### PR TITLE
Flaky residence assigned officers error

### DIFF
--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -67,7 +67,10 @@ feature 'Residence' do
         click_link "Validate document"
       end
 
-      click_button 'Validate document'
+      within("#new_residence") do
+        click_button "Validate document"
+      end
+
       expect(page).to have_content(/\d errors? prevented the verification of this document/)
     end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1211

What
====
- Hunt the flaky that appears in `/spec/features/officing/residence_spec.rb:70:`
- Specific error in test: 
```  5) Residence Assigned officers Error on verify
     Failure/Error: click_button 'Validate document'
     Capybara::ElementNotFound:
       Unable to find visible button "Validate document"
     # ./spec/features/officing/residence_spec.rb:70:in `block (3 levels) in <top (required)>'
```


How
===

- Explanation:

There are two buttons (one link and one button) with the same name. This only happen with the translation for the buttons match. For example in Spanish it is different translations.

- Flaky Explanation:

The fact it is a flaky test is because capybara calls them visually with `click_link` and `click_button` and both have the same name.

- Fix Explantion:

Include a `within` in each call to the button/link to specify exactly where the button/link we need to use is located.
```       
      within("#new_residence") do
        click_button "Validate document"
      end
```
-Backport PR:

Waiting for revision to create it.


Screenshots
===========
![c_d_issue_1211](https://user-images.githubusercontent.com/34024463/35914476-b094c272-0c03-11e8-9c30-8cdec5f73179.jpg)


Test
====
- No test added

Deployment
==========
- N/A

Warnings
========
- `click_on` , `click_link` , `click_button` It can be ambiguous and can give an error. If it is called in the same way, the place to search should be specified.
- In the same document there are more tests with calls to these methods. After the revision I can match the other tests.
