### PR TITLE
Fix display of unfeasibility explanation

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -321,6 +321,10 @@ class Budget
       should_show_price? && price_explanation.present?
     end
 
+    def should_show_unfeasibility_explanation?
+      unfeasible? && valuation_finished? && unfeasibility_explanation.present?
+    end
+
     def formatted_price
       budget.formatted_amount(price)
     end

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -67,7 +67,7 @@
         </div>
       <% end %>
 
-      <% if investment.unfeasible? && investment.unfeasibility_explanation.present? %>
+      <% if investment.should_show_unfeasibility_explanation? %>
         <h2><%= t('budgets.investments.show.unfeasibility_explanation') %></h2>
         <p><%= investment.unfeasibility_explanation %></p>
       <% end %>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -963,7 +963,7 @@ feature 'Budget Investments' do
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
     expect(page).to have_content("Unfeasibility explanation")
-    expect(page).to have_content(investment.unfeasibility_explanation)
+    expect(page).to have_content("Local government is not competent in this matter")
   end
 
   scenario "Show (unfeasible budget investment with valuation not finished)" do
@@ -981,7 +981,7 @@ feature 'Budget Investments' do
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
     expect(page).not_to have_content("Unfeasibility explanation")
-    expect(page).not_to have_content(investment.unfeasibility_explanation)
+    expect(page).not_to have_content("Local government is not competent in this matter")
   end
 
   scenario "Show milestones", :js do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -966,6 +966,24 @@ feature 'Budget Investments' do
     expect(page).to have_content(investment.unfeasibility_explanation)
   end
 
+  scenario "Show (unfeasible budget investment with valuation not finished)" do
+    user = create(:user)
+    login_as(user)
+
+    investment = create(:budget_investment,
+                        :unfeasible,
+                        valuation_finished: false,
+                        budget: budget,
+                        group: group,
+                        heading: heading,
+                        unfeasibility_explanation: 'Local government is not competent in this matter')
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+
+    expect(page).not_to have_content("Unfeasibility explanation")
+    expect(page).not_to have_content(investment.unfeasibility_explanation)
+  end
+
   scenario "Show milestones", :js do
     user = create(:user)
     investment = create(:budget_investment)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -280,6 +280,51 @@ describe Budget::Investment do
     end
   end
 
+  describe "#should_show_unfeasibility_explanation?" do
+    let(:budget) { create(:budget) }
+    let(:investment) do
+      create(:budget_investment, budget: budget,
+             unfeasibility_explanation: "because of reasons",
+             valuation_finished: true,
+             feasibility: "unfeasible")
+    end
+
+    it "returns true for unfeasible investments with unfeasibility explanation and valuation finished" do
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(true)
+      end
+    end
+
+    it "returns false in valuation has not finished" do
+      investment.update(valuation_finished: false)
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+
+    it "returns false if not unfeasible" do
+      investment.update(feasibility: "undecided")
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+
+    it "returns false if unfeasibility explanation blank" do
+      investment.update(unfeasibility_explanation: "")
+      Budget::Phase::PUBLISHED_PRICES_PHASES.each do |phase|
+        budget.update(phase: phase)
+
+        expect(investment.should_show_unfeasibility_explanation?).to eq(false)
+      end
+    end
+  end
+
   describe "#by_budget" do
 
     it "returns investments scoped by budget" do


### PR DESCRIPTION
What
====
- Only display unfeasibility explanation of a budget investment when the investment is unfeasible, valuation has finished and the unfeasibility_explanation is not blank

How
===
- Adding a check for valuation finished, it's the only one we were missing

Deployment
==========
- As usual

Warnings
========
- None
