### PR TITLE
Include valuators group in Investment table & csv download

### DIFF
--- a/app/helpers/valuation_helper.rb
+++ b/app/helpers/valuation_helper.rb
@@ -13,11 +13,6 @@ module ValuationHelper
     ValuatorGroup.order("name ASC").collect { |g| [ g.name, "group_#{g.id}"] }
   end
 
-  def assigned_valuators(investment)
-    [investment.valuator_groups.collect(&:name) +
-     investment.valuators.collect(&:description_or_name)].flatten.join(', ')
-  end
-
   def assigned_valuators_info(valuators)
     case valuators.size
     when 0

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -342,12 +342,29 @@ class Budget
       where(heading_id: heading_ids)
     end
 
+    def assigned_valuators
+      if valuators.size.zero?
+        I18n.t("admin.budget_investments.index.no_valuators_assigned")
+      else
+        self.valuators.collect(&:description_or_name).compact.join(', ')
+      end
+    end
+
+    def assigned_valuation_groups
+      if valuator_groups.count.zero?
+        I18n.t("admin.budget_investments.index.no_valuation_groups")
+      else
+        self.valuator_groups.collect(&:name).compact.join(', ')
+      end
+    end
+
     def self.to_csv(investments, options = {})
       attrs = [I18n.t("admin.budget_investments.index.table_id"),
                I18n.t("admin.budget_investments.index.table_title"),
                I18n.t("admin.budget_investments.index.table_supports"),
                I18n.t("admin.budget_investments.index.table_admin"),
                I18n.t("admin.budget_investments.index.table_valuator"),
+               I18n.t("admin.budget_investments.index.table_valuation_group"),
                I18n.t("admin.budget_investments.index.table_geozone"),
                I18n.t("admin.budget_investments.index.table_feasibility"),
                I18n.t("admin.budget_investments.index.table_valuation_finished"),
@@ -363,11 +380,8 @@ class Budget
                   else
                     I18n.t("admin.budget_investments.index.no_admin_assigned")
                   end
-          vals = if investment.valuators.empty?
-                   I18n.t("admin.budget_investments.index.no_valuators_assigned")
-                 else
-                   investment.valuators.collect(&:description_or_name).join(', ')
-                 end
+          vals = investment.assigned_valuators
+          val_groups = investment.assigned_valuation_groups
           heading_name = investment.heading.name
           price_string = "admin.budget_investments.index.feasibility"\
                          ".#{investment.feasibility}"
@@ -375,8 +389,8 @@ class Budget
           valuation_finished = investment.valuation_finished? ?
                                          I18n.t('shared.yes') :
                                          I18n.t('shared.no')
-          csv << [id, title, total_votes, admin, vals, heading_name, price,
-                  valuation_finished]
+          csv << [id, title, total_votes, admin, vals, val_groups, heading_name,
+                  price, valuation_finished]
         end
       end
       csv_string

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -343,19 +343,11 @@ class Budget
     end
 
     def assigned_valuators
-      if valuators.size.zero?
-        I18n.t("admin.budget_investments.index.no_valuators_assigned")
-      else
-        self.valuators.collect(&:description_or_name).compact.join(', ')
-      end
+      self.valuators.collect(&:description_or_name).compact.join(', ').presence
     end
 
     def assigned_valuation_groups
-      if valuator_groups.count.zero?
-        I18n.t("admin.budget_investments.index.no_valuation_groups")
-      else
-        self.valuator_groups.collect(&:name).compact.join(', ')
-      end
+      self.valuator_groups.collect(&:name).compact.join(', ').presence
     end
 
     def self.to_csv(investments, options = {})
@@ -380,8 +372,8 @@ class Budget
                   else
                     I18n.t("admin.budget_investments.index.no_admin_assigned")
                   end
-          vals = investment.assigned_valuators
-          val_groups = investment.assigned_valuation_groups
+          assigned_valuators = investment.assigned_valuators || '-'
+          assigned_valuation_groups = investment.assigned_valuation_groups || '-'
           heading_name = investment.heading.name
           price_string = "admin.budget_investments.index.feasibility"\
                          ".#{investment.feasibility}"
@@ -389,8 +381,8 @@ class Budget
           valuation_finished = investment.valuation_finished? ?
                                          I18n.t('shared.yes') :
                                          I18n.t('shared.no')
-          csv << [id, title, total_votes, admin, vals, val_groups, heading_name,
-                  price, valuation_finished]
+          csv << [id, title, total_votes, admin, assigned_valuators, assigned_valuation_groups,
+                  heading_name, price, valuation_finished]
         end
       end
       csv_string

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -24,6 +24,7 @@
         <th><%= t("admin.budget_investments.index.table_supports") %></th>
         <th><%= t("admin.budget_investments.index.table_admin") %></th>
         <th><%= t("admin.budget_investments.index.table_valuator") %></th>
+        <th><%= t("admin.budget_investments.index.table_valuation_group") %></th>
         <th><%= t("admin.budget_investments.index.table_geozone") %></th>
         <th><%= t("admin.budget_investments.index.table_feasibility") %></th>
         <th class="text-center"><%= t("admin.budget_investments.index.table_valuation_finished") %></th>
@@ -67,11 +68,10 @@
             <% end %>
           </td>
           <td class="small">
-            <% if investment.valuators.size == 0 && investment.valuator_groups.size == 0 %>
-              <%= t("admin.budget_investments.index.no_valuators_assigned") %>
-            <% else %>
-              <%= assigned_valuators(investment) %>
-            <% end %>
+            <%= investment.assigned_valuators %>
+          </td>
+          <td class="small">
+            <%= investment.assigned_valuation_groups %>
           </td>
           <td class="small">
             <%= investment.heading.name %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -68,10 +68,12 @@
             <% end %>
           </td>
           <td class="small">
-            <%= investment.assigned_valuators %>
+            <% no_valuators_assigned = t("admin.budget_investments.index.no_valuators_assigned") %>
+            <%= investment.assigned_valuators || no_valuators_assigned %>
           </td>
           <td class="small">
-            <%= investment.assigned_valuation_groups %>
+            <% no_valuation_groups = t("admin.budget_investments.index.no_valuation_groups") %>
+            <%= investment.assigned_valuation_groups || no_valuation_groups %>
           </td>
           <td class="small">
             <%= investment.heading.name %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -974,7 +974,6 @@ en:
         assigned_admin: Assigned administrator
         no_admin_assigned: No admin assigned
         no_valuators_assigned: No valuators assigned
-        no_valuation_groups: No valuation groups assigned
         summary_link: "Investment project summary"
         valuator_summary_link: "Valuator summary"
         feasibility:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -171,6 +171,7 @@ en:
         assigned_admin: Assigned administrator
         no_admin_assigned: No admin assigned
         no_valuators_assigned: No valuators assigned
+        no_valuation_groups: Without valuation groups
         feasibility:
           feasible: "Feasible (%{price})"
           unfeasible: "Unfeasible"
@@ -182,6 +183,7 @@ en:
         table_supports: "Supports"
         table_admin: "Administrator"
         table_valuator: "Valuator"
+        table_valuation_group: "Valuation Group"
         table_geozone: "Scope of operation"
         table_feasibility: "Feasibility"
         table_valuation_finished: "Val. Fin."
@@ -972,6 +974,7 @@ en:
         assigned_admin: Assigned administrator
         no_admin_assigned: No admin assigned
         no_valuators_assigned: No valuators assigned
+        no_valuation_groups: Without valuation groups
         summary_link: "Investment project summary"
         valuator_summary_link: "Valuator summary"
         feasibility:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -171,7 +171,7 @@ en:
         assigned_admin: Assigned administrator
         no_admin_assigned: No admin assigned
         no_valuators_assigned: No valuators assigned
-        no_valuation_groups: Without valuation groups
+        no_valuation_groups: No valuation groups assigned
         feasibility:
           feasible: "Feasible (%{price})"
           unfeasible: "Unfeasible"
@@ -974,7 +974,7 @@ en:
         assigned_admin: Assigned administrator
         no_admin_assigned: No admin assigned
         no_valuators_assigned: No valuators assigned
-        no_valuation_groups: Without valuation groups
+        no_valuation_groups: No valuation groups assigned
         summary_link: "Investment project summary"
         valuator_summary_link: "Valuator summary"
         feasibility:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -171,6 +171,7 @@ es:
         assigned_admin: Administrador asignado
         no_admin_assigned: Sin admin asignado
         no_valuators_assigned: Sin evaluador
+        no_valuation_groups: Sin grupos evaluadores
         feasibility:
           feasible: "Viable (%{price})"
           unfeasible: "Inviable"
@@ -182,6 +183,7 @@ es:
         table_supports: "Apoyos"
         table_admin: "Administrador"
         table_valuator: "Evaluador"
+        table_valuation_group: "Grupos evaluadores"
         table_geozone: "Ámbito de actuación"
         table_feasibility: "Viabilidad"
         table_valuation_finished: "Ev. Fin."
@@ -972,6 +974,7 @@ es:
         assigned_admin: Administrador asignado
         no_admin_assigned: Sin admin asignado
         no_valuators_assigned: Sin evaluador
+        no_valuation_groups: Sin grupos evaluadores
         summary_link: "Resumen de propuestas"
         valuator_summary_link: "Resumen de evaluadores"
         feasibility:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -974,7 +974,6 @@ es:
         assigned_admin: Administrador asignado
         no_admin_assigned: Sin admin asignado
         no_valuators_assigned: Sin evaluador
-        no_valuation_groups: Sin grupos evaluadores
         summary_link: "Resumen de propuestas"
         valuator_summary_link: "Resumen de evaluadores"
         feasibility:

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -72,14 +72,14 @@ feature 'Admin budget investments' do
       within("#budget_investment_#{budget_investment1.id}") do
         expect(page).to have_content("No admin assigned")
         expect(page).to have_content("Valuator Olga")
-        expect(page).to have_content("Without valuation groups")
+        expect(page).to have_content("No valuation groups assigned")
       end
 
       within("#budget_investment_#{budget_investment2.id}") do
         expect(page).to have_content("No admin assigned")
         expect(page).to have_content("Valuator Olga")
         expect(page).to have_content("Valuator Miriam")
-        expect(page).to have_content("Without valuation groups")
+        expect(page).to have_content("No valuation groups assigned")
       end
 
       budget_investment3.update(administrator_id: admin.id)
@@ -88,7 +88,7 @@ feature 'Admin budget investments' do
       within("#budget_investment_#{budget_investment3.id}") do
         expect(page).to have_content("Gema")
         expect(page).to have_content("No valuators assigned")
-        expect(page).to have_content("Without valuation groups")
+        expect(page).to have_content("No valuation groups assigned")
       end
     end
 
@@ -115,7 +115,7 @@ feature 'Admin budget investments' do
       end
 
       within("#budget_investment_#{budget_investment3.id}") do
-        expect(page).to have_content("Without valuation groups")
+        expect(page).to have_content("No valuation groups assigned")
       end
 end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -64,25 +64,31 @@ feature 'Admin budget investments' do
       admin = create(:administrator, user: create(:user, username: 'Gema'))
 
       budget_investment1.valuators << valuator1
-      budget_investment2.valuator_ids = [valuator1.id, valuator2.id]
-      budget_investment3.update(administrator_id: admin.id)
+      budget_investment2.valuators << valuator1
+      budget_investment2.valuators << valuator2
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       within("#budget_investment_#{budget_investment1.id}") do
         expect(page).to have_content("No admin assigned")
         expect(page).to have_content("Valuator Olga")
+        expect(page).to have_content("Without valuation groups")
       end
 
       within("#budget_investment_#{budget_investment2.id}") do
         expect(page).to have_content("No admin assigned")
         expect(page).to have_content("Valuator Olga")
         expect(page).to have_content("Valuator Miriam")
+        expect(page).to have_content("Without valuation groups")
       end
+
+      budget_investment3.update(administrator_id: admin.id)
+      visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       within("#budget_investment_#{budget_investment3.id}") do
         expect(page).to have_content("Gema")
         expect(page).to have_content("No valuators assigned")
+        expect(page).to have_content("Without valuation groups")
       end
     end
 
@@ -109,9 +115,9 @@ feature 'Admin budget investments' do
       end
 
       within("#budget_investment_#{budget_investment3.id}") do
-        expect(page).to have_content("No valuators assigned")
+        expect(page).to have_content("Without valuation groups")
       end
-    end
+end
 
     scenario "Filtering by budget heading", :js do
       group1 = create(:budget_group, name: "Streets", budget: budget)
@@ -977,7 +983,9 @@ feature 'Admin budget investments' do
                                                          price: 100)
       valuator = create(:valuator, user: create(:user, username: 'Rachel',
                                                        email: 'rachel@val.org'))
-      investment.valuators.push(valuator)
+      group = create(:valuator_group, name: "Test name")
+
+      investment.valuator_groups << group
 
       admin = create(:administrator, user: create(:user, username: 'Gema'))
       investment.update(administrator_id: admin.id)
@@ -1002,6 +1010,7 @@ feature 'Admin budget investments' do
 
       expect(page).to have_content investment.administrator.name
       expect(page).to have_content valuators
+      expect(page).to have_content group.name
       expect(page).to have_content price
       expect(page).to have_content I18n.t('shared.no')
     end


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2472

What
====
- In the Budgets Investments admin section, add's the valuators group in the html table and in the csv

How
===
- Added one more column to the self.to_csv function on Budget::Investment and app/views/admin/budget_investments/_investments.html.erb

Screenshots
===========
- Html
![screenshot from 2018-02-21 13-38-32](https://user-images.githubusercontent.com/33748390/36480545-facdb984-170c-11e8-8baf-a6b35a3daffa.png)
- Csv
![screenshot from 2018-02-21 13-41-06](https://user-images.githubusercontent.com/33748390/36480546-fafbc64e-170c-11e8-8954-e55601232f44.png)

Test
====
- Added more conditions to the existing tests

Deployment
==========
- none

Warnings
========
- none
