### PR TITLE
Fix `rake db:dev_seed` task flaky spec

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -481,26 +481,26 @@ section "Creating Spending Proposals" do
 end
 
 section "Creating Budgets" do
-  Budget.create(
+  budget = Budget.create(
     name: "Budget #{Date.current.year - 1}",
     currency_symbol: "€",
     phase: 'finished'
   )
+
   Budget.create(
     name: "Budget #{Date.current.year}",
     currency_symbol: "€",
     phase: 'accepting'
   )
 
-    (1..([1, 2, 3].sample)).each do |i|
-      group = budget.groups.create!(name: "#{Faker::StarWars.planet} #{i}")
+  (1..([1, 2, 3].sample)).each do |i|
+    group = budget.groups.create!(name: "#{Faker::StarWars.planet} #{i}")
 
-      geozones = Geozone.reorder("RANDOM()").limit([2, 5, 6, 7].sample)
-      geozones.each do |geozone|
-        group.headings << group.headings.create!(name: "#{geozone.name} #{i}",
-                                                 price: rand(1..100) * 100000,
-                                                 population: rand(1..50) * 10000)
-      end
+    geozones = Geozone.reorder("RANDOM()").limit([2, 5, 6, 7].sample)
+    geozones.each do |geozone|
+      group.headings << group.headings.create!(name: "#{geozone.name} #{i}",
+                                               price: rand(1..100) * 100000,
+                                               population: rand(1..50) * 10000)
     end
   end
 end

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -481,26 +481,32 @@ section "Creating Spending Proposals" do
 end
 
 section "Creating Budgets" do
-  budget = Budget.create(
+  finished_budget = Budget.create(
     name: "Budget #{Date.current.year - 1}",
     currency_symbol: "€",
     phase: 'finished'
   )
 
-  Budget.create(
+  accepting_budget = Budget.create(
     name: "Budget #{Date.current.year}",
     currency_symbol: "€",
     phase: 'accepting'
   )
 
   (1..([1, 2, 3].sample)).each do |i|
-    group = budget.groups.create!(name: "#{Faker::StarWars.planet} #{i}")
+    finished_group  = finished_budget.groups.create!(name: "#{Faker::StarWars.planet} #{i}")
+    accepting_group = accepting_budget.groups.create!(name: "#{Faker::StarWars.planet} #{i}")
 
     geozones = Geozone.reorder("RANDOM()").limit([2, 5, 6, 7].sample)
     geozones.each do |geozone|
-      group.headings << group.headings.create!(name: "#{geozone.name} #{i}",
-                                               price: rand(1..100) * 100000,
-                                               population: rand(1..50) * 10000)
+      finished_group.headings << finished_group.headings.create!(name: "#{geozone.name} #{i}",
+                                                                 price: rand(1..100) * 100000,
+                                                                 population: rand(1..50) * 10000)
+
+      accepting_group.headings << accepting_group.headings.create!(name: "#{geozone.name} #{i}",
+                                                                   price: rand(1..100) * 100000,
+                                                                   population: rand(1..50) * 10000)
+
     end
   end
 end
@@ -561,7 +567,7 @@ end
 
 section "Balloting Investments" do
   100.times do
-    budget = Budget.reorder("RANDOM()").first
+    budget = Budget.finished.reorder("RANDOM()").first
     ballot = Budget::Ballot.create(user: User.reorder("RANDOM()").first, budget: budget)
     ballot.add_investment(budget.investments.reorder("RANDOM()").first)
   end

--- a/spec/lib/tasks/dev_seed_spec.rb
+++ b/spec/lib/tasks/dev_seed_spec.rb
@@ -1,5 +1,7 @@
-require 'rails_helper'
 require 'rake'
+require 'rails_helper'
+Rake::Task.define_task(:environment)
+Rake.application.rake_require('tasks/db')
 
 describe 'rake db:dev_seed' do
   let :run_rake_task do


### PR DESCRIPTION
Where
=====
* **Related issue:** #1197 (This PR closes #1197 once merged)

What
====
* Added missing `require` statements needed for the spec to work properly
* Removed extra `end` that was causing the test to fail
* Mitigated scenario where the `rake db:dev_seed` task spec would fail if a randomly selected budget had no investments associated with it under the `Balloting Investments` seeding section

How
===
* The problem was that the budget selected randomly under the `Balloting Investments` section could not have investments associated with it, so when an investment of said budget was to be added to a ballot, the `Budget::Ballot::Line#check_selected` validation failed since the `selected?` method was not available to a `NilClass` element

* The proposed PR takes as inspiration the `Balloting Investments` section of the `dev_seeds` [file](https://github.com/consul/consul/blob/master/db/dev_seeds.rb#L396) found in CONSUL to select **only** finished budgets as a method to mitigate said flaky test

Test
====
* Fixed coverage ✅
