### PR TITLE
Fix recurrent flakys for voting comments-related specs

### DIFF
--- a/spec/features/comments/budget_investments_spec.rb
+++ b/spec/features/comments/budget_investments_spec.rb
@@ -472,17 +472,17 @@ feature 'Commenting Budget::Investments' do
       visit budget_investment_path(@budget, @investment)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -478,17 +478,17 @@ feature 'Commenting debates' do
       visit debate_path(@debate)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -554,17 +554,17 @@ feature 'Commenting legislation questions' do
                                                               @legislation_annotation)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/polls_spec.rb
+++ b/spec/features/comments/polls_spec.rb
@@ -486,17 +486,17 @@ feature 'Commenting polls' do
       visit poll_path(@poll)
 
       within("#comment_#{@comment.id}_votes") do
+        find('.in_favor a').click
         within('.in_favor') do
-          first('a').click
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          first('a').click
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -1066,17 +1066,16 @@ feature 'Commenting topics from budget investments' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 

--- a/spec/features/custom/probe_option_comments_spec.rb
+++ b/spec/features/custom/probe_option_comments_spec.rb
@@ -419,8 +419,11 @@ feature 'Commenting Probe Options' do
       @probe = Probe.create(codename: 'plaza')
       @probe_option = create(:probe_option, probe: @probe)
       @comment = create(:comment, commentable: @probe_option)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do
@@ -465,17 +468,16 @@ feature 'Commenting Probe Options' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
-        find('.against a').click
-
         within('.in_favor') do
-          expect(page).to have_content "0"
+          expect(page).to have_content('0')
         end
 
+        find('.against a').click
         within('.against') do
-          expect(page).to have_content "1"
+          expect(page).to have_content('1')
         end
 
-        expect(page).to have_content "1 vote"
+        expect(page).to have_content('1 vote')
       end
     end
 


### PR DESCRIPTION
Where
=====
* **Related issues:** #1177, #1192
* **Related PR:** #1212

What
====
* The changes done on #1212, while they did reduce the number of times `voting comments` related tests failed, they did not mitigate entirely the flakys —the proposed changes on this PR should resolve these issues completely.

How
===
* Added an `after` hook to logout to `probe_option_comments#update` scenario, similar to the other affected examples, to ensure a clean state before each test

Test
====
* Fixed coverage

Notes
====
* Once merged, it will be ported to upstream to ensure consistency and avoid (possible) flakys
