### PR TITLE
Revert "Fix incorrect URL generation for attachments (documents)"

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,7 @@
 class Document < ActiveRecord::Base
   include DocumentsHelper
   include DocumentablesHelper
-  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:basename.:extension",
+  has_attached_file :attachment, url: "/system/:class/:prefix/:style/:hash.:extension",
                                  hash_data: ":class/:style/:custom_hash_data",
                                  use_timestamp: false,
                                  hash_secret: Rails.application.secrets.secret_key_base


### PR DESCRIPTION
Reverts AyuntamientoMadrid/consul#1334

Sorry @aitbw but still this is not the solution, this fixes links to Documents created previously to the problem (possible october) but breaks document urls for the ones created after the problem.

I'm taking over the associated issue