### PR TITLE
Fix social share buttons

### DIFF
--- a/app/views/ballots/_ballot.html.erb
+++ b/app/views/ballots/_ballot.html.erb
@@ -11,10 +11,17 @@
     </h2>
 
     <% if @ballot.geozone.present? && district_wide_amount_spent(@ballot) > 0 %>
-      <%= social_share_button_tag("#{t('ballots.show.social_share',
-                                        amount: format_price(district_wide_amount_spent(@ballot)),
-                                        geozone: @ballot.geozone.name)} #{setting['twitter_hashtag']}",
-                                  url: participatory_budget_url) %>
+
+      <% ballot_title = t("ballots.show.social_share",
+                           amount: format_price(district_wide_amount_spent(@ballot)),
+                           geozone: @ballot.geozone.name) %>
+
+      <%= render partial: 'shared/social_share', locals: {
+        title: ballot_title,
+        url: participatory_budget_url,
+        description: ballot_title
+      } %>
+
     <% end %>
 
     <% if setting["feature.spending_proposal_features.final_voting_allowed"].present? %>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -40,8 +40,12 @@
 
   <% if user_voted_for && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{investment.title} #{setting['twitter_hashtag']}",
-          url: budget_investment_url(investment.budget, investment), via: setting['twitter_handle']) %>
+      <%= render partial: 'shared/social_share', locals: {
+        title: investment.title,
+        image_url: image_absolute_url(investment.image, :thumb),
+        url: budget_investment_url(investment.budget, investment),
+        description: investment.title
+      } %>
     </div>
   <% end %>
 </div>

--- a/app/views/custom/probe_options/plaza/show.html.erb
+++ b/app/views/custom/probe_options/plaza/show.html.erb
@@ -131,15 +131,13 @@
                     <%= "<small>Imágenes (#{@probe_option.file_size('dossier', 'pdf')})</small>".html_safe %>
         <% end %>
 
-        <div class="sidebar-divider"></div>
-        <h3><%= t("probes.show.share") %></h3>
-        <div class="social-share-full">
-          <%= social_share_button_tag("#{@probe_option.name} #{setting['twitter_hashtag']}") %>
-          <a href="whatsapp://send?text=<%= CGI.escape(@probe_option.name) %>&nbsp;<%= plaza_probe_option_url(@probe_option) %>" data-action="share/whatsapp/share">
-            <span class="icon-whatsapp whatsapp"></span>
-            <span class="show-for-sr"><%= t("social.whatsapp") %></span>
-          </a>
-        </div>
+        <%= render partial: 'shared/social_share', locals: {
+          share_title: t("probes.show.share"),
+          title: @probe_option.name,
+          url: plaza_probe_option_url(@probe_option),
+          description: @probe_option.name
+        } %>
+
       </aside>
     </div>
 <% end %>

--- a/app/views/custom/probes/plaza/thanks.html.erb
+++ b/app/views/custom/probes/plaza/thanks.html.erb
@@ -30,24 +30,19 @@
       </p>
     </div>
 
-    <div class="small-12 medium-6 large-7 column">
-      <aside>
-        <div class="sidebar-divider"></div>
-        <h3><%= t("probes.show.share") %></h3>
-        <div class="social-share-full">
-          <%= social_share_button_tag("#{@probe_option.name} #{setting['twitter_hashtag']}") %>
-          <a href="whatsapp://send?text=<%= CGI.escape(@probe_option.name) %>&nbsp;<%= plaza_probe_option_url(@probe_option) %>" data-action="share/whatsapp/share">
-            <span class="icon-whatsapp whatsapp"></span>
-            <span class="show-for-sr"><%= t("social.whatsapp") %></span>
-          </a>
-        </div>
-      </aside>
+    <aside class="small-12 medium-6 large-7 column">
+      <%= render partial: 'shared/social_share', locals: {
+        share_title: t("probes.show.share"),
+        title: @probe_option.name,
+        url: plaza_probe_option_url(@probe_option),
+        description: @probe_option.name
+      } %>
 
       <div class="callout success margin-top">
         <p>Tu voto ha sido recibido, mientras esté el proceso abierto puedes cambiarlo en cualquier momento.</p>
         <p><small>* Las cinco plazas con mayor puntuación obtienen de 5 a 1 punto respectivamente, que se sumarán a los puntos del jurado para esta primera preselección. Pasada la fase de preselección, las dos plazas finalistas serán votadas por la ciudadanía, que decidirá directamente cuál de las dos será la ganadora. Puedes <a href="http://www.coam.org/media/Default%20Files/servicios/concursos/concursos_ocam/2016/plaza_espania/160617_bases_plaza_espana.pdf" target="_blank" title="<%= t("shared.target_blank_html") %>">consultar toda la información</a> sobre el jurado y el proceso.</small></p>
         <p><small>** El jurado está evaluando que todos los proyectos cumplan los requisitos exigidos, incluyendo los criterios ciudadanos aprobados. En caso de que alguno no los cumpla y sea descalificado, se informará por correo electrónico a sus votantes. Puedes cambiar tu voto hasta el último día de votación. En ningún caso pasará a la siguiente fase ninguna propuesta que no cumpla las bases adecuadamente, se detecte previamente o no.</small></p>
       </div>
-    </div>
+    </aside>
   </div>
 <% end %>

--- a/app/views/legislation/proposals/_featured_votes.html.erb
+++ b/app/views/legislation/proposals/_featured_votes.html.erb
@@ -37,7 +37,11 @@
   <% if voted_for?(@featured_proposals_votes, proposal) %>
     <% if setting['twitter_handle'] %>
       <div class="share-supported">
-        <%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+        <%= render partial: 'shared/social_share', locals: {
+          title: proposal.title,
+          url: proposal_url(proposal),
+          description: proposal.summary
+        } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/legislation/proposals/_votes.html.erb
+++ b/app/views/legislation/proposals/_votes.html.erb
@@ -72,7 +72,11 @@
 
   <% if voted_for?(@legislation_proposal_votes, proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+      <%= render partial: 'shared/social_share', locals: {
+          title: proposal.title,
+          url: proposal_url(proposal),
+          description: proposal.summary
+      } %>
     </div>
   <% end %>
 </div>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -37,7 +37,11 @@
   <% if voted_for?(@featured_proposals_votes, proposal) %>
     <% if setting['twitter_handle'] %>
       <div class="share-supported">
-        <%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+        <%= render partial: 'shared/social_share', locals: {
+          title: proposal.title,
+          url: proposal_url(proposal),
+          description: proposal.summary
+        } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -79,7 +79,11 @@
 
   <% if voted_for?(@proposal_votes, proposal) && setting['twitter_handle'] %>
     <div class="share-supported">
-      <%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
+      <%= render partial: 'shared/social_share', locals: {
+          title: proposal.title,
+          url: proposal_url(proposal),
+          description: proposal.summary
+      } %>
     </div>
   <% end %>
 </div>

--- a/app/views/spending_proposals/_votes.html.erb
+++ b/app/views/spending_proposals/_votes.html.erb
@@ -39,8 +39,10 @@
   <% end %>
 
   <% if user_voted_for && setting['twitter_handle'] %>
-    <div class="share-supported">
-      <%= social_share_button_tag("#{spending_proposal.title} #{setting['twitter_hashtag']}", url: spending_proposal_url(spending_proposal), via: setting['twitter_handle']) %>
-    </div>
+    <%= render partial: 'shared/social_share', locals: {
+      title: spending_proposal.title,
+      url: spending_proposal_url(spending_proposal),
+      description: spending_proposal.title
+    } %>
   <% end %>
 </div>


### PR DESCRIPTION
References
==========
**Issues**:
- https://github.com/AyuntamientoMadrid/consul/issues/1338
- https://github.com/AyuntamientoMadrid/consul/issues/1245

Objectives
==========

Replaces hardcoded social share button tag with correct partial. For example, replace:

```
<%= social_share_button_tag("#{proposal.title} #{setting['twitter_hashtag']}", url: proposal_url(proposal), via: setting['twitter_handle']) %>
```
using the correct `shared/social_share` partial:

```
<%= render partial: 'shared/social_share', locals: {
    title: proposal.title,
    url: proposal_url(proposal),
    description: proposal.summary
} %>
```