### PR TITLE
Fix UserSegment feasible and undecided investment authors

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -531,7 +531,7 @@ en:
       administrators: Administrators
       proposal_authors: Proposal authors
       investment_authors: Investment authors in the current budget
-      feasible_and_undecided_investment_authors: Authors of feasible or undecided investments in the current budget
+      feasible_and_undecided_investment_authors: "Authors of some investment in the current budget that does not comply with: [valuation finished unfesasible]"
       selected_investment_authors: Authors of selected investments in the current budget
       winner_investment_authors: Authors of winner investments in the current budget
       invalid_recipients_segment: "Recipients user segment is invalid"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -531,7 +531,7 @@ es:
       administrators: Administradores
       proposal_authors: Usuarios autores de propuestas
       investment_authors: Usuarios autores de proyectos de gasto en los actuales presupuestos
-      feasible_and_undecided_investment_authors: Usuarios autores de proyectos de gasto viables o sin decidir en los actuales presupuestos
+      feasible_and_undecided_investment_authors: "Usuarios autores de algún proyecto de gasto en los actuales presupuestos que no cumpla: [evaluación finalizada inviable]"
       selected_investment_authors: Usuarios autores de proyectos de gasto seleccionadas en los actuales presupuestos
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -25,8 +25,9 @@ class UserSegments
   end
 
   def self.feasible_and_undecided_investment_authors
-    feasibility = %w(feasible undecided)
-    author_ids(current_budget_investments.where(feasibility: feasibility).pluck(:author_id).uniq)
+    unfeasible_and_finished_condition = "feasibility = 'unfeasible' and valuation_finished = true"
+    investments = current_budget_investments.where.not(unfeasible_and_finished_condition)
+    author_ids(investments.pluck(:author_id).uniq)
   end
 
   def self.selected_investment_authors

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -70,18 +70,32 @@ describe UserSegments do
 
   describe "#feasible_and_undecided_investment_authors" do
     it "returns authors of a feasible or an undecided budget investment" do
-      feasible_investment = create(:budget_investment, :feasible, author: user1)
-      undecided_investment = create(:budget_investment, :undecided, author: user2)
-      unfeasible_investment = create(:budget_investment, :unfeasible, author: user3)
+      user4 = create(:user)
+      user5 = create(:user)
+      user6 = create(:user)
+
+      feasible_investment_finished = create(:budget_investment, :feasible, :finished, author: user1)
+      undecided_investment_finished = create(:budget_investment, :undecided, :finished, author: user2)
+      feasible_investment_unfinished = create(:budget_investment, :feasible, author: user3)
+      undecided_investment_unfinished = create(:budget_investment, :undecided, author: user4)
+      unfeasible_investment_unfinished = create(:budget_investment, :unfeasible, author: user5)
+      unfeasible_investment_finished = create(:budget_investment, :unfeasible, :finished, author: user6)
+
       budget = create(:budget)
-      feasible_investment.update(budget: budget)
-      undecided_investment.update(budget: budget)
-      unfeasible_investment.update(budget: budget)
+      feasible_investment_finished.update(budget: budget)
+      undecided_investment_finished.update(budget: budget)
+      feasible_investment_unfinished.update(budget: budget)
+      undecided_investment_unfinished.update(budget: budget)
+      unfeasible_investment_unfinished.update(budget: budget)
+      unfeasible_investment_finished.update(budget: budget)
 
       investment_authors = described_class.feasible_and_undecided_investment_authors
       expect(investment_authors).to include user1
       expect(investment_authors).to include user2
-      expect(investment_authors).not_to include user3
+      expect(investment_authors).to include user3
+      expect(investment_authors).to include user4
+      expect(investment_authors).to include user5
+      expect(investment_authors).not_to include user6
     end
 
     it "does not return duplicated users" do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/consul/consul/issues/2487

What
====
Added new filter to `UserSegments#feasible_and_undecided_investment_authors` to include those investments marked as unfeasible but the valuation still to be finished.

Screenshots
===========
<img width="1051" alt="screen shot 2018-02-27 at 17 50 51" src="https://user-images.githubusercontent.com/2141690/36741975-d22a383e-1be6-11e8-8cdb-f7e7f8d1d684.png">