### PR TITLE
Hide budget index map

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -16,7 +16,7 @@ class BudgetsController < ApplicationController
 
   def index
     @finished_budgets = @budgets.finished.order(created_at: :desc)
-    @budgets_coordinates = current_budget_map_locations
+    # @budgets_coordinates = current_budget_map_locations
   end
 
   private

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -98,10 +98,12 @@
       </div>
 
       <% unless current_budget.informing? %>
-        <div id="map">
-          <h3><%= t("budgets.index.map") %></h3>
-          <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
-        </div>
+        <% if false %>
+          <div id="map">
+            <h3><%= t("budgets.index.map") %></h3>
+            <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
+          </div>
+        <% end %>
 
         <p>
           <% show_links = show_links_to_budget_investments(current_budget) %>

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -146,7 +146,7 @@ feature 'Budgets' do
     expect(page).to have_css(".phase.active", count: 1)
   end
 
-  context "Index map" do
+  xcontext "Index map" do
 
     let(:group) { create(:budget_group, budget: budget) }
     let(:heading) { create(:budget_heading, group: group) }


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1314

What
====
This PR hides the map in the budget index page until a solution to make it load quicker in production, to avoid long page load times.