### PR TITLE
Fixes Facebook share button

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -153,8 +153,8 @@
         share_title: t("budgets.investments.show.share"),
         title: investment.title,
         image_url: image_absolute_url(investment.image, :thumb),
-        url: investment.url,
-        description: investment.description
+        url: budget_investment_url(investment.budget, investment),
+        description: investment.title
       } %>
 
       <% if current_user %>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -59,7 +59,8 @@
         <%= render partial: 'shared/social_share', locals: {
           share_title: t("debates.show.share"),
           title: @debate.title,
-          url: debate_url(@debate)
+          url: debate_url(@debate),
+          description: @debate.title
         } %>
       </aside>
     </div>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -114,7 +114,8 @@
           <%= render partial: 'shared/social_share', locals: {
             share_title: t("proposals.show.share"),
             title: @proposal.title,
-            url: proposal_url(@proposal)
+            url: proposal_url(@proposal),
+            description: @proposal.summary
           } %>
         </aside>
       <% end %>

--- a/app/views/polls/_poll_header.html.erb
+++ b/app/views/polls/_poll_header.html.erb
@@ -20,7 +20,8 @@
       <%= render partial: 'shared/social_share', locals: {
         share_title: t("shared.share"),
         title: @poll.name,
-        url: poll_url(@poll)
+        url: poll_url(@poll),
+        description: @poll.name
       } %>
     </aside>
   </div>

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -23,7 +23,8 @@
 
         <%= render partial: 'shared/social_share', locals: {
           title: @proposal.title,
-          url: proposal_url(@proposal)
+          url: proposal_url(@proposal),
+          description: @proposal.summary
         } %>
 
         <% if @proposal_improvement_path.present? %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -202,7 +202,8 @@
         <%= render partial: 'shared/social_share', locals: {
           share_title: t("proposals.show.share"),
           title: @proposal.title,
-          url: proposal_url(@proposal)
+          url: proposal_url(@proposal),
+          description: @proposal.summary
         } %>
 
         <% if current_user %>

--- a/app/views/spending_proposals/show.html.erb
+++ b/app/views/spending_proposals/show.html.erb
@@ -64,7 +64,8 @@
       <%= render partial: 'shared/social_share', locals: {
         share_title: t("spending_proposals.show.share"),
         title: @spending_proposal.title,
-        url: spending_proposal_url(@spending_proposal)
+        url: spending_proposal_url(@spending_proposal),
+        description: @spending_proposal.title
       } %>
     </aside>
   </div>


### PR DESCRIPTION
Where
=====
* **Related Issue:** CONSUL https://github.com/AyuntamientoMadrid/consul/issues/1245

What
====
This PR fixes Facebook share button adding a `description`. This adds the required `data-desc` element, and Facebook will then accept the request.

More information on https://github.com/huacnlee/social-share-button/pull/160/files
