### PR TITLE
Move custom I18n strings to `config/locales/custom` folder structure

### DIFF
--- a/config/locales/custom/en/activemodel.yml
+++ b/config/locales/custom/en/activemodel.yml
@@ -1,0 +1,5 @@
+en:
+  activemodel:
+    attributes:
+      officing/residence:
+        postal_code: "Postal code"

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -1,0 +1,63 @@
+en:
+  activerecord:
+    models:
+      valuator_group:
+        one: "Valuator group"
+        other: "Valuator groups"
+    attributes:
+      volunteer_poll:
+        email: "Email"
+        first_name: "First Name"
+        last_name: "Last name"
+        document_number: "Document number"
+        phone: "Phone"
+        monday_13_morning: monday 13 morning
+        monday_13_afternoon: monday_13_afternoon
+        tuesday_14_morning: tuesday 14 morning
+        tuesday_14_afternoon: tuesday 14 afternoon
+        wednesday_15_morning: wednesday 15 morning
+        wednesday_15_afternoon: wednesday 15 afternoon
+        thursday_16_morning: thursday 16 morning
+        thursday_16_afternoon: thursday 16 afternoon
+        friday_17_morning: friday 17 morning
+        friday_17_afternoon: friday 17 afternoon
+        saturday_18_morning: saturday 18 morning
+        saturday_18_afternoon: saturday 18 afternoon
+        sunday_19_morning: sunday 19 morning
+        sunday_19_afternoon: sunday 19 afternoon
+        monday_20_morning: monday 20 morning
+        monday_20_afternoon: monday 20 afternoon
+        turns: "turns"
+        any_district: "Any district"
+        arganzuela: "Arganzuela"
+        barajas: "Barajas"
+        carabanchel: "Carabanchel"
+        centro: "Centro"
+        chamartin: "Chamartín"
+        chamberi: "Chamberí"
+        ciudad_lineal: "Ciudad Lineal"
+        fuencarral_el_pardo: "Fuencarral-El Pardo"
+        hortaleza: "Hortaleza"
+        latina: "Latina"
+        moncloa_aravaca: "Moncola-Aravaca"
+        moratalaz: "Moratalaz"
+        puente_de_vallecas: "Puente de Vallecas"
+        retiro: "Retiro"
+        salamanca: "Salamanca"
+        san_blas_canillejas: "San Blas Canillejas"
+        tetuan: "Tetuán"
+        usera: "Usera"
+        vicalvaro: "Vicálvaro"
+        villa_de_vallecas: "Villa de Vallecas"
+        villaverde: "Villaverde"
+      budget_poll:
+        name: "First and last name"
+        email: "Email (optional)"
+        preferred_subject: "Preferred subject"
+        collective: "Collective"
+        public_worker: "Public Worker"
+        proposal_author: "Proposal author"
+        selected_proposal_author: "Selected proposal author"
+        help: "I want to help"
+      budget/investment:
+        heading_id: "Is your project for the whole city or is it located in a specific district?"

--- a/config/locales/custom/en/activerecord.yml
+++ b/config/locales/custom/en/activerecord.yml
@@ -1,9 +1,5 @@
 en:
   activerecord:
-    models:
-      valuator_group:
-        one: "Valuator group"
-        other: "Valuator groups"
     attributes:
       volunteer_poll:
         email: "Email"

--- a/config/locales/custom/es/activemodel.yml
+++ b/config/locales/custom/es/activemodel.yml
@@ -1,0 +1,5 @@
+es:
+  activemodel:
+    attributes:
+      officing/residence:
+        postal_code: "Código postal"

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,9 +1,5 @@
 es:
   activerecord:
-    models:
-      valuator_group:
-        one: "Grupo de Evaluadores"
-        other: "Grupos de Evaluadores"
     attributes:
       volunteer_poll:
         email: "Email"

--- a/config/locales/custom/es/activerecord.yml
+++ b/config/locales/custom/es/activerecord.yml
@@ -1,5 +1,63 @@
 es:
   activerecord:
+    models:
+      valuator_group:
+        one: "Grupo de Evaluadores"
+        other: "Grupos de Evaluadores"
     attributes:
+      volunteer_poll:
+        email: "Email"
+        first_name: "Nombre"
+        last_name: "Apellidos"
+        document_number: "Número de documento"
+        phone: "Número de teléfono de contacto (preferiblemente móvil)"
+        monday_13_morning: Lunes 13 feb mañana
+        monday_13_afternoon: Lunes 13 feb tarde
+        tuesday_14_morning: Martes 14 feb mañana
+        tuesday_14_afternoon: Martes 14 feb tarde
+        wednesday_15_morning: Miércoles 15 feb mañana
+        wednesday_15_afternoon: Miércoles 15 feb tarde
+        thursday_16_morning: Jueves 16 feb mañana
+        thursday_16_afternoon: Jueves 16 feb tarde
+        friday_17_morning: Viernes 17 feb mañana
+        friday_17_afternoon: Viernes 17 feb tarde
+        saturday_18_morning: Sábado 18 feb mañana
+        saturday_18_afternoon: Sábado 18 feb tarde
+        sunday_19_morning: Domingo 19 feb mañana
+        sunday_19_afternoon: Domingo 19 feb tarde
+        monday_20_morning: Lunes 20 feb mañana
+        monday_20_afternoon: Lunes 20 feb tarde
+        turns: "turnos"
+        any_district: "En cualquier distrito"
+        arganzuela: "Arganzuela"
+        barajas: "Barajas"
+        carabanchel: "Carabanchel"
+        centro: "Centro"
+        chamartin: "Chamartín"
+        chamberi: "Chamberí"
+        ciudad_lineal: "Ciudad Lineal"
+        fuencarral_el_pardo: "Fuencarral-El Pardo"
+        hortaleza: "Hortaleza"
+        latina: "Latina"
+        moncloa_aravaca: "Moncola-Aravaca"
+        moratalaz: "Moratalaz"
+        puente_de_vallecas: "Puente de Vallecas"
+        retiro: "Retiro"
+        salamanca: "Salamanca"
+        san_blas_canillejas: "San Blas Canillejas"
+        tetuan: "Tetuán"
+        usera: "Usera"
+        vicalvaro: "Vicálvaro"
+        villa_de_vallecas: "Villa de Vallecas"
+        villaverde: "Villaverde"
+      budget_poll:
+        name: "Nombre y apellidos"
+        email: "Email (opcional)"
+        preferred_subject: "Tema preferido"
+        collective: "Colectivo"
+        public_worker: "Empleado público"
+        proposal_author: "Autor de propuesta"
+        selected_proposal_author: "Autor de propuesta seleccionado"
+        help: "Quiero ayudar"
       budget/investment:
         heading_id: "¿Tu proyecto es para toda la ciudad o está ubicado en un distrito en concreto?"

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -20,4 +20,3 @@ en:
         document_type: "Document type"
         document_number: "Document number (including letters)"
         year_of_birth: "Year born"
-        postal_code: "Postal code"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -34,6 +34,9 @@ en:
       valuator:
         one: "Valuator"
         other: "Valuators"
+      valuator_group:
+        one: "Valuator group"
+        other: "Valuator groups"
       manager:
         one: "Manager"
         other: "Managers"

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -34,9 +34,6 @@ en:
       valuator:
         one: "Valuator"
         other: "Valuators"
-      valuator_group:
-        one: "Valuator group"
-        other: "Valuator groups"
       manager:
         one: "Manager"
         other: "Managers"
@@ -98,60 +95,6 @@ en:
         one: "Poll"
         other: "Polls"
     attributes:
-      volunteer_poll:
-        email: "Email"
-        first_name: "First Name"
-        last_name: "Last name"
-        document_number: "Document number"
-        phone: "Phone"
-        monday_13_morning: monday 13 morning
-        monday_13_afternoon: monday_13_afternoon
-        tuesday_14_morning: tuesday 14 morning
-        tuesday_14_afternoon: tuesday 14 afternoon
-        wednesday_15_morning: wednesday 15 morning
-        wednesday_15_afternoon: wednesday 15 afternoon
-        thursday_16_morning: thursday 16 morning
-        thursday_16_afternoon: thursday 16 afternoon
-        friday_17_morning: friday 17 morning
-        friday_17_afternoon: friday 17 afternoon
-        saturday_18_morning: saturday 18 morning
-        saturday_18_afternoon: saturday 18 afternoon
-        sunday_19_morning: sunday 19 morning
-        sunday_19_afternoon: sunday 19 afternoon
-        monday_20_morning: monday 20 morning
-        monday_20_afternoon: monday 20 afternoon
-        turns: "turns"
-        any_district: "Any district"
-        arganzuela: "Arganzuela"
-        barajas: "Barajas"
-        carabanchel: "Carabanchel"
-        centro: "Centro"
-        chamartin: "Chamartín"
-        chamberi: "Chamberí"
-        ciudad_lineal: "Ciudad Lineal"
-        fuencarral_el_pardo: "Fuencarral-El Pardo"
-        hortaleza: "Hortaleza"
-        latina: "Latina"
-        moncloa_aravaca: "Moncola-Aravaca"
-        moratalaz: "Moratalaz"
-        puente_de_vallecas: "Puente de Vallecas"
-        retiro: "Retiro"
-        salamanca: "Salamanca"
-        san_blas_canillejas: "San Blas Canillejas"
-        tetuan: "Tetuán"
-        usera: "Usera"
-        vicalvaro: "Vicálvaro"
-        villa_de_vallecas: "Villa de Vallecas"
-        villaverde: "Villaverde"
-      budget_poll:
-        name: "First and last name"
-        email: "Email (optional)"
-        preferred_subject: "Preferred subject"
-        collective: "Collective"
-        public_worker: "Public Worker"
-        proposal_author: "Proposal author"
-        selected_proposal_author: "Selected proposal author"
-        help: "I want to help"
       budget:
         name: "Name"
         description_accepting: "Description during Accepting phase"
@@ -164,15 +107,11 @@ en:
         phase: "Phase"
         currency_symbol: "Currency"
       budget/investment:
-        heading_id: "Sección de presupuesto"
+        heading_id: "Heading"
         title: "Title"
-        description: "Description"
-        external_url: "External url"
-        administrator_id: "Administrator"
         description: "Description"
         external_url: "Link to additional documentation"
-        heading_id: "Is your project for the whole city or is it located in a specific district?"
-        title: "Title"
+        administrator_id: "Administrator"
         location: "Location (optional)"
         organization_name: "If you are proposing in the name of a collective/organization, or on behalf of more people, write its name"
         image: "Proposal descriptive image"

--- a/config/locales/es/activemodel.yml
+++ b/config/locales/es/activemodel.yml
@@ -20,4 +20,3 @@ es:
         document_type: "Tipo documento"
         document_number: "Numero de documento"
         year_of_birth: "Año de nacimiento"
-        postal_code: "Código postal"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -34,6 +34,9 @@ es:
       valuator:
         one: "Evaluador"
         other: "Evaluadores"
+      valuator_group:
+        one: "Grupo de Evaluadores"
+        other: "Grupos de Evaluadores"
       manager:
         one: "Gestor"
         other: "Gestores"

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -34,9 +34,6 @@ es:
       valuator:
         one: "Evaluador"
         other: "Evaluadores"
-      valuator_group:
-        one: "Grupo de Evaluadores"
-        other: "Grupos de Evaluadores"
       manager:
         one: "Gestor"
         other: "Gestores"
@@ -98,60 +95,6 @@ es:
         one: "Votación"
         other: "Votaciones"
     attributes:
-      volunteer_poll:
-        email: "Email"
-        first_name: "Nombre"
-        last_name: "Apellidos"
-        document_number: "Número de documento"
-        phone: "Número de teléfono de contacto (preferiblemente móvil)"
-        monday_13_morning: Lunes 13 feb mañana
-        monday_13_afternoon: Lunes 13 feb tarde
-        tuesday_14_morning: Martes 14 feb mañana
-        tuesday_14_afternoon: Martes 14 feb tarde
-        wednesday_15_morning: Miércoles 15 feb mañana
-        wednesday_15_afternoon: Miércoles 15 feb tarde
-        thursday_16_morning: Jueves 16 feb mañana
-        thursday_16_afternoon: Jueves 16 feb tarde
-        friday_17_morning: Viernes 17 feb mañana
-        friday_17_afternoon: Viernes 17 feb tarde
-        saturday_18_morning: Sábado 18 feb mañana
-        saturday_18_afternoon: Sábado 18 feb tarde
-        sunday_19_morning: Domingo 19 feb mañana
-        sunday_19_afternoon: Domingo 19 feb tarde
-        monday_20_morning: Lunes 20 feb mañana
-        monday_20_afternoon: Lunes 20 feb tarde
-        turns: "turnos"
-        any_district: "En cualquier distrito"
-        arganzuela: "Arganzuela"
-        barajas: "Barajas"
-        carabanchel: "Carabanchel"
-        centro: "Centro"
-        chamartin: "Chamartín"
-        chamberi: "Chamberí"
-        ciudad_lineal: "Ciudad Lineal"
-        fuencarral_el_pardo: "Fuencarral-El Pardo"
-        hortaleza: "Hortaleza"
-        latina: "Latina"
-        moncloa_aravaca: "Moncola-Aravaca"
-        moratalaz: "Moratalaz"
-        puente_de_vallecas: "Puente de Vallecas"
-        retiro: "Retiro"
-        salamanca: "Salamanca"
-        san_blas_canillejas: "San Blas Canillejas"
-        tetuan: "Tetuán"
-        usera: "Usera"
-        vicalvaro: "Vicálvaro"
-        villa_de_vallecas: "Villa de Vallecas"
-        villaverde: "Villaverde"
-      budget_poll:
-        name: "Nombre y apellidos"
-        email: "Email (opcional)"
-        preferred_subject: "Tema preferido"
-        collective: "Colectivo"
-        public_worker: "Empleado público"
-        proposal_author: "Autor de propuesta"
-        selected_proposal_author: "Autor de propuesta seleccionado"
-        help: "Quiero ayudar"
       budget:
         name: "Nombre"
         description_accepting: "Descripción durante la fase de presentación de proyectos"


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1129

What
====
* Move custom Decide Madrid I18n strings to `config/locales/custom` folder structure
* Removed duplicated keys

Notes
========
* This is the first PR in a series of reviews to keep Decide Madrid I18n files equal to CONSUL's, along with removing deprecated/duplicated keys, fixing typos, replace untranslated strings, etc —so any help is greatly appreciated!
