### PR TITLE
fix for the flaky error 1191, not random investments list

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -107,7 +107,7 @@ module Budgets
 
       def set_random_seed
         if params[:order] == 'random' || params[:order].blank?
-          seed = params[:random_seed] || session[:random_seed] || rand(-100..100) / 100.0
+          seed = params[:random_seed] || session[:random_seed] || rand(-100000..100000)
           params[:random_seed] ||= Float(seed) rescue 0
           session[:random_seed] = params[:random_seed]
         else

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -575,16 +575,19 @@ feature 'Budget Investments' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Each user as a different and consistent random budget investment order', :js do
+    scenario 'Each user has a different and consistent random budget investment order when random_seed is disctint', :js do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
+      r1 = 1
+      r2 = 2
+
       in_browser(:one) do
-        visit budget_investments_path(budget, heading: heading, random_seed: '0.8')
+        visit budget_investments_path(budget, heading: heading, random_seed: r1)
         @first_user_investments_order = investments_order
       end
 
       in_browser(:two) do
-        visit budget_investments_path(budget, heading: heading, random_seed: '-0.1')
+        visit budget_investments_path(budget, heading: heading, random_seed: r2)
         @second_user_investments_order = investments_order
       end
 
@@ -609,6 +612,23 @@ feature 'Budget Investments' do
 
         expect(investments_order).to eq(@second_user_investments_order)
       end
+    end
+
+    scenario 'Each user has a equal and consistent budget investment order when the random_seed is equal', :js do
+      (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
+
+      in_browser(:one) do
+        visit budget_investments_path(budget, heading: heading, random_seed: '1')
+        @first_user_investments_order = investments_order
+      end
+
+      in_browser(:two) do
+        visit budget_investments_path(budget, heading: heading, random_seed: '1')
+        @second_user_investments_order = investments_order
+      end
+
+      expect(@first_user_investments_order).to eq(@second_user_investments_order)
+
     end
 
     def investments_order

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -579,12 +579,12 @@ feature 'Budget Investments' do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
-        visit budget_investments_path(budget, heading: heading)
+        visit budget_investments_path(budget, heading: heading, random_seed: '0.8')
         @first_user_investments_order = investments_order
       end
 
       in_browser(:two) do
-        visit budget_investments_path(budget, heading: heading)
+        visit budget_investments_path(budget, heading: heading, random_seed: '-0.1')
         @second_user_investments_order = investments_order
       end
 


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1191

What
====
- It fix a flaky error, caused by a not-so-random seed

How
===
-When entering budget_investments_path the list of investments shown is generated randomly based on a random number chosen between -100 and 100 as seen in the 1st image (line 110). The problem is produced because it is relatively likely to repeat the number (each has a 0.5% chance of appearing). once fixed that random number the rest of the process is deterministic, as seen in the 2nd and 3rd images, setting the number the results are the same.
To prevent flaky error, it is enough to pass the value of random_seed by parameter, even so the probability that two people get the same list of investmens is 0.25% in production

Screenshots
===========
1º image
![screenshot from 2018-02-07 16 52 49](https://user-images.githubusercontent.com/33748390/35926232-f574db06-0c27-11e8-8f5d-cbfec3211c3c.png)
2º image
![fixed_rand_code](https://user-images.githubusercontent.com/33748390/35925463-11b1644e-0c26-11e8-8ed7-e3a02880c84d.png)
3º image
![fixed_rand_console](https://user-images.githubusercontent.com/33748390/35925465-11d49ab8-0c26-11e8-9bbf-2735b1c61016.png)

Test
====
- I't a fix!

Deployment
==========
- none

Warnings
========
- This PR not fixex the errors found by @bertocq yesterday, I still work's on those
