### PR TITLE
Heading link on budgets message

### DIFF
--- a/app/helpers/budget_headings_helper.rb
+++ b/app/helpers/budget_headings_helper.rb
@@ -6,4 +6,10 @@ module BudgetHeadingsHelper
     end
   end
 
+  def heading_link(assigned_heading = nil, budget = nil)
+    return nil unless assigned_heading && budget
+    heading_path = budget_investments_path(budget, heading_id: assigned_heading.try(:id))
+    link_to(assigned_heading.name, heading_path)
+  end
+
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -220,11 +220,11 @@ class Budget
     end
 
     def reason_for_not_being_ballotable_by(user, ballot)
-      return permission_problem(user)    if permission_problem?(user)
-      return :not_selected               unless selected?
-      return :no_ballots_allowed         unless budget.balloting?
-      return :different_heading_assigned unless ballot.valid_heading?(heading)
-      return :not_enough_money_html      if ballot.present? && !enough_money?(ballot)
+      return permission_problem(user)         if permission_problem?(user)
+      return :not_selected                    unless selected?
+      return :no_ballots_allowed              unless budget.balloting?
+      return :different_heading_assigned_html unless ballot.valid_heading?(heading)
+      return :not_enough_money_html           if ballot.present? && !enough_money?(ballot)
     end
 
     def permission_problem(user)

--- a/app/views/budgets/investments/_ballot.html.erb
+++ b/app/views/budgets/investments/_ballot.html.erb
@@ -42,17 +42,31 @@
 
   <% if reason.present? && !ballot.has_investment?(investment) %>
 
-    <div class="js-participation-not-allowed participation-not-allowed" style='display:none'>
+    <div class="js-participation-not-allowed participation-not-allowed" style="display:none">
+
+      <% verify_account = link_to(t("votes.verify_account"), verification_path) %>
+      <% signin = link_to(t("votes.signin"), new_user_session_path) %>
+      <% signup = link_to(t("votes.signup"), new_user_registration_path) %>
+      <% my_heading = link_to(investment.heading.name,
+                      budget_investments_path(budget_id: investment.budget_id,
+                                              heading_id: investment.heading_id)) %>
+      <% change_ballot = link_to(t("budgets.ballots.reasons_for_not_balloting.change_ballot"),
+                                          budget_ballot_path(@budget))%>
+
+      <% if @assigned_heading.present? %>
+        <% heading_link = link_to(@assigned_heading.name,
+                                  budget_investments_path(@budget,
+                                  heading_id: @assigned_heading.try(:id))) %>
+      <% end %>
+
       <p>
-        <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
-              verify_account: link_to(t("votes.verify_account"), verification_path),
-              signin: link_to(t("votes.signin"), new_user_session_path),
-              signup: link_to(t("votes.signup"), new_user_registration_path),
-              my_heading: link_to(investment.heading.name,
-                                  budget_investments_path(budget_id: investment.budget_id,
-                                                          heading_id: investment.heading_id)),
-              change_ballot: link_to(t("budgets.ballots.reasons_for_not_balloting.change_ballot"),
-                                    budget_ballot_path(@budget))).html_safe %>
+        <small>
+          <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
+                verify_account: verify_account, signin: signin,
+                signup: signup, my_heading: my_heading,
+                change_ballot: change_ballot,
+                heading_link: heading_link).html_safe %>
+        </small>
       </p>
     </div>
 

--- a/app/views/budgets/investments/_ballot.html.erb
+++ b/app/views/budgets/investments/_ballot.html.erb
@@ -53,19 +53,13 @@
       <% change_ballot = link_to(t("budgets.ballots.reasons_for_not_balloting.change_ballot"),
                                           budget_ballot_path(@budget))%>
 
-      <% if @assigned_heading.present? %>
-        <% heading_link = link_to(@assigned_heading.name,
-                                  budget_investments_path(@budget,
-                                  heading_id: @assigned_heading.try(:id))) %>
-      <% end %>
-
       <p>
         <small>
           <%= t("budgets.ballots.reasons_for_not_balloting.#{reason}",
                 verify_account: verify_account, signin: signin,
                 signup: signup, my_heading: my_heading,
                 change_ballot: change_ballot,
-                heading_link: heading_link).html_safe %>
+                heading_link: heading_link(@assigned_heading, @budget)).html_safe %>
         </small>
       </p>
     </div>

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -37,10 +37,7 @@
               <div class="small-12 medium-9">
                 <div class="callout warning margin-top">
                   <%= t("budgets.investments.header.different_heading_assigned_html",
-                        heading_link: link_to(
-                          @assigned_heading.name,
-                          budget_investments_path(@budget, heading_id: @assigned_heading.try(:id)))
-                       ) %>
+                        heading_link: heading_link(@assigned_heading, @budget)) %>
                   <br>
                   <small>
                     <%= t("budgets.investments.header.change_ballot",

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -35,7 +35,7 @@
                 <%= t("budgets.investments.index.by_heading", heading: @heading.name) %>
               </h2>
               <div class="small-12 medium-9">
-                <div class="callout warning">
+                <div class="callout warning margin-top">
                   <%= t("budgets.investments.header.different_heading_assigned_html",
                         heading_link: link_to(
                           @assigned_heading.name,

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -44,9 +44,7 @@
   <% elsif @assigned_heading.present? %>
     <p>
       <%= t("budgets.investments.index.sidebar.different_heading_assigned_html",
-              heading_link: link_to(
-                @assigned_heading.name,
-                budget_investments_path(@budget, heading_id: @assigned_heading.try(:id)))
+              heading_link: heading_link(@assigned_heading, @budget)
             ) %>
       <br>
       <small>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -29,11 +29,13 @@
   <% if reason.present? && !user_voted_for %>
     <div class="js-participation-not-allowed participation-not-allowed" style='display:none' aria-hidden="false">
       <p>
+        <small>
           <%= t("votes.budget_investments.#{reason}",
                 verify_account: link_to(t("votes.verify_account"), verification_path),
                 signin: link_to(t("votes.signin"), new_user_session_path),
                 signup: link_to(t("votes.signup"), new_user_registration_path)
            ).html_safe %>
+        </small>
       </p>
     </div>
   <% end %>

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -37,3 +37,6 @@ en:
       no_demographic_data: "* There is no demographic data for %{total} participants."
       participatory_disclaimer: "** The numbers of total participation refer to persons that created, supported or voted investment proposals."
       heading_disclaimer: "*** Data about headings refer to the heading where each user voted, not necessarily the one that person is registered on."
+  votes:
+    budget_investments:
+      different_heading_assigned: "You can only support investment projects in one district"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -58,3 +58,6 @@ es:
       no_demographic_data: "* No se dispone de los datos demográficos de %{total} participantes."
       participatory_disclaimer: "** Las cifras de participación total se refieren a personas que han creado, apoyado o votado propuestas."
       heading_disclaimer: "*** Los datos de distrito se refieren al distrito en el que el usuario ha votado, no necesariamente en el que está empadronado."
+  votes:
+    budget_investments:
+      different_heading_assigned: "Sólo puedes apoyar proyectos de gasto de un distrito"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -163,7 +163,6 @@ en:
           one_filter_html: "Current applied filters: <b><em>%{filter}</em></b>"
           two_filters_html: "Current applied filters: <b><em>%{filter}, %{advanced_filters}</em></b>"
         buttons:
-          search: Search
           filter: Filter
         download_current_selection: "Download current selection"
         no_budget_investments: "There are no investment projects."

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -19,7 +19,7 @@ en:
         not_selected: Unselected investment projects can not be supported
         not_enough_money_html: "You have already assigned the available budget.<br><small>Remember you can %{change_ballot} at any time</small>"
         no_ballots_allowed: Selecting phase is closed
-        different_heading_assigned: You have already voted a different heading
+        different_heading_assigned_html: "You have already voted a different heading: %{heading_link}"
         change_ballot: change your votes
     groups:
       show:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -163,7 +163,6 @@ es:
           one_filter_html: "Filtros en uso: <b><em>%{filter}</em></b>"
           two_filters_html: "Filtros en uso: <b><em>%{filter}, %{advanced_filters}</em></b>"
         buttons:
-          search: Buscar
           filter: Filtrar
         download_current_selection: "Descargar selección actual"
         no_budget_investments: "No hay proyectos de gasto."

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -19,7 +19,7 @@ es:
         not_selected: No se pueden votar proyectos inviables.
         not_enough_money_html: "Ya has asignado el presupuesto disponible.<br><small>Recuerda que puedes %{change_ballot} en cualquier momento</small>"
         no_ballots_allowed: El periodo de votación está cerrado.
-        different_heading_assigned: Ya has votado proyectos de otro distrito.
+        different_heading_assigned_html: "Ya has votado proyectos de otro distrito: %{heading_link}"
         change_ballot: cambiar tus votos
     groups:
       show:

--- a/spec/features/ballots_spec.rb
+++ b/spec/features/ballots_spec.rb
@@ -293,7 +293,7 @@ feature 'Ballots' do
       visit spending_proposals_path(geozone: new_york)
 
       expect(page).not_to have_css "#progressbar"
-      expect(page).to have_content "You have active votes in another district:"
+      expect(page).to have_content "You have active votes in another district: California"
       expect(page).to have_link california.name, href: spending_proposals_path(geozone: california)
     end
 

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -226,7 +226,7 @@ feature 'Ballots' do
         click_link "Districts"
         click_link "District 2"
 
-        expect(page).to have_content("You have active votes in another heading")
+        expect(page).to have_content("You have active votes in another heading: District 1")
       end
     end
 
@@ -296,7 +296,7 @@ feature 'Ballots' do
       visit budget_investments_path(budget, heading_id: new_york.id)
 
       expect(page).not_to have_css "#progressbar"
-      expect(page).to have_content "You have active votes in another heading:"
+      expect(page).to have_content "You have active votes in another heading: California"
       expect(page).to have_link california.name, href: budget_investments_path(budget, heading_id: california.id)
     end
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -948,7 +948,7 @@ describe Budget::Investment do
           ballot = create(:budget_ballot, user: user, budget: budget)
           ballot.investments << inv1
 
-          expect(inv2.reason_for_not_being_ballotable_by(user, ballot)).to eq(:different_heading_assigned)
+          expect(inv2.reason_for_not_being_ballotable_by(user, ballot)).to eq(:different_heading_assigned_html)
         end
 
         it "rejects proposals with price higher than current available money" do


### PR DESCRIPTION
Where
=====
**Related Issue:** https://github.com/consul/consul/issues/2496

What
====

This PR adds heading link on the different heading assigned message.

Screenshots
===========
**Message before (with the link only on header message)**

<img width="960" alt="heading_before" src="https://user-images.githubusercontent.com/631897/36933251-1dc6e070-1ed6-11e8-8908-7e21f1995997.png">

**Message after (with the link on the header and each item on hover)**

<img width="912" alt="heading_after" src="https://user-images.githubusercontent.com/631897/36933253-1fa3d182-1ed6-11e8-91e7-ef2cb40c3ffc.png">
