### PR TITLE
Fix fo flaky spec, admin/legislation/dreaft_versions_spec.rb fails updating version

### DIFF
--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -69,7 +69,6 @@ feature 'Admin legislation draft versions' do
   context 'Update' do
     scenario 'Valid legislation draft version', :js do
       process = create(:legislation_process, title: 'An example legislation process')
-      draft_version = create(:legislation_draft_version, title: 'Version 1', process: process)
 
       visit admin_root_path
 
@@ -82,6 +81,9 @@ feature 'Admin legislation draft versions' do
       expect(page).to have_content 'An example legislation process'
 
       click_link 'An example legislation process'
+
+      create(:legislation_draft_version, title: 'Version 1', process: process)
+
       click_link 'Text'
 
       click_link 'Version 1'


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1228

What
====
- Fix the flaky error happened in ./spec/features/admin/legislation/draft_versions_spec.rb:87. The object which should be shown seems to be lost.
I guess (after more than 250 attempts and without reproducing the error) that DatabaseCleaner or other function deleted the object, so I moved the create order to the last possible moment. 

How
===
- I moved one line :)

Screenshots
===========
- None

Test
====
- It's a fix!

Deployment
==========
- none

Warnings
========
- none
