### PR TITLE
Fix incorrect URLs for attachments (documents)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,7 @@
 class Document < ActiveRecord::Base
   include DocumentsHelper
   include DocumentablesHelper
-  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:hash.:extension",
+  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:basename.:extension",
                                  hash_data: ":class/:style/:custom_hash_data",
                                  use_timestamp: false,
                                  hash_secret: Rails.application.secrets.secret_key_base


### PR DESCRIPTION
Where
=====
* **Related issue:** #1280 (Closes #1280 once merged)

What
====
* Fixes incorrect URLs for attachments (documents) that caused 404 errors

How
===
* 404 errors were being returned when an user tried to download documents attached to certain Proposals (detailed on #1280)

* The errors were caused because the URL to access the documents was being generated based on the `secrets#secret_key_base` key rather than the filename of the attached documents, so when a change to this secret was made, it made the URLs invalid —the DB records and the actual files were left untouched

* To solve this issue, the `url` for the `Document` model was modified to use the `:basename` property rather than `:hash` —all broken URLs will work again (and previously working URLs are left untouched)

Test
====
* All green! :white_check_mark:

Warnings
========
* Since this bug appeared because of a change to the `secret_key_base` key, it is possible attached images were also affected since the `Image` model also generates URLs based on the hash, as shown [here](https://github.com/AyuntamientoMadrid/consul/blob/master/app/models/image.rb#L11)

* We should enforce the usage of `:basename` for this as well in order to avoid future possible bugs :relieved:

Notes
========
* Backport pending to [CONSUL](http://github.com/consul/consul/) to ensure consistency