### PR TITLE
Fixed emails list segments scope

### DIFF
--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -14,7 +14,7 @@ class Newsletter < ActiveRecord::Base
   validates_format_of :from, :with => /@/
 
   def list_of_recipients
-    UserSegments.send(segment_recipient)
+    UserSegments.send(segment_recipient).newsletter
   end
 
   def draft?

--- a/app/views/admin/emails_download/index.html.erb
+++ b/app/views/admin/emails_download/index.html.erb
@@ -10,7 +10,7 @@
       <%= t('admin.emails_download.index.download_segment_help_text') %>
     </p>
 
-    <%= select_tag :users_segment, options_for_select(UserSegments::SEGMENTS
+    <%= select_tag :users_segment, options_for_select(UserSegments::EMAILS_DOWNLOAD_SEGMENTS
                                    .collect { |s| [t("admin.segment_recipient.#{s}"), s] }) %>
 
     <div class="margin-top">

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -1,5 +1,5 @@
 class UserSegments
-  SEGMENTS = %w(all_users
+  EMAILS_DOWNLOAD_SEGMENTS = %w(all_users
                 proposal_authors
                 investment_authors
                 feasible_and_undecided_investment_authors
@@ -7,7 +7,7 @@ class UserSegments
                 winner_investment_authors)
 
   def self.all_users
-    User.newsletter.active
+    User.active
   end
 
   def self.proposal_authors

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -6,15 +6,11 @@ describe UserSegments do
   let(:user3) { create(:user) }
 
   describe "#all_users" do
-    it "returns all active users with newsletter enabled" do
-      active_user1 = create(:user, newsletter: true)
-      active_user2 = create(:user, newsletter: true)
-      active_user3 = create(:user, newsletter: false)
+    it "returns all active users enabled" do
+      active_user = create(:user)
       erased_user  = create(:user, erased_at: Time.current)
 
-      expect(described_class.all_users).to include active_user1
-      expect(described_class.all_users).to include active_user2
-      expect(described_class.all_users).not_to include active_user3
+      expect(described_class.all_users).to include active_user
       expect(described_class.all_users).not_to include erased_user
     end
   end

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -31,4 +31,18 @@ describe Newsletter do
     newsletter.from = "this_is_not_an_email"
     expect(newsletter).not_to be_valid
   end
+
+  describe '#list_of_recipients' do
+    it 'returns users segment list with newsletter enabled' do
+      user_with_newsletter_enabled = create(:user, newsletter: true)
+      user_with_newsletter_disabled = create(:user, newsletter: false)
+
+      newsletter.update(segment_recipient: 1)
+
+      users_list = newsletter.list_of_recipients
+
+      expect(users_list).to include user_with_newsletter_enabled
+      expect(users_list).not_to include user_with_newsletter_disabled
+    end
+  end
 end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2120
* **Related PR's:** https://github.com/consul/consul/pull/2466, https://github.com/AyuntamientoMadrid/consul/pull/1282

What
====
Removed `newsletters` scope from `UsersSegment.all_users` method, as it should be applied in the Newsletter model, where it's needed. The UserSegments class remains then impartial to any filter that only makes sense outside it.

Test
====
As usual.
