### PR TITLE
Hunt the flaky - Tracking Tracking pages Codes

### DIFF
--- a/spec/features/tracks_spec.rb
+++ b/spec/features/tracks_spec.rb
@@ -301,40 +301,65 @@ feature 'Tracking' do
       Setting['per_page_code_head'] = '<script type="text/javascript">function weboConv(idConv){}</script>'
     end
 
-    scenario "Codes", :js do
-      visit root_path
-      expect(page.html).to have_content "weboConv(23);"
+    context "Codes", :js do
+      scenario "root_path" do
+        visit root_path
+        expect(page.html).to have_content "weboConv(23);"
+      end
 
-      visit "users/sign_up"
-      expect(page.html).to have_content "weboConv(24);"
+      scenario "users/sign_up" do
+        visit "users/sign_up"
+        expect(page.html).to have_content "weboConv(24);"
+      end
 
-      visit "users/sign_up/success"
-      expect(page.html).to have_content "weboConv(26);"
+      scenario "users/sign_up/success" do
+        visit "users/sign_up/success"
+        expect(page.html).to have_content "weboConv(26);"
+      end
 
-      visit "debates"
-      expect(page.html).to have_content "weboConv(27);"
+      scenario "debates" do
+        visit "debates"
+        expect(page.html).to have_content "weboConv(27);"
+      end
+    end
 
-      user = create(:user, :level_two)
-      login_as(user)
+    context "Codes after login", :js do
 
-      visit "debates/new"
-      expect(page.html).to have_content "weboConv(28);"
+      background do
+        user = create(:user, :level_two)
+        login_as(user)
+      end
 
-      visit "proposals"
-      expect(page.html).to have_content "weboConv(29);"
+      scenario "debates/new" do
+        visit "debates/new"
+        expect(page.html).to have_content "weboConv(28);"
+      end
 
-      visit "proposals/new"
-      expect(page.html).to have_content "weboConv(30);"
+      scenario "proposals" do
+        visit "proposals"
+        expect(page.html).to have_content "weboConv(29);"
+      end
 
-      visit "procesos"
-      expect(page.html).to have_content "weboConv(32);"
+      scenario "proposals/new" do
+        visit "proposals/new"
+        expect(page.html).to have_content "weboConv(30);"
+      end
 
-      budget = create(:budget)
-      visit "presupuestos"
-      expect(page.html).to have_content "weboConv(33);"
+      scenario "procesos" do
+        visit "procesos"
+        expect(page.html).to have_content "weboConv(32);"
+      end
 
-      visit help_path
-      expect(page.html).to have_content "weboConv(34);"
+      scenario "presupuestos" do
+        budget = create(:budget)
+        visit "presupuestos"
+        expect(page.html).to have_content "weboConv(33);"
+      end
+
+      scenario "help_path" do
+        visit help_path
+        expect(page.html).to have_content "weboConv(34);"
+      end
     end
 
     scenario "codes with turbolinks", :js do


### PR DESCRIPTION
Where
=====
* **Related Issue:** #1175 (this PR closes #1175)

What
====
Fix the flaky that appeared in `spec/features/tracks_spec.rb:304`.

How
===
### Explain why the spec was flaky, or under which conditions/scenario it failed randomly

This flaky was related to JS files that are been loaded in the page.
In my opinion, the continuous visits to different pages don't let the JavaScript files load correctly, so, sometimes, the page need some code that has not been loaded yet. That caused some different errors, not only the ones related to CKEDITOR (I really think they all have the same origin).

```
Tracking Tracking pages Codes
     Failure/Error: visit "proposals"
     
     Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).
     
       TypeError: undefined is not an object (evaluating 'c[a].dir=c.rtl[a]?"rtl":"ltr"')
       TypeError: undefined is not an object (evaluating 'c[a].dir=c.rtl[a]?"rtl":"ltr"')
           at http://127.0.0.1:37131/assets/application-b83f044ca54db32bceefe13374a0ea2b8a5eae440216a1304f66efa0181df814.js:32375 in d
		[...]
```

```
Tracking Tracking pages Codes
     Failure/Error: visit "proposals"
     
     Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).
     
       Error: [CKEDITOR.resourceManager.load] Resource name "default" was not found at "http://127.0.0.1:43747/assets/ckeditor/styles.js?t=H5SC".
       Error: [CKEDITOR.resourceManager.load] Resource name "default" was not found at "http://127.0.0.1:43747/assets/ckeditor/styles.js?t=H5SC".
           at http://127.0.0.1:43747/assets/application-b83f044ca54db32bceefe13374a0ea2b8a5eae440216a1304f66efa0181df814.js:32381
           [...]
```

### Explain why your PR fixes it

This solution splits the large test in several small ones. This let each visit has its own scenario, where the JS files are not been mixed between calls and loaded correctly. 

Screenshots
===========
There aren't, it's a flaky.

Test
====
The test has been splited in several smaller tests to minify the risk of overlapping one call with the next one.

Deployment
==========
Nothing to apply.

Warnings
========
Nothing to apply.
