### PR TITLE
Allow admin to change budget groups name

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -273,6 +273,7 @@ $sidebar-active: #f4fcd0;
 
   .input-group-button {
     padding-bottom: rem-calc(16);
+    vertical-align: top;
   }
 }
 

--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -10,9 +10,6 @@ class Admin::BudgetGroupsController < Admin::BaseController
 
   def update
     @group = Budget::Group.by_slug(params[:id]).first
-    if @group.generate_slug?
-      params[:id] = @group.generate_slug
-    end
     @group.update(budget_group_params)
   end
 

--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -8,6 +8,14 @@ class Admin::BudgetGroupsController < Admin::BaseController
     @groups = @budget.groups.includes(:headings)
   end
 
+  def update
+    @group = Budget::Group.by_slug(params[:id]).first
+    if @group.generate_slug?
+      params[:id] = @group.generate_slug
+    end
+    @group.update(budget_group_params)
+  end
+
   private
 
     def budget_group_params

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -72,6 +72,10 @@ module AdminHelper
     user_roles(user).join(", ")
   end
 
+  def display_budget_goup_form(group)
+    group.errors.messages.size > 0 ? "" : "display:none"
+  end
+
   private
 
     def namespace

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -10,18 +10,27 @@ class Budget
     validates :name, presence: true, uniqueness: { scope: :budget }
     validates :slug, presence: true, format: /\A[a-z0-9\-_]+\z/
 
+    scope :by_slug, ->(slug) { where(slug: slug) }
+
+    before_save :strip_name
+
     def to_param
-      name.parameterize
+      slug
     end
 
     def single_heading_group?
       headings.count == 1
     end
 
-    private
-
     def generate_slug?
       slug.nil? || budget.drafting?
     end
+
+    private
+
+    def strip_name
+      self.name = self.name.strip
+    end
+
   end
 end

--- a/app/views/admin/budget_groups/update.js.erb
+++ b/app/views/admin/budget_groups/update.js.erb
@@ -1,5 +1,5 @@
 <% if @group.errors.any? %>
-  $("#group-form-<%= @group.id %>").html('<%= j render("admin/budgets/group_form", group: @group, budget: @group.budget, button_title: "admin.budgets.form.submit", id: "group-form-#{@group.id}", css_class: "group-toggle-#{@group.id}" ) %>');
+  $("#group-form-<%= @group.id %>").html('<%= j render("admin/budgets/group_form", group: @group, budget: @group.budget, button_title: t("admin.budgets.form.submit"), id: "group-form-#{@group.id}", css_class: "group-toggle-#{@group.id}" ) %>');
 <% else %>
   $("#group-name-<%= @group.id %>").html('<%= @group.name %>')
   $(".group-toggle-<%= @group.id %>").toggle()

--- a/app/views/admin/budget_groups/update.js.erb
+++ b/app/views/admin/budget_groups/update.js.erb
@@ -1,0 +1,6 @@
+<% if @group.errors.any? %>
+  $("#group-form-<%= @group.id %>").html('<%= j render("admin/budgets/group_form", group: @group, budget: @group.budget, button_title: "admin.budgets.form.submit", id: "group-form-#{@group.id}", css_class: "group-toggle-#{@group.id}" ) %>');
+<% else %>
+  $("#group-name-<%= @group.id %>").html('<%= @group.name %>')
+  $(".group-toggle-<%= @group.id %>").toggle()
+<% end %>

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
-        <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: "admin.budgets.form.submit", css_class: "group-toggle-#{group.id}" %>
+        <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
       </th>

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -2,8 +2,10 @@
   <thead>
     <tr>
       <th colspan="4" class="with-button">
-        <%= group.name %>
+        <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
+        <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: "admin.budgets.form.submit", css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>
+        <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
       </th>
     </tr>
 

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -5,7 +5,7 @@
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: "admin.budgets.form.submit", css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>
-        <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
+        <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
       </th>
     </tr>
 

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -4,31 +4,32 @@
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
-        <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
+        <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>
       </th>
     </tr>
 
-  <% if headings.blank? %>
-  </thead>
-  <tbody>
-    <tr>
-      <td colspan="4">
-        <div class="callout primary">
-          <%= t("admin.budgets.form.no_heading") %>
-        </div>
-      </td>
-    </tr>
-  <% else %>
+  <% if headings.present? %>
     <tr>
       <th><%= t("admin.budgets.form.table_heading") %></th>
       <th class="text-right"><%= t("admin.budgets.form.table_amount") %></th>
       <th class="text-right"><%= t("admin.budgets.form.table_population") %></th>
       <th><%= t("admin.actions.actions") %></th>
     </tr>
+  <% end %>
+
   </thead>
   <tbody>
-  <% end %>
+
+    <% if headings.blank? %>
+      <tr>
+        <td colspan="4">
+          <div class="callout primary">
+            <%= t("admin.budgets.form.no_heading") %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
 
     <tr id="group-<%= group.id %>-new-heading-form" style="display:none">
       <td colspan="4">

--- a/app/views/admin/budgets/_group_form.html.erb
+++ b/app/views/admin/budgets/_group_form.html.erb
@@ -9,7 +9,7 @@
                       placeholder: t("admin.budgets.form.group"),
                       class: "input-group-field" %>
     <div class="input-group-button">
-      <%= f.submit t(button_title), class: "button success" %>
+      <%= f.submit button_title, class: "button success" %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/budgets/_group_form.html.erb
+++ b/app/views/admin/budgets/_group_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_for [:admin, budget, group], html: {id: id, style: display_budget_goup_form(group), class: css_class}, remote: true do |f| %>
+
+  <%= f.label :name, t("admin.budgets.form.group") %>
+
+  <div class="input-group">
+    <%= f.text_field :name,
+                      label: false,
+                      maxlength: 50,
+                      placeholder: t("admin.budgets.form.group"),
+                      class: "input-group-field" %>
+    <div class="input-group-button">
+      <%= f.submit t(button_title), class: "button success" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/budgets/_groups.html.erb
+++ b/app/views/admin/budgets/_groups.html.erb
@@ -10,21 +10,7 @@
   <%= link_to t("admin.budgets.form.add_group"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#new-group-form" } %>
 <% end %>
 
-<%= form_for [:admin, @budget, Budget::Group.new], html: {id: "new-group-form", style: "display:none"}, remote: true do |f| %>
-
-  <%= f.label :name, t("admin.budgets.form.group") %>
-
-  <div class="input-group">
-    <%= f.text_field :name,
-                      label: false,
-                      maxlength: 50,
-                      placeholder: t("admin.budgets.form.group"),
-                      class: "input-group-field" %>
-    <div class="input-group-button">
-      <%= f.submit t("admin.budgets.form.create_group"), class: "button success" %>
-    </div>
-  </div>
-<% end %>
+<%= render 'admin/budgets/group_form', budget: @budget, group: Budget::Group.new, id: "new-group-form", button_title: "admin.budgets.form.create_group", css_class: '' %>
 
 <% groups.each do |group| %>
   <div id="<%= dom_id(group) %>">

--- a/app/views/admin/budgets/_groups.html.erb
+++ b/app/views/admin/budgets/_groups.html.erb
@@ -10,7 +10,7 @@
   <%= link_to t("admin.budgets.form.add_group"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#new-group-form" } %>
 <% end %>
 
-<%= render 'admin/budgets/group_form', budget: @budget, group: Budget::Group.new, id: "new-group-form", button_title: "admin.budgets.form.create_group", css_class: '' %>
+<%= render 'admin/budgets/group_form', budget: @budget, group: Budget::Group.new, id: "new-group-form", button_title: t("admin.budgets.form.create_group"), css_class: '' %>
 
 <% groups.each do |group| %>
   <div id="<%= dom_id(group) %>">

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -109,6 +109,8 @@ en:
         no_groups: No groups created yet. Each user will be able to vote in only one heading per group.
         add_group: Add new group
         create_group: Create group
+        edit_group: Edit group
+        submit: Save group
         heading: Heading name
         add_heading: Add heading
         amount: Amount

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -109,6 +109,8 @@ es:
         no_groups: No hay grupos creados todavía. Cada usuario podrá votar en una sola partida de cada grupo.
         add_group: Añadir nuevo grupo
         create_group: Crear grupo
+        edit_group: Editar grupo
+        submit: Guardar grupo
         heading: Nombre de la partida
         add_heading: Añadir partida
         amount: Cantidad

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1063,6 +1063,7 @@ ActiveRecord::Schema.define(version: 20180220211105) do
     t.integer  "related_content_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "flags_count",                  default: 0
     t.datetime "hidden_at"
     t.integer  "related_content_scores_count", default: 0
     t.integer  "author_id"

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -6,25 +6,25 @@ feature 'Admin can change the groups name' do
   let(:group) { create(:budget_group, budget: budget) }
 
   background do
-
     admin = create(:administrator)
     login_as(admin.user)
   end
 
   scenario "Show button" do
     visit admin_budget_path(group.budget)
+
     within("#budget_group_#{group.id}") do
-      expect(page).to have_content(I18n.t("admin.budgets.form.edit_group" ))
+      expect(page).to have_content('Edit group')
     end
   end
 
   scenario "Change name", :js do
     visit admin_budget_path(group.budget)
     within("#budget_group_#{group.id}") do
-      click_link I18n.t("admin.budgets.form.edit_group" )
+      click_link 'Edit group'
       within("#group-form-#{group.id}") do
         fill_in 'budget_group_name', with: 'Google'
-        click_button I18n.t("admin.budgets.form.submit" )
+        click_button 'Save group'
       end
     end
 
@@ -37,10 +37,10 @@ feature 'Admin can change the groups name' do
     visit admin_budget_path(group.budget)
 
     within("#budget_group_#{group.id}") do
-      click_link I18n.t("admin.budgets.form.edit_group" )
+      click_link 'Edit group'
       within("#group-form-#{group.id}") do
         fill_in 'budget_group_name', with: 'Google'
-        click_button I18n.t("admin.budgets.form.submit" )
+        click_button 'Save group'
       end
     end
 
@@ -53,15 +53,16 @@ feature 'Admin can change the groups name' do
   scenario "Can't repeat names", :js  do
     group.budget.groups << create(:budget_group, name: 'group_name')
     visit admin_budget_path(group.budget)
+
     within("#budget_group_#{group.id}") do
-      click_link I18n.t("admin.budgets.form.edit_group" )
+      click_link 'Edit group'
       within("#group-form-#{group.id}") do
         fill_in 'budget_group_name', with: 'group_name'
-        click_button I18n.t("admin.budgets.form.submit" )
+        click_button 'Save group'
       end
     end
 
-    expect(page).to have_content(I18n.t("errors.messages.taken"))
+    expect(page).to have_content('has already been taken')
   end
 
 end

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+feature 'Admin can change the groups name' do
+
+  let(:budget) { create(:budget, phase: 'drafting') }
+  let(:group) { create(:budget_group, budget: budget) }
+
+  background do
+
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  scenario "Show button" do
+    visit admin_budget_path(group.budget)
+    within("#budget_group_#{group.id}") do
+      expect(page).to have_content(I18n.t("admin.budgets.form.edit_group" ))
+    end
+  end
+
+  scenario "Change name", :js do
+    visit admin_budget_path(group.budget)
+    within("#budget_group_#{group.id}") do
+      click_link I18n.t("admin.budgets.form.edit_group" )
+      within("#group-form-#{group.id}") do
+        fill_in 'budget_group_name', with: 'Google'
+        click_button I18n.t("admin.budgets.form.submit" )
+      end
+    end
+
+    expect(page).to have_content('Google')
+  end
+
+  scenario "Can change name when the budget isn't drafting, but the slug remains", :js do
+    old_slug = group.slug
+    budget.update(phase: 'reviewing')
+    visit admin_budget_path(group.budget)
+
+    within("#budget_group_#{group.id}") do
+      click_link I18n.t("admin.budgets.form.edit_group" )
+      within("#group-form-#{group.id}") do
+        fill_in 'budget_group_name', with: 'Google'
+        click_button I18n.t("admin.budgets.form.submit" )
+      end
+    end
+
+    group.reload
+
+    expect(page).to have_content('Google')
+    expect(group.slug).to eq old_slug
+  end
+
+  scenario "Can't repeat names", :js  do
+    group.budget.groups << create(:budget_group, name: 'group_name')
+    visit admin_budget_path(group.budget)
+    within("#budget_group_#{group.id}") do
+      click_link I18n.t("admin.budgets.form.edit_group" )
+      within("#group-form-#{group.id}") do
+        fill_in 'budget_group_name', with: 'group_name'
+        click_button I18n.t("admin.budgets.form.submit" )
+      end
+    end
+
+    expect(page).to have_content(I18n.t("errors.messages.taken"))
+  end
+
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2438

What
====
- Adds an inline form who changes the name of a Budget::Group if it's possible

How
===
- Added update function to admin/budget_groups_controller,  a js.erb view who handles the display of both error and correct saved object, and a new tests file. Also refactored a form, moved to partial.

Screenshots
===========
![peek 2018-02-14 17-49](https://user-images.githubusercontent.com/33748390/36216566-7b742694-11af-11e8-9202-ed6a13abc3a0.gif)

Test
====
- Added tests to check the correct behaviour of the form, working and showing errors

Deployment
==========
- none

Warnings
========
- none
