### PR TITLE
Fix some flakies on imageable and documentable, also found serious issues with PhantomJS

### DIFF
--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -132,8 +132,8 @@ end
 def attach_document(path, success = true)
   attach_file :document_attachment, path, make_visible: true
   if success
-    expect(page).to have_css ".loading-bar.complete"
+    expect(page).to have_content "Remove document"
   else
-    expect(page).to have_css ".loading-bar.errors"
+    expect(page).not_to have_content "Remove document"
   end
 end

--- a/spec/shared/features/imageable.rb
+++ b/spec/shared/features/imageable.rb
@@ -96,8 +96,9 @@ def attach_image(path, success = true)
   image_input = image.find("input[type=file]", visible: false)
   attach_file image_input[:id], path, make_visible: true
   if success
-    expect(page).to have_css ".loading-bar.complete"
+    expect(page).to have_content "Remove image"
   else
-    expect(page).to have_css ".loading-bar.errors"
+save_and_open_page
+    expect(page).not_to have_content "Remove image"
   end
 end

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -78,7 +78,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
         attach_file(document[:id], "spec/fixtures/files/empty.pdf", make_visible: true)
       end
 
-      expect(page).to have_css ".file-name", text: "empty.pdf"
+      expect(page).to have_content "Remove document"
     end
 
     scenario "Should update nested document file title with file name after choosing a file when no title defined", :js do
@@ -111,7 +111,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
       documentable_attach_new_file("spec/fixtures/files/empty.pdf")
 
-      expect(page).to have_css ".loading-bar.complete"
+      expect(page).to have_content "Remove document"
     end
 
     scenario "Should update loading bar style after unvalid file upload", :js do
@@ -120,7 +120,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
       documentable_attach_new_file("spec/fixtures/files/logo_header.png", false)
 
-      expect(page).to have_css ".loading-bar.errors"
+      expect(page).not_to have_content "Remove document"
     end
 
     scenario "Should update document cached_attachment field after valid file upload", :js do
@@ -283,12 +283,13 @@ def documentable_attach_new_file(path, success = true)
   # making https://github.com/teampoltergeist/poltergeist/blob/master/lib/capybara/poltergeist/client/browser.coffee#L186
   # always choose the previous used input.
   page.execute_script("$('##{document_input[:id]}').removeAttr('_poltergeist_selected')")
-
   within document do
     if success
-      expect(page).to have_css ".loading-bar.complete"
+      expect(page).to have_content "Remove document"
     else
-      expect(page).to have_css ".loading-bar.errors"
+      within '.small-9.column.action-add.attachment-errors.document-attachment' do
+        expect(page).to have_content "Choose document"
+      end
     end
   end
 end

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -83,7 +83,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
 
       imageable_attach_new_file(imageable_factory_name, "spec/fixtures/files/clippy.jpg")
 
-      expect(page).to have_selector ".loading-bar.complete"
+      expect(page).to have_content "Remove image"
     end
 
     scenario "Should update loading bar style after invalid file upload", :js do
@@ -92,7 +92,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
 
       imageable_attach_new_file(imageable_factory_name, "spec/fixtures/files/logo_header.png", false)
 
-      expect(page).to have_selector ".loading-bar.errors"
+      expect(page).not_to have_content "Remove image"
     end
 
     scenario "Should update image cached_attachment field after valid file upload", :js do
@@ -240,9 +240,9 @@ def imageable_attach_new_file(_imageable_factory_name, path, success = true)
     attach_file(image_input[:id], path, make_visible: true)
     within image do
       if success
-        expect(page).to have_css(".loading-bar.complete")
+        expect(page).to have_content "Remove image"
       else
-        expect(page).to have_css(".loading-bar.errors")
+        expect(page).not_to have_content "Remove image"
       end
     end
   end


### PR DESCRIPTION
Where
=====
* **Related Issue:** none

What
====
- Fix some flakies on imageable and documentable

How
===
- I found some workarounds for some test who trusts on on javascript for the proof of the code,  but the proof itself fails, so I looked for some alternative using html

Screenshots
===========
- None related

Test
====
- Fixed some tests 

Deployment
==========
- None

Warnings
========
- I have made a disturbing discovery, the current version of PanthomJs (v 2.1.1) has a bug in the function attach_file with which all the tests that use it fail systematically. I have tested version 1.9.8 and these tests work in particular but others are broken, so the versions 2.1.1, 2.5.0 do not work. I have also tried selenium and it's even worse (gem selenium-webdriver)

- Attached files with the outputs of the execution of spec ./spec/features/proposals_spec.rb with the 4 variants [outputs.zip](https://github.com/AyuntamientoMadrid/consul/files/1748752/outputs.zip)

- As a compromise measure I propose to avoid as much as possible the use of javascript in the tests if possible, because it is very unstable. In this PR certain tests are solved, which depended on the execution of an effect (the filling of a green or red bar), which was simply ignored.
