### PR TITLE
Add administrators & beta tester User Segments

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -535,6 +535,7 @@ en:
       selected_investment_authors: Authors of selected investments in the current budget
       winner_investment_authors: Authors of winner investments in the current budget
       invalid_recipients_segment: "Recipients user segment is invalid"
+      beta_testers: "Beta testers"
     newsletters:
       create_success: Newsletter created successfully
       update_success: Newsletter updated successfully

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -528,6 +528,7 @@ en:
         title: 'Moderators: User search'
     segment_recipient:
       all_users: All users
+      administrators: Administrators
       proposal_authors: Proposal authors
       investment_authors: Investment authors in the current budget
       feasible_and_undecided_investment_authors: Authors of feasible or undecided investments in the current budget

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -528,6 +528,7 @@ es:
         title: 'Moderadores: Búsqueda de usuarios'
     segment_recipient:
       all_users: Todos los usuarios
+      administrators: Administradores
       proposal_authors: Usuarios autores de propuestas
       investment_authors: Usuarios autores de proyectos de gasto en los actuales presupuestos
       feasible_and_undecided_investment_authors: Usuarios autores de proyectos de gasto viables o sin decidir en los actuales presupuestos

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -535,6 +535,7 @@ es:
       selected_investment_authors: Usuarios autores de proyectos de gasto seleccionadas en los actuales presupuestos
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"
+      beta_testers: "Beta testers"
     newsletters:
       create_success: Newsletter creada correctamente
       update_success: Newsletter actualizada correctamente

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -1,5 +1,6 @@
 class UserSegments
   SEGMENTS = %w(all_users
+                administrators
                 proposal_authors
                 investment_authors
                 feasible_and_undecided_investment_authors
@@ -8,6 +9,10 @@ class UserSegments
 
   def self.all_users
     User.active
+  end
+
+  def self.administrators
+    all_users.administrators
   end
 
   def self.proposal_authors

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -5,7 +5,8 @@ class UserSegments
                 investment_authors
                 feasible_and_undecided_investment_authors
                 selected_investment_authors
-                winner_investment_authors)
+                winner_investment_authors
+                beta_testers)
 
   def self.all_users
     User.active
@@ -34,6 +35,16 @@ class UserSegments
 
   def self.winner_investment_authors
     author_ids(current_budget_investments.winners.pluck(:author_id).uniq)
+  end
+
+  def self.beta_testers
+    testers = %w(aranacm@madrid.es
+                 bertocq@gmail.com
+                 mariajecheca@gmail.com
+                 alberto@decabeza.es
+                 voodoorai2000@gmail.com)
+
+    User.where(email: testers)
   end
 
   private

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -15,6 +15,18 @@ describe UserSegments do
     end
   end
 
+  describe "#administrators" do
+    it "returns all active administrators users" do
+      active_user = create(:user)
+      active_admin = create(:administrator).user
+      erased_user = create(:user, erased_at: Time.current)
+
+      expect(described_class.administrators).to include active_admin
+      expect(described_class.administrators).not_to include active_user
+      expect(described_class.administrators).not_to include erased_user
+    end
+  end
+
   describe "#proposal_authors" do
     it "returns users that have created a proposal" do
       proposal = create(:proposal, author: user1)


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1291 

What
====
We need a user segment to have only administrators as recipients of both
newsletters and notifications, also one for betatesting just with our accounts

How
===
Adding a new segment functions, with its spec and name on ymls

Screenshots
===========
![screen shot 2018-02-21 at 19 05 14](https://user-images.githubusercontent.com/983242/36496954-2b66bc08-173a-11e8-915f-adb5282960f6.jpg)

Test
====
Updated user segment model spec

Deployment
==========
As usual

Warnings
========
None