### PR TITLE
Flaky spec: Debates Show: "Back" link directs to previous page

### DIFF
--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -64,11 +64,15 @@ feature 'Debates' do
     end
   end
 
-  scenario 'Show: "Back" link directs to previous page', :js do
+  scenario 'Show: "Back" link directs to previous page' do
     debate = create(:debate, title: 'Test Debate 1')
 
     visit debates_path(order: :hot_score, page: 1)
-    first(:link, debate.title).click
+
+    within("#debate_#{debate.id}") do
+      click_link debate.title
+    end
+
     link_text = find_link('Go back')[:href]
 
     expect(link_text).to include(debates_path(order: :hot_score, page: 1))


### PR DESCRIPTION
Where
=====
Related Issue: #1213 (this PR closes #1213)

What
====
Fix the flaky that appears in the `spec/features/debates_spec.rb:72` spec.

How
===
### Explain why the test is flaky, or under which conditions/scenario it fails randomly

This test used the function first (`first(:link, debate.title).click`), which is supposed [not to wait](http://stefan.haflidason.com/testing-with-rails-and-capybara-methods-that-wait-method-that-wont/) until some element appears on the page. If it doesn't wait, the test will look for the 'Go back' link before the page is rendered, so that it won't find it and will crash.

This changes make the test wait until a matching object appears on the screen. It is also a more specific test because of the use of the within, with encapsulates the finding to a concrete area.

As a side note, I noticed that the test was been executed as `:js` when no JS was needed. This may be causing flakies (because the use of JS is one of the flaky sources detected).

### Explain why your PR fixes it

`click_link` waits until a matching element appears on the page (ref. [here](http://stefan.haflidason.com/testing-with-rails-and-capybara-methods-that-wait-method-that-wont/) and [here](https://coderwall.com/p/bfaqwa/capybara-select-first-element-ambiguity-resolution)), whereas first doesn't. That can cause `race condition` flaky, because the find is done before the page is ready. Changing the method for the `click_link` makes the test wait and doesn't cause a `race condition`.

Screenshots
===========
There aren't because this is a flaky.

Test
====
The test has been rewriten to avoid the use of first (it doesn't waits) in favor of click_link (that waits)

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
