### PR TITLE
Adds titles and descriptions for all budget phases

### DIFF
--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -1,5 +1,5 @@
-<% provide :title, t("meta_tags.budget_2018.accepting.title") %>
-<% provide :meta_description, t("meta_tags.budget_2018.accepting.description") %>
+<% provide :title, t("meta_tags.budget_2018.#{current_budget.phase}.title") %>
+<% provide :meta_description, t("meta_tags.budget_2018.#{current_budget.phase}.description") %>
 
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: budgets_url %>
@@ -8,8 +8,8 @@
 <% provide :social_media_meta_tags do %>
   <%= render "shared/social_media_meta_tags",
               social_url: budgets_url,
-              social_title: t("meta_tags.budget_2018.accepting.title"),
-              social_description: t("meta_tags.budget_2018.accepting.social"),
+              social_title: t("meta_tags.budget_2018.#{current_budget.phase}.title"),
+              social_description: t("meta_tags.budget_2018.#{current_budget.phase}.description"),
               twitter_image_url: 'social_media_budgets_2018_twitter.png',
               og_image_url: 'social_media_budgets_2018.png' %>
 <% end %>

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -1,5 +1,11 @@
-<% provide :title, t("meta_tags.welcome_index.title") %>
-<% provide :meta_description, t("meta_tags.welcome_index.description") %>
+<% if current_budget %>
+  <% provide :title, t("meta_tags.welcome_index.#{current_budget.phase}.title") %>
+  <% provide :meta_description, t("meta_tags.welcome_index.#{current_budget.phase}.description") %>
+<% else %>
+  <% provide :title, t("meta_tags.welcome_index.title") %>
+  <% provide :meta_description, t("meta_tags.welcome_index.description") %>
+<% end %>
+
 <% provide :tracking_page_number, "23" %>
 <% content_for :canonical do %>
   <%= render "shared/canonical", href: root_url %>

--- a/app/views/welcome/_header.html.erb
+++ b/app/views/welcome/_header.html.erb
@@ -3,12 +3,15 @@
     <div class="row">
       <div class="small-12 medium-9 column small-centered">
         <span class="tiny-title"><%= t("welcome.header_budget.label") %></span>
-        <p class="lead-title margin-top"><%= t("welcome.header_budget.title") %></p>
-        <p class="lead"><%= t("welcome.header_budget.text") %></p>
+        <p class="lead-title margin-top">
+          <%= t("welcome.header_budget.#{current_budget.phase}.title") %>
+        </p>
+        <p class="lead"><%= t("welcome.header_budget.#{current_budget.phase}.text") %></p>
         <div class="small-12 medium-6 large-4 column small-centered">
           <%= link_to t("welcome.header_budget.#{current_budget.phase}.button"),
                       budgets_path,
-                      class: "button expanded large", title: t("welcome.header_budget.#{current_budget.phase}.button") %>
+                      title: t("welcome.header_budget.#{current_budget.phase}.button"),
+                      class: "button expanded large" %>
         </div>
       </div>
     </div>
@@ -19,7 +22,9 @@
       <div class="small-12 column small-centered">
         <span class="label"><%= t("welcome.header.label") %></span>
         <p class="lead-title"><%= t("welcome.header.title") %></p>
-        <p class="lead"><%= t("welcome.header.text", supports: setting["votes_for_proposal_success"]) %></p>
+        <p class="lead">
+          <%= t("welcome.header.text", supports: setting["votes_for_proposal_success"]) %>
+        </p>
         <div class="small-12 medium-6 large-4 column small-centered">
           <%= link_to t("welcome.header.button"),
                       new_proposal_path,

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -237,11 +237,37 @@ en:
       button: "Create a proposal"
     header_budget:
       label: "Participatory budgets 2018"
-      title: "Decide the citizen projects that Madrid City Council will do, you have:"
-      text: "100 million euros"
       accepting:
+        title: "Decide the citizen projects that Madrid City Council will do, you have:"
+        text: "100 million euros"
         button: "Send your project"
       reviewing:
+        title: "Decide the citizen projects that Madrid City Council will do, you have:"
+        text: "100 million euros"
+        button: "See projects"
+      selecting:
+        title: "Choose investment projects in one district and the entire city to be voted on"
+        text: "Support citizen projects"
+        button: "See projects"
+      valuating:
+        title: "The City Council reviews and rates the most supported projects until May 15"
+        text: "Most supported projects"
+        button: "See projects"
+      publishing_prices:
+        title: "The City Council reviews and rates the most supported projects until May 15"
+        text: "Most supported projects"
+        button: "See projects"
+      balloting:
+        title: "Decides what projects the City Council will do with 100 million"
+        text: "Vote in participatory budgets"
+        button: "See projects"
+      reviewing_ballots:
+        title: "In a few days we will know the winning projects of the participatory budgets"
+        text: "Thank you for voting!"
+        button: "See projects"
+      finished:
+        title: "Look at the winning projects of the 2018 participatory budgets"
+        text: "Thank you for voting!"
         button: "See projects"
     once_plazas:
       label: "Voting results"

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -73,7 +73,27 @@ en:
       accepting:
         title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
         description: "Presenta tus proyectos a los presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
-        social: "#ParticipativosMadrid18: Tú decides a qué proyectos ciudadanos dedicar 100 millones de euros del presupuesto municipal."
+      selecting:
+        title: "Apoya proyectos de los presupuestos participativos de Madrid"
+        description: "Entra en Decide Madrid y apoya las ideas para mejorar Madrid. Los proyectos más apoyados de presupuestos participativos pueden pasar a la votación final."
+      valuating:
+        title: "Evaluación de proyectos de los presupuestos participativos"
+        description: "La votación final de proyectos de los presupuestos participativos de Madrid empieza el 15 de mayo. ¡Prepárate para decidir el destino de 100 millones!"
+      balloting:
+        title: "Vota los proyectos finalistas de presupuestos participativos"
+        description: "Vota en Decide Madrid los proyectos que quieres que haga el Ayuntamiento en tu barrio y en Madrid. ¡Decide a qué ideas dedicar 100 millones de euros!"
+      finished:
+        title: "Resultados de los presupuestos participativos 2018"
+        description: "La ciudadanía ha decidido qué hará el Ayuntamiento con 100 millones de euros reservados a proyectos ciudadanos. Entérate de los proyectos ganadores."
+      reviewing:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
+      publishing_prices:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
+      reviewing_ballots:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
   social_share:
     polls_show:
       title_1: "Votación de Plaza de España, Madrid 100% sostenible y billete intermodal"

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -56,6 +56,30 @@ en:
     welcome_index:
       title: "Decide Madrid: portal de participación ciudadana de Madrid"
       description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
+      accepting:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Apoya proyectos de los presupuestos participativos 2018 en Decide Madrid para que pasen a la votación final. Decide qué se hace con 100 millones de euros."
+      selecting:
+        title: "Participa en los presupuestos participativos de Madrid"
+        description: "Entra en Decide Madrid y apoya las ideas para mejorar Madrid. Los proyectos más apoyados de presupuestos participativos pueden pasar a la votación final."
+      valuating:
+        title: "Participa en los presupuestos participativos de Madrid"
+        description: "Prepárate para decidir el destino de 100 millones de euros del presupuesto municipal. La votación final de proyectos se abrirá el 15 de mayo de 2018."
+      balloting:
+        title: "Decide 100 millones en los presupuestos participativos"
+        description: "Estamos en la fase decisiva de los  presupuestos participativos 2018 del Ayuntamiento de Madrid. Vota los proyectos planteados por la ciudadanía."
+      finished:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "Entérate de qué proyectos se harán con los presupuestos participativos en Decide Madrid. Es la web de participación ciudadana del Ayuntamiento de Madrid. "
+      reviewing:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
+      publishing_prices:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
+      reviewing_ballots:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
     proposals:
       title: "Propuestas ciudadanas de Madrid - Decide Madrid"
       description: "Participa activamente en Decide Madrid creando y votando propuestas ciudadanas que quieras que el Ayuntamiento de Madrid lleve a cabo."

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -237,11 +237,37 @@ es:
       button: "Crea una propuesta"
     header_budget:
       label: "Presupuestos participativos 2018"
-      title: "Decide los proyectos ciudadanos que hará el Ayuntamiento de Madrid, tienes:"
-      text: "100 millones de euros"
       accepting:
+        title: "Decide los proyectos ciudadanos que hará el Ayuntamiento de Madrid, tienes:"
+        text: "100 millones de euros"
         button: "Presenta tu proyecto"
       reviewing:
+        title: "Decide los proyectos ciudadanos que hará el Ayuntamiento de Madrid, tienes:"
+        text: "100 millones de euros"
+        button: "Ver proyectos"
+      selecting:
+        title: "Elige los proyectos de un distrito y toda la ciudad para que pasen a votación"
+        text: "Apoya proyectos ciudadanos"
+        button: "Ver proyectos"
+      valuating:
+        title: "El Ayuntamiento revisa y tasa los proyectos más apoyados hasta el 15 de mayo"
+        text: "Proyectos más apoyados"
+        button: "Ver proyectos"
+      publishing_prices:
+        title: "El Ayuntamiento revisa y tasa los proyectos más apoyados hasta el 15 de mayo"
+        text: "Proyectos más apoyados"
+        button: "Ver proyectos"
+      balloting:
+        title: "Decide qué proyectos hará el Ayuntamiento con 100 millones"
+        text: "Vota los presupuestos participativos"
+        button: "Ver proyectos"
+      reviewing_ballots:
+        title: "En unos días conoceremos los proyectos ganadores de los presupuestos participativos"
+        text: "¡Gracias por votar!"
+        button: "Ver proyectos"
+      finished:
+        title: "Mira los proyectos ganadores de los presupuestos participativos 2018"
+        text: "¡Gracias por votar!"
         button: "Ver proyectos"
     once_plazas:
       label: "Resultados votación"

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -1,7 +1,4 @@
 es:
-  users:
-    show:
-      deleted_budget_investment: Este proyecto de gasto ha sido eliminado
   admin:
     probes:
       index:
@@ -76,7 +73,27 @@ es:
       accepting:
         title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
         description: "Presenta tus proyectos a los presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
-        social: "#ParticipativosMadrid18: Tú decides a qué proyectos ciudadanos dedicar 100 millones de euros del presupuesto municipal."
+      selecting:
+        title: "Apoya proyectos de los presupuestos participativos de Madrid"
+        description: "Entra en Decide Madrid y apoya las ideas para mejorar Madrid. Los proyectos más apoyados de presupuestos participativos pueden pasar a la votación final."
+      valuating:
+        title: "Evaluación de proyectos de los presupuestos participativos"
+        description: "La votación final de proyectos de los presupuestos participativos de Madrid empieza el 15 de mayo. ¡Prepárate para decidir el destino de 100 millones!"
+      balloting:
+        title: "Vota los proyectos finalistas de presupuestos participativos"
+        description: "Vota en Decide Madrid los proyectos que quieres que haga el Ayuntamiento en tu barrio y en Madrid. ¡Decide a qué ideas dedicar 100 millones de euros!"
+      finished:
+        title: "Resultados de los presupuestos participativos 2018"
+        description: "La ciudadanía ha decidido qué hará el Ayuntamiento con 100 millones de euros reservados a proyectos ciudadanos. Entérate de los proyectos ganadores."
+      reviewing:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
+      publishing_prices:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
+      reviewing_ballots:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Presupuestos participativos 2018 del Ayuntamiento de Madrid. Tú decides en qué gastar 100 millones de euros."
   social_share:
     polls_show:
       title_1: "Votación de Plaza de España, Madrid 100% sostenible y billete intermodal"

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -56,6 +56,30 @@ es:
     welcome_index:
       title: "Decide Madrid: portal de participación ciudadana de Madrid"
       description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
+      accepting:
+        title: "Presupuestos participativos 2018 - Ayuntamiento de Madrid"
+        description: "Apoya proyectos de los presupuestos participativos 2018 en Decide Madrid para que pasen a la votación final. Decide qué se hace con 100 millones de euros."
+      selecting:
+        title: "Participa en los presupuestos participativos de Madrid"
+        description: "Entra en Decide Madrid y apoya las ideas para mejorar Madrid. Los proyectos más apoyados de presupuestos participativos pueden pasar a la votación final."
+      valuating:
+        title: "Participa en los presupuestos participativos de Madrid"
+        description: "Prepárate para decidir el destino de 100 millones de euros del presupuesto municipal. La votación final de proyectos se abrirá el 15 de mayo de 2018."
+      balloting:
+        title: "Decide 100 millones en los presupuestos participativos"
+        description: "Estamos en la fase decisiva de los  presupuestos participativos 2018 del Ayuntamiento de Madrid. Vota los proyectos planteados por la ciudadanía."
+      finished:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "Entérate de qué proyectos se harán con los presupuestos participativos en Decide Madrid. Es la web de participación ciudadana del Ayuntamiento de Madrid. "
+      reviewing:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
+      publishing_prices:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
+      reviewing_ballots:
+        title: "Decide Madrid, plataforma de participación ciudadana"
+        description: "En la web de participación ciudadana Decide Madrid podrás proponer, apoyar, crear propuestas y decidir en qué gasta el Ayuntamiento su presupuesto."
     proposals:
       title: "Propuestas ciudadanas de Madrid - Decide Madrid"
       description: "Participa activamente en Decide Madrid creando y votando propuestas ciudadanas que quieras que el Ayuntamiento de Madrid lleve a cabo."

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -16,13 +16,49 @@ feature "Welcome screen" do
     budget.update_attributes(phase: :accepting)
 
     visit root_path
-
+    expect(page).to have_content("Decide the citizen projects that Madrid City Council")
     expect(page).to have_link("Send your project")
 
     budget.update_attributes(phase: :reviewing)
 
     visit root_path
+    expect(page).to have_content("100 million euros")
+    expect(page).to have_link("See projects")
 
+    budget.update_attributes(phase: :selecting)
+
+    visit root_path
+    expect(page).to have_content("Support citizen projects")
+    expect(page).to have_link("See projects")
+
+    budget.update_attributes(phase: :valuating)
+
+    visit root_path
+    expect(page).to have_content("Most supported projects")
+    expect(page).to have_link("See projects")
+
+    budget.update_attributes(phase: :publishing_prices)
+
+    visit root_path
+    expect(page).to have_content("Most supported projects")
+    expect(page).to have_link("See projects")
+
+    budget.update_attributes(phase: :balloting)
+
+    visit root_path
+    expect(page).to have_content("Vote in participatory budgets")
+    expect(page).to have_link("See projects")
+
+    budget.update_attributes(phase: :reviewing_ballots)
+
+    visit root_path
+    expect(page).to have_content("In a few days we will know the winning projects")
+    expect(page).to have_link("See projects")
+
+    budget.update_attributes(phase: :finished)
+
+    visit root_path
+    expect(page).to have_content("Thank you for voting!")
     expect(page).to have_link("See projects")
   end
 


### PR DESCRIPTION
What
====

This PR: 

- Adds titles and descriptions for meta tags for each of budget phases (on budgets home).

- Adds titles and descriptions for meta tags for each of budget phases (on welcome home).

- Adds welcome header texts for each budget phases.

- Removes unnecessary custom keys on `config/locales/custom/es/custom.yml`.

How
==

Using the `current_budget.phase`:

On metatags (e.g.):
```
<% provide :title, t("meta_tags.budget_2018.#{current_budget.phase}.title") %>
<% provide :meta_description, t("meta_tags.budget_2018.#{current_budget.phase}.description") %>
```

On i18n keys (e.g.):
```
<%= t("welcome.header_budget.#{current_budget.phase}.title") %>
```
