### PR TITLE
Use friendly urls in budgets' index

### DIFF
--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -81,7 +81,9 @@
             <% group.headings.order_by_group_name.each do |heading| %>
               <li class="heading small-12 medium-4 large-2">
                 <% unless current_budget.informing? %>
-                  <%= link_to budget_investments_path(current_budget.id, heading_id: heading.id) do %>
+                  <%= link_to custom_budget_investments_path(group,
+                                                             budget_id: current_budget,
+                                                             heading_id: heading) do %>
                     <%= heading_name_and_price_html(heading, current_budget) %>
                   <% end %>
                 <% else %>

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -66,6 +66,19 @@ feature 'Budgets' do
         expect(page).not_to have_css('div#map')
       end
     end
+
+    scenario "Use friendly urls" do
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+
+      visit budgets_path
+
+      within("#groups_and_headings") do
+        friendly_url = "/presupuestos/#{budget.name.parameterize}/#{group.name.parameterize}/#{heading.name.parameterize}"
+        expect(page).to have_link("#{heading.name } €1,000,000", href: friendly_url)
+      end
+    end
+
   end
 
   scenario 'Index shows only published phases' do


### PR DESCRIPTION
Where
=====
* **Related Issue:** https://github.com/AyuntamientoMadrid/consul/issues/1258

What
====
We were using semi friendly urls:
`presupuestos/3/proyecto?heading_id=49`

With this PR we have nicer urls using slugs
`presupuestos/2018/distritos/arganzuela`

Deployment
==========
- As usual

Notes
========
- There is still a little redundacy depending on budget names and groups with a single heading:
decidepre.madrid.es/**presupuestos/presupuestos**-participativos-2018/**toda-la-ciudad/toda-la-ciudad**
