### PR TITLE
Flaky spec: Emails spec

### DIFF
--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -25,7 +25,7 @@ feature 'Emails' do
   end
 
   context 'Proposal comments' do
-    scenario "Send email on proposal comment", :js do
+    scenario "Send email on proposal comment" do
       user = create(:user, email_on_comment: true)
       proposal = create(:proposal, author: user)
       comment_on(proposal)
@@ -36,7 +36,7 @@ feature 'Emails' do
       expect(email).to have_body_text(proposal_path(proposal))
     end
 
-    scenario 'Do not send email about own proposal comments', :js do
+    scenario 'Do not send email about own proposal comments' do
       user = create(:user, email_on_comment: true)
       proposal = create(:proposal, author: user)
       comment_on(proposal, user)
@@ -44,7 +44,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario 'Do not send email about proposal comment unless set in preferences', :js do
+    scenario 'Do not send email about proposal comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       proposal = create(:proposal, author: user)
       comment_on(proposal)
@@ -54,7 +54,7 @@ feature 'Emails' do
   end
 
   context 'Debate comments' do
-    scenario "Send email on debate comment", :js do
+    scenario "Send email on debate comment" do
       user = create(:user, email_on_comment: true)
       debate = create(:debate, author: user)
       comment_on(debate)
@@ -67,7 +67,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own debate comments', :js do
+    scenario 'Do not send email about own debate comments' do
       user = create(:user, email_on_comment: true)
       debate = create(:debate, author: user)
       comment_on(debate, user)
@@ -75,7 +75,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error "No email has been sent!"
     end
 
-    scenario 'Do not send email about debate comment unless set in preferences', :js do
+    scenario 'Do not send email about debate comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       debate = create(:debate, author: user)
       comment_on(debate)
@@ -85,7 +85,7 @@ feature 'Emails' do
   end
 
   context 'Budget investments comments' do
-    scenario 'Send email on budget investment comment', :js do
+    scenario 'Send email on budget investment comment' do
       user = create(:user, email_on_comment: true)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
@@ -98,7 +98,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own budget investments comments', :js do
+    scenario 'Do not send email about own budget investments comments' do
       user = create(:user, email_on_comment: true)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment, user)
@@ -106,7 +106,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about budget investment comment unless set in preferences', :js do
+    scenario 'Do not send email about budget investment comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
@@ -120,7 +120,7 @@ feature 'Emails' do
       @proposal = create(:proposal)
     end
 
-    scenario 'Send email on topic comment', :js do
+    scenario 'Send email on topic comment' do
       user = create(:user, email_on_comment: true)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
@@ -133,7 +133,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own topic comments', :js do
+    scenario 'Do not send email about own topic comments' do
       user = create(:user, email_on_comment: true)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic, user)
@@ -141,7 +141,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about topic comment unless set in preferences', :js do
+    scenario 'Do not send email about topic comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
@@ -151,7 +151,7 @@ feature 'Emails' do
   end
 
   context 'Poll comments' do
-    scenario 'Send email on poll comment', :js do
+    scenario 'Send email on poll comment' do
       user = create(:user, email_on_comment: true)
       poll = create(:poll, author: user)
       comment_on(poll)
@@ -164,7 +164,7 @@ feature 'Emails' do
       expect(email).to have_body_text(account_path)
     end
 
-    scenario 'Do not send email about own poll comments', :js do
+    scenario 'Do not send email about own poll comments' do
       user = create(:user, email_on_comment: true)
       poll = create(:poll, author: user)
       comment_on(poll, user)
@@ -172,7 +172,7 @@ feature 'Emails' do
       expect { open_last_email }.to raise_error 'No email has been sent!'
     end
 
-    scenario 'Do not send email about poll question comment unless set in preferences', :js do
+    scenario 'Do not send email about poll question comment unless set in preferences' do
       user = create(:user, email_on_comment: false)
       poll = create(:poll, author: user)
       comment_on(poll)

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -113,25 +113,8 @@ module CommonActions
   def comment_on(commentable, user = nil)
     user ||= create(:user)
 
-    login_as(user)
-    commentable_path = if commentable.is_a?(Proposal)
-                         proposal_path(commentable)
-                       elsif commentable.is_a?(Debate)
-                         debate_path(commentable)
-                       elsif commentable.is_a?(Topic)
-                         community_topic_path(commentable, community_id: commentable.community_id)
-                       elsif commentable.is_a?(Poll)
-                         poll_path(commentable)
-                       else
-                         budget_investment_path(commentable, budget_id: commentable.budget_id)
-                       end
-    visit commentable_path
-
-    comment_field = "comment-body-#{commentable.class.name.parameterize('_')}_#{commentable.id}"
-    fill_in comment_field, with: 'Have you thought about...?'
-    click_button 'Publish comment'
-
-    expect(page).to have_content 'Have you thought about...?'
+    comment = create(:comment, commentable: commentable, user: user)
+    CommentNotifier.new(comment: comment).process
   end
 
   def reply_to(original_user, manuela = nil)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1236, #1239 and #1240 (all the three issues throw the same flaky)

What
====
Fix the flaky that appears in the `emails_spec.rb` examples that use `comment_on` function (referenced above)

How
===
### Explain why the test is flaky, or under which conditions/scenario it fails randomly
In the error provided in the issue, there was a problem when creating a comment from the UI. My thoughts about this were focused in JavaScript, because the comments use it to be published, so, instead of fixing every single test that used the function by sending the emails "by hand", I made the function create a comment and launch the email notifications, instead of relying in JS to create a comment and send the notifications. 

This spec is testing if the emails are been send when commenting in different objects. The UI is not relevant here, but the code behind it, so we omit all the front part and focus on the backend (avoiding, also, the use of JS).

### Explain why your PR fixes it
A comment is created using FactoryGirl, and then the email notification system is activated "by hand", so we ensure that the email is always send (or, at least, the tests tries to send it. It won't be able to do so if the corresponding conditions are not been filled).

Screenshots
===========
There aren't because this is a flaky test fix.

Test
====
`comment_on` function has been rewriten to avoid the use of JS. This function is only being used here.

Deployment
==========
Nothing to apply

Warnings
========
Nothing to apply
