### PR TITLE
Flaky error when comment isn't assigned to the legislation proposal

### DIFF
--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -137,7 +137,8 @@ feature 'Commenting legislation questions' do
   end
 
   scenario 'Turns links into html links' do
-    create :comment, commentable: legislation_annotation, body: 'Built with http://rubyonrails.org/'
+    legislation_annotation = create :legislation_annotation, author: user
+    legislation_annotation.comments << create(:comment, body: 'Built with http://rubyonrails.org/')
 
     visit legislation_process_draft_version_annotation_path(legislation_annotation.draft_version.process,
                                                             legislation_annotation.draft_version,


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1180

What
====
- Fix a flaky error when comment isn't assigned to  the legislation proposal

How
===
- As you can see in the attached image, when a comment is NOT assigned it gives exactly the error sought. So the problem is that sometimes the comment is not assigned correctly (it has already happened in other flakies, delegate the assignment of variables to let is not 100% reliable), assigning the variables manually resolves the problem

Screenshots
===========
![screenshot from 2018-02-08 10 12 52](https://user-images.githubusercontent.com/33748390/35965194-61c6025c-0cba-11e8-90e1-b857d5ce3164.png)

Test
====
- It's a fix

Deployment
==========
- none

Warnings
========
- none
