### PR TITLE
Add maps to random mappable objects in dev_seed

### DIFF
--- a/db/dev_seeds.rb
+++ b/db/dev_seeds.rb
@@ -38,5 +38,6 @@ require_relative 'dev_seeds/forums'
 require_relative 'dev_seeds/probe_options'
 require_relative 'dev_seeds/admin_notifications'
 require_relative 'dev_seeds/legislation_proposals'
+require_relative 'dev_seeds/geolocations'
 
 log "All dev seeds created successfuly 👍"

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -93,17 +93,6 @@ section "Marking investments as visible to valuators" do
   end
 end
 
-section "Geolocating Investments" do
-  Budget.all.each do |budget|
-    budget.investments.each do |investment|
-      MapLocation.create(latitude: Setting['map_latitude'].to_f + rand(-10..10)/100.to_f,
-                         longitude: Setting['map_longitude'].to_f + rand(-10..10)/100.to_f,
-                         zoom: Setting['map_zoom'],
-                         investment_id: investment.id)
-    end
-  end
-end
-
 section "Balloting Investments" do
   Budget.finished.first.investments.last(20).each do |investment|
     investment.update(selected: true, feasibility: "feasible")

--- a/db/dev_seeds/geolocations.rb
+++ b/db/dev_seeds/geolocations.rb
@@ -1,0 +1,19 @@
+section "Creating Geolocations"  do
+  def create_geolocation(proposal_id: nil, investment_id: nil)
+    MapLocation.create(latitude: Setting['map_latitude'].to_f + rand(-10..10)/100.to_f,
+                       longitude: Setting['map_longitude'].to_f + rand(-10..10)/100.to_f,
+                       zoom: Setting['map_zoom'],
+                       proposal_id: proposal_id,
+                       investment_id: investment_id)
+  end
+
+  sample = [*1..Proposal.count].sample
+  proposals = Proposal.all.sample(sample).map(&:id)
+  proposals.each do |p|
+    create_geolocation(proposal_id: p)
+  end
+
+  Budget::Investment.find_each do |i|
+    create_geolocation(investment_id: i.id)
+  end
+end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2209

What
====
Add maps to some mappable random objects in dev_seed, so that when it's run there are map locations for that objects.

How
===
Add a loop that generates a `MapLocation` for random proposals. Each time the dev_seed is run, the amount of proposals geolocated will vary. When a proposal is chosen for geolocating, it will not be repeated in the same process. This way, each proposal will only have 1 map location.

Screenshots
===========
There aren't because is backend.

Test
====
There aren't new tests.

Deployment
==========
Nothing to apply.

Warnings
========
There are 2 mappable models: `Proposal` and `Budget::Investment`.
I only geolocated random proposals because all the investments [are already being geolocated](https://github.com/AyuntamientoMadrid/consul/blob/master/db/dev_seeds.rb#L542).
