### PR TITLE
Ensure community is destroyed if associated communitable dissapears

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -7,7 +7,6 @@ class CommunitiesController < ApplicationController
   skip_authorization_check
 
   def show
-    raise ActionController::RoutingError, 'Not Found' unless communitable_exists?
     redirect_to root_path if Setting['feature.community'].blank?
   end
 
@@ -31,9 +30,5 @@ class CommunitiesController < ApplicationController
 
   def valid_order?
     params[:order].present? && TOPIC_ORDERS.include?(params[:order])
-  end
-
-  def communitable_exists?
-    @community.proposal.present? || @community.investment.present?
   end
 end

--- a/app/models/concerns/communitable.rb
+++ b/app/models/concerns/communitable.rb
@@ -4,6 +4,7 @@ module Communitable
   included do
     belongs_to :community
     before_create :associate_community
+    after_destroy :destroy_community
   end
 
   def associate_community
@@ -11,4 +12,9 @@ module Communitable
     self.community_id = community.id
   end
 
+  def destroy_community
+    if self.really_destroyed?
+      Community.find(self.community_id).destroy
+    end
+  end
 end

--- a/spec/features/communities_spec.rb
+++ b/spec/features/communities_spec.rb
@@ -147,11 +147,10 @@ feature 'Communities' do
 
     scenario "Accesing a community without associated communitable" do
       proposal = create(:proposal)
-      community = proposal.community
+      community_id = proposal.community_id
       proposal.really_destroy!
-      community.reload
 
-      expect { visit community_path(community) }.to raise_error(ActionController::RoutingError)
+      expect { visit community_path(community_id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe Community, type: :model do
       expect(community.participants).to include(proposal.author)
     end
   end
+
+  it "is destroyed when the communitable object dissapears (hard delete)" do
+    proposal = create(:proposal)
+
+    expect(proposal.community).to be_valid
+    community = proposal.community
+
+    proposal.really_destroy!
+
+    expect(Community.where(id: community.id)).to be_empty
+  end
+
+  it "is not destroyed when communitable objects is soft deleted" do
+    proposal = create(:proposal)
+
+    expect(proposal.community).to be_valid
+    community = proposal.community
+
+    proposal.destroy
+
+    expect(Community.where(id: community.id)).not_to be_empty
+  end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2360 

What
====
Ensure that a community is deleted when the related communitable object is destroyed (paranoia hard delete).

How
===

- I created an `after_delete` callback that is called every time a communitable object is destroyed (soft and hard).
To avoid deleting the community when the communitable is softly destroyed, the status of the object is checked in the callback. If it has been soft deleted, the community is not destroyed; if, on the contrary, the communitable is destroyed, his community is also destroyed. https://github.com/AyuntamientoMadrid/consul/commit/332efed1b0df3da9fc1979b6c176f1cebee66e2e

- The `ActionController::RoutingError` exception that is raised by hand when the `communitable` doesn't exists is not needed anymore, because if a communitable object is `really_destroyed` the community associated will be destroyed, so it will throw an `ActiveRecord::RecordNotFound` exception when trying to access the `show` view. https://github.com/AyuntamientoMadrid/consul/commit/974f0d20dbc0e948dcc6e27c1fd00db83814b8ac


Screenshots
===========
There aren't because this is backend.

Test
====
Two tests has been added (https://github.com/AyuntamientoMadrid/consul/commit/9cafe3b4e2eba879a8446a8b533358e23e16d684):
- One checks that the communities are not been deleted if the communitable object hasn't been hard deleted.
- The other one checks that the communities are deleted when the communitable object has been hard deleted.

One test has been modified (https://github.com/AyuntamientoMadrid/consul/commit/974f0d20dbc0e948dcc6e27c1fd00db83814b8ac#diff-7d683b8d7d7e89dc285b92934ed99c20L148 )
Now, when a communitable object is deleted (from DB), their related community is also deleted, so when a user tries to access to the `show` view of the community it throws an `ActiveRecord::RecordNotFound` error, no the `ActionController::RoutingError` exception raised by hand in the communities controller.


Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
