### PR TITLE
Flaky spec: Admin budget investment mark/unmark visible to valuators

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1037,16 +1037,16 @@ end
 
   context "Mark as visible to valuators" do
 
+    let(:valuator) { create(:valuator) }
+    let(:admin) { create(:administrator) }
+
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading) { create(:budget_heading, group: group) }
+
+    let(:investment1) { create(:budget_investment, heading: heading) }
+    let(:investment2) { create(:budget_investment, heading: heading) }
+
     scenario "Mark as visible to valuator", :js do
-      valuator = create(:valuator)
-      admin = create(:administrator)
-
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
-
-      investment1 = create(:budget_investment, heading: heading)
-      investment2 = create(:budget_investment, heading: heading)
-
       investment1.valuators << valuator
       investment2.valuators << valuator
       investment1.update(administrator: admin)
@@ -1059,17 +1059,12 @@ end
         check "budget_investment_visible_to_valuators"
       end
 
-      login_as(valuator.user.reload)
-      visit root_path
-      click_link "Admin"
-      click_link "Valuation"
+      visit admin_budget_budget_investments_path(budget)
+      within('#filter-subnav') { click_link 'Under valuation' }
 
-      within "#budget_#{budget.id}" do
-        click_link "Evaluate"
+      within("#budget_investment_#{investment1.id}") do
+        expect(find("#budget_investment_visible_to_valuators")).to be_checked
       end
-
-      expect(page).to     have_content investment1.title
-      expect(page).not_to have_content investment2.title
     end
 
     scenario "Unmark as visible to valuator", :js do
@@ -1096,17 +1091,12 @@ end
         uncheck "budget_investment_visible_to_valuators"
       end
 
-      login_as(valuator.user.reload)
-      visit root_path
-      click_link "Admin"
-      click_link "Valuation"
+      visit admin_budget_budget_investments_path(budget)
+      within('#filter-subnav') { click_link 'Under valuation' }
 
-      within "#budget_#{budget.id}" do
-        click_link "Evaluate"
+      within("#budget_investment_#{investment1.id}") do
+        expect(find("#budget_investment_visible_to_valuators")).not_to be_checked
       end
-
-      expect(page).not_to have_content investment1.title
-      expect(page).to     have_content investment2.title
     end
 
     scenario "Showing the valuating checkbox" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1194

What
====
Fix the flaky test that appeared in `spec/features/admin/budget_investments_spec.rb`, lines 998 and 960.

How
===
### Explain why the test is flaky, or under which conditions/scenario it fails randomly
The problem here was related to the AJAX call that set the variable `visible_to_valuators` to true/false. When in the test the checkbox was clicked, sometimes the variable wasn't modified by the time the valuator page loaded.

![1194_02_1m4sec](https://user-images.githubusercontent.com/31625251/35972112-cf3d71d8-0cd0-11e8-9645-c403e01efde9.png)

My guess about it is that, in those cases, the test was faster than the AJAX call made to update the variable, so, by the time Capybara arrived to the valuators page, the investment wasn't updated yet. When the investment was updated on time, the test passed.

![1194_01_2m2sec](https://user-images.githubusercontent.com/31625251/35972221-37ddee0c-0cd1-11e8-84c8-4ac9b4fe39e0.png)

### Explain why your PR fixes it
First, the test has been divided in two different scenarios:
1. Checks if the investments marked as `visible_to_valuators` are shown for the valuator.
The investments are marked directly when they are created, and then the test visits the valuators page and checks if the correct investments are shown. This way, we remove that part from the other test, avoiding possible flakies but testing the exact same thing at the end.

2. Checks if checking/unchecking the check_box modifies the investment by JS. That should be done with JS, because the function that modifies it is called with AJAX.
When both tests where in the same scenario, just after checking the checkbox there was a login_as to start the session as an evaluator. This call, sometimes, was too fast and the AJAX call didn't have enough time to finish. Now, the spec only tests if after checking/unchecking the checkbox and revisiting the page it is, in fact, checked/unchecked. This process uses enough time to let the AJAX call finish, as seen here:

![1194_01](https://user-images.githubusercontent.com/31625251/36088123-12397f4c-0fd6-11e8-891e-cb7efa7502f8.png)

This images shows how much time AJAX has have to finish. As we see, the time passed using wait_for_ajax and the used with this solution are similar, while the quantity used in the old method is less. This time, the old test passed, but not always happens like that.

![1194_03](https://user-images.githubusercontent.com/31625251/36088200-69702a4a-0fd6-11e8-8e15-1243b91a4890.png)

This time, the old method was too slow and it failed.

However, there are some times that the use of wait_for_ajax makes the test faster, as we can see in this picture:

![1194_02](https://user-images.githubusercontent.com/31625251/36088244-9a8a9296-0fd6-11e8-8bfb-e3be38bd63a9.png)



Screenshots
===========
There aren't.

Test
====
They have been divided as explained above.

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply