### PR TITLE
increased max_wait_time for capybara

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,6 +57,9 @@ Rails.application.configure do
     if ENV['BULLET']
       Bullet.raise = true # raise an error if n+1 query occurs
     end
+    Capybara.configure do |config|
+      config.default_max_wait_time = 5
+    end
   end
 
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,8 @@
 Rails.application.configure do
+
+  config.assets.debug = true # I'm looking for a flaky on poltegeist
+  config.serve_static_files = false # I'm looking for a flaky on poltegeist
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's
@@ -18,7 +22,7 @@ Rails.application.configure do
   config.allow_concurrency = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
+  # config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,9 +57,6 @@ Rails.application.configure do
     if ENV['BULLET']
       Bullet.raise = true # raise an error if n+1 query occurs
     end
-    Capybara.configure do |config|
-      config.default_max_wait_time = 5
-    end
   end
 
 end

--- a/spec/features/legislation/draft_versions_spec.rb
+++ b/spec/features/legislation/draft_versions_spec.rb
@@ -61,8 +61,8 @@ feature 'Legislation Draft Versions' do
 
       select("Version 2")
 
-      expect(page).not_to have_content("Body of the first version")
-      expect(page).to have_content("Body of the second version")
+      expect(page).not_to have_selector("#sticky-panel", text: "Body of the first version")
+      expect(page).to have_selector("#sticky-panel", text: "Body of the second version")
     end
 
     context "for final versions" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1178
* **Related Issue:** https://github.com/consul/consul/issues/2447

What
====
- Fix a flaky test on /spec/features/legislation/draft_versions_spec.rb:64

How
===
- I've noticed that a race condition its happening between jabvascript and capybara, so I added a few more seconds (5s) to Capybara.config.default_max_wait_time

- As can be seen on the next images, a very rough test shows that the default default_max_wait_time is too short (2s) and causes some  race condition problems

- code who prints time stamps and status
![timestamps_code](https://user-images.githubusercontent.com/33748390/36671347-933e61f4-1afb-11e8-8e06-20bd6aef8add.png)

- output
![timestamps_outputs](https://user-images.githubusercontent.com/33748390/36671348-9368d68c-1afb-11e8-9597-5752c243c24f.png)

- 2.7 seconds need the process to change the html, more than the 2 default seconds

Screenshots
===========
- none

Test
====
- It fix some tests

Deployment
==========
- none

Warnings
========
- none
