### PR TITLE
Fix incorrect URL generation for attachments (documents)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,7 @@
 class Document < ActiveRecord::Base
   include DocumentsHelper
   include DocumentablesHelper
-  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:hash.:extension",
+  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:basename.:extension",
                                  hash_data: ":class/:style/:custom_hash_data",
                                  use_timestamp: false,
                                  hash_secret: Rails.application.secrets.secret_key_base


### PR DESCRIPTION
Where
=====
* **Related issue:** #1280 (Closes #1280 once merged)
* **Related PRs:** #1307, #1321

What
====
* As per @voodoorai2000's request, I'm bringing back the patch presented on #1307 and reverted on #1321

* See [this comment](https://github.com/AyuntamientoMadrid/consul/issues/1280#issuecomment-368906844) in order to reproduce the issue locally

How
===
* See #1307 for more details

Test
====
* Manual testing is needed for this patch. Check out [these](https://github.com/AyuntamientoMadrid/consul/issues/1280#issuecomment-370024857) [comments](https://github.com/AyuntamientoMadrid/consul/issues/1280#issuecomment-370027623) on how to test it on a Preproduction environment before deploying

* You can use this [Rake task](https://gist.github.com/aitbw/93910b27d2a0ba0aa42db99811adda9d) to see how many `Proposal` and `Budget::Investment` are affected before and after the patch

Deployment
==========
* :point_up: see above

Warnings
========
* See #1307 for more details

Notes
========
* See #1307 for more details

