### PR TITLE
Only one menu element can have 'active' CSS selector at once

### DIFF
--- a/app/views/custom/layouts/_header.html.erb
+++ b/app/views/custom/layouts/_header.html.erb
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <div class="subnavigation expanded">
+  <div id="navigation_bar" class="subnavigation expanded">
     <div class="row">
       <div class="hide-for-small-only">
         <%= render "shared/subnavigation" %>

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -13,7 +13,7 @@
       <li>
         <%= layout_menu_link_to t("layouts.header.proposals"),
                                 proposals_path,
-                                controller_name == 'proposals',
+                                controller.class == ProposalsController,
                                 accesskey: "2",
                                 title: t("shared.go_to_page") + t("layouts.header.proposals") %>
       </li>

--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -13,7 +13,6 @@ def log(msg)
   @logger.info "#{msg}\n"
 end
 
-
 require_relative 'dev_seeds/settings'
 require_relative 'dev_seeds/geozones'
 require_relative 'dev_seeds/users'
@@ -35,5 +34,6 @@ require_relative 'dev_seeds/notifications'
 require_relative 'dev_seeds/forums'
 require_relative 'dev_seeds/probe_options'
 require_relative 'dev_seeds/admin_notifications'
+require_relative 'dev_seeds/legislation_proposals'
 
 log "All dev seeds created successfuly 👍"

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -1,28 +1,32 @@
 section "Creating legislation processes" do
   5.times do
-    process = ::Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
-                                             description: Faker::Lorem.paragraphs.join("\n\n"),
-                                             summary: Faker::Lorem.paragraph,
-                                             additional_info: Faker::Lorem.paragraphs.join("\n\n"),
-                                             start_date: Date.current - 3.days,
-                                             end_date: Date.current + 3.days,
-                                             debate_start_date: Date.current - 3.days,
-                                             debate_end_date: Date.current - 1.day,
-                                             draft_publication_date: Date.current + 1.day,
-                                             allegations_start_date: Date.current + 2.days,
-                                             allegations_end_date: Date.current + 3.days,
-                                             result_publication_date: Date.current + 4.days,
-                                             debate_phase_enabled: true,
-                                             allegations_phase_enabled: true,
-                                             draft_publication_enabled: true,
-                                             result_publication_enabled: true,
-                                             published: true)
+    Legislation::Process.create!(title: Faker::Lorem.sentence(3).truncate(60),
+                                 description: Faker::Lorem.paragraphs.join("\n\n"),
+                                 summary: Faker::Lorem.paragraph,
+                                 additional_info: Faker::Lorem.paragraphs.join("\n\n"),
+                                 proposals_description: Faker::Lorem.paragraph,
+                                 start_date: Date.current - 3.days,
+                                 end_date: Date.current + 3.days,
+                                 debate_start_date: Date.current - 3.days,
+                                 debate_end_date: Date.current - 1.day,
+                                 proposals_phase_start_date: Date.current - 3.days,
+                                 proposals_phase_end_date: Date.current - 1.day,
+                                 draft_publication_date: Date.current + 1.day,
+                                 allegations_start_date: Date.current + 2.days,
+                                 allegations_end_date: Date.current + 3.days,
+                                 result_publication_date: Date.current + 4.days,
+                                 debate_phase_enabled: true,
+                                 allegations_phase_enabled: true,
+                                 draft_publication_enabled: true,
+                                 result_publication_enabled: true,
+                                 proposals_phase_enabled: true,
+                                 published: true)
   end
 
-  ::Legislation::Process.all.each do |process|
+  Legislation::Process.all.each do |process|
     (1..3).each do |i|
-      version = process.draft_versions.create!(title: "Version #{i}",
-                                               body: Faker::Lorem.paragraphs.join("\n\n"))
+      process.draft_versions.create!(title: "Version #{i}",
+                                     body: Faker::Lorem.paragraphs.join("\n\n"))
     end
   end
 end

--- a/db/dev_seeds/legislation_proposals.rb
+++ b/db/dev_seeds/legislation_proposals.rb
@@ -1,0 +1,12 @@
+section "Creating legislation proposals" do
+  10.times do
+    Legislation::Proposal.create!(title: Faker::Lorem.sentence(3).truncate(60),
+                                  description: Faker::Lorem.paragraphs.join("\n\n"),
+                                  question: Faker::Lorem.sentence(3),
+                                  summary: Faker::Lorem.paragraph,
+                                  author: User.all.sample,
+                                  process: Legislation::Process.all.sample,
+                                  terms_of_service: '1',
+                                  proposal_type: 'proposal')
+  end
+end

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -7,9 +7,10 @@ feature 'Legislation Proposals' do
     it_behaves_like 'notifiable in-app', Legislation::Proposal
   end
 
-  let(:user) { create(:user) }
-  let(:user2) { create(:user) }
-  let(:process) { create(:legislation_process) }
+  let(:user)     { create(:user) }
+  let(:user2)    { create(:user) }
+  let(:process)  { create(:legislation_process) }
+  let(:proposal) { create(:legislation_proposal) }
 
   scenario 'Each user as a different and consistent random proposals order', :js do
     create_list(:legislation_proposal, 10, process: process)
@@ -55,6 +56,14 @@ feature 'Legislation Proposals' do
 
     expect(legislation_proposals_order).to eq(first_page_proposals_order)
     expect(first_page_proposals_order & second_page_proposals_order).to eq([])
+  end
+
+  scenario "Only one menu element has 'active' CSS selector" do
+    visit legislation_process_proposal_path(proposal.process, proposal)
+
+    within('#navigation_bar') do
+      expect(page).to have_css('.active', count: 1)
+    end
   end
 
   def legislation_proposals_order


### PR DESCRIPTION
Where
=====
* **Related issue:** #1198 (Closes #1198 once merged)

What
====
* Append the `active` CSS selector to only one menu element at once

How
===
* Created `Legislation::Proposal` seeds to replicate the issue locally
* Replaced `controller_name == 'proposals'` with `controller.class == ProposalsController` that was colliding with the `legislation/proposals_controller` file
* Removed unused variables when creating `Legislation::Process` seeds

Screenshots
===========
* Before: 
![35772390-e1afb89e-093d-11e8-99cb-9ed1ffe38d10](https://user-images.githubusercontent.com/9470839/36183091-24dd77ec-1103-11e8-8362-3ef848c0e1e7.jpg)

* After: 
![screenshot-2018-2-13 porro est qui unde natus](https://user-images.githubusercontent.com/9470839/36183098-2cccd984-1103-11e8-9ccf-ef602ef58798.png)

Test
====
* Increased coverage to make sure only one `active` selector was available under the `navigation_bar` div
