### PR TITLE
Replace valuators_allowed setting for checking current budget phase

### DIFF
--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -100,7 +100,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def restrict_access
-      unless current_user.administrator? || Setting['feature.budgets.valuators_allowed'].present?
+      unless current_user.administrator? || current_budget.valuating?
         raise ActionController::RoutingError.new('Not Found')
       end
     end

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -37,7 +37,6 @@ section "Creating Settings" do
   Setting.create(key: 'feature.spending_proposal_features.open_results_page', value: nil)
 
   Setting.create(key: 'feature.budgets', value: "true")
-  Setting.create(key: 'feature.budgets.valuators_allowed', value: "true")
   Setting.create(key: 'feature.twitter_login', value: "true")
   Setting.create(key: 'feature.facebook_login', value: "true")
   Setting.create(key: 'feature.google_login', value: "true")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -327,7 +327,6 @@ FactoryBot.define do
 
   factory :budget_investment, class: 'Budget::Investment' do
     sequence(:title) { |n| "Budget Investment #{n} title" }
-    association :heading, factory: :budget_heading
     association :author, factory: :user
     description          'Spend money on this'
     price                10
@@ -335,6 +334,12 @@ FactoryBot.define do
     skip_map             '1'
     terms_of_service     '1'
     incompatible          false
+
+    before(:create) do |investment|
+      investment.budget = create(:budget) unless investment.budget.present?
+      investment.group = create(:budget_group, budget: investment.budget) unless investment.group.present?
+      investment.heading = create(:budget_heading, group: investment.group) unless investment.heading.present?
+    end
 
     trait :with_confidence_score do
       before(:save) { |i| i.calculate_confidence_score }

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1230,7 +1230,7 @@ feature 'Admin budget investments' do
     end
 
     scenario "Unmark as visible to valuator", :js do
-      Setting['feature.budgets.valuators_allowed'] = true
+      budget.update(phase: 'valuating')
 
       valuator = create(:valuator)
       admin = create(:administrator)

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -404,15 +404,18 @@ feature 'Admin budget investments' do
       streets = create(:budget_heading, group: group_2)
 
       [2, 4, 90, 100, 200, 300].each do |n|
-        create(:budget_investment, heading: parks, cached_votes_up: n, title: "Park with #{n} supports")
+        create(:budget_investment, heading: parks, budget: budget,
+                                  cached_votes_up: n, title: "Park with #{n} supports")
       end
 
       [21, 31, 51, 81, 91, 101].each do |n|
-        create(:budget_investment, heading: roads, cached_votes_up: n, title: "Road with #{n} supports")
+        create(:budget_investment, heading: roads, budget: budget,
+                                   cached_votes_up: n, title: "Road with #{n} supports")
       end
 
       [3, 10, 30, 33, 44, 55].each do |n|
-        create(:budget_investment, heading: streets, cached_votes_up: n, title: "Street with #{n} supports")
+        create(:budget_investment, heading: streets, budget: budget,
+                                  cached_votes_up: n, title: "Street with #{n} supports")
       end
 
       visit admin_budget_budget_investments_path(budget)
@@ -825,11 +828,11 @@ feature 'Admin budget investments' do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
 
-      budget_investment1 = create(:budget_investment, heading: heading)
+      budget_investment1 = create(:budget_investment, heading: heading, budget: budget)
       budget_investment1.set_tag_list_on(:valuation, 'Education, Health')
       budget_investment1.save
 
-      budget_investment2 = create(:budget_investment, heading: heading)
+      budget_investment2 = create(:budget_investment, heading: heading, budget: budget)
 
       visit edit_admin_budget_budget_investment_path(budget_investment2.budget, budget_investment2)
 
@@ -846,7 +849,7 @@ feature 'Admin budget investments' do
     end
 
     scenario "Adds non existent valuation tags" do
-      budget_investment = create(:budget_investment)
+      budget_investment = create(:budget_investment, budget: budget)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
       click_link 'Edit classification'
@@ -872,11 +875,11 @@ feature 'Admin budget investments' do
       heading1 = create(:budget_heading, group: group1)
       heading2 = create(:budget_heading, group: group2)
 
-      budget_investment1 = create(:budget_investment, heading: heading1)
+      budget_investment1 = create(:budget_investment, heading: heading1, budget: budget1)
       budget_investment1.set_tag_list_on(:valuation, 'Education 2017')
       budget_investment1.save
 
-      budget_investment2 = create(:budget_investment, heading: heading2)
+      budget_investment2 = create(:budget_investment, heading: heading2, budget: budget2)
       budget_investment2.set_tag_list_on(:valuation, 'Education 2018')
       budget_investment2.save
 
@@ -1205,8 +1208,8 @@ feature 'Admin budget investments' do
     let(:group) { create(:budget_group, budget: budget) }
     let(:heading) { create(:budget_heading, group: group) }
 
-    let(:investment1) { create(:budget_investment, heading: heading) }
-    let(:investment2) { create(:budget_investment, heading: heading) }
+    let(:investment1) { create(:budget_investment, heading: heading, budget: budget) }
+    let(:investment2) { create(:budget_investment, heading: heading, budget: budget) }
 
     scenario "Mark as visible to valuator", :js do
       investment1.valuators << valuator
@@ -1238,8 +1241,8 @@ feature 'Admin budget investments' do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group)
 
-      investment1 = create(:budget_investment, heading: heading, visible_to_valuators: true)
-      investment2 = create(:budget_investment, heading: heading, visible_to_valuators: true)
+      investment1 = create(:budget_investment, heading: heading, visible_to_valuators: true, budget: budget)
+      investment2 = create(:budget_investment, heading: heading, visible_to_valuators: true, budget: budget)
 
       investment1.valuators << valuator
       investment2.valuators << valuator

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -123,7 +123,7 @@ feature 'Admin budgets' do
     end
 
     scenario 'Try to destroy a budget with investments' do
-      create(:budget_investment, heading: heading)
+      create(:budget_investment, heading: heading, budget: budget)
 
       visit admin_budgets_path
       click_link 'Edit budget'
@@ -192,11 +192,11 @@ feature 'Admin budgets' do
       group = create(:budget_group, budget: budget)
       heading = create(:budget_heading, group: group, price: 4)
       unselected = create(:budget_investment, :unselected, heading: heading, price: 1,
-                                                           ballot_lines_count: 3)
+                                                           ballot_lines_count: 3, budget: budget)
       winner = create(:budget_investment, :winner, heading: heading, price: 3,
-                                                   ballot_lines_count: 2)
+                                                   ballot_lines_count: 2, budget: budget)
       selected = create(:budget_investment, :selected, heading: heading, price: 2,
-                                                       ballot_lines_count: 1)
+                                                       ballot_lines_count: 1, budget: budget)
 
       visit edit_admin_budget_path(budget)
       click_link 'Calculate Winner Investments'

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -53,11 +53,16 @@ feature 'Ballots' do
         district_heading1 = create(:budget_heading, group: districts, name: "District 1")
         district_heading2 = create(:budget_heading, group: districts, name: "District 2")
 
-        city_investment1      = create(:budget_investment, :selected, heading: city_heading1)
-        city_investment2      = create(:budget_investment, :selected, heading: city_heading1)
-        district1_investment1 = create(:budget_investment, :selected, heading: district_heading1)
-        district1_investment2 = create(:budget_investment, :selected, heading: district_heading1)
-        district2_investment1 = create(:budget_investment, :selected, heading: district_heading2)
+        city_investment1      = create(:budget_investment, :selected, heading: city_heading1,
+                                                                      budget: budget)
+        city_investment2      = create(:budget_investment, :selected, heading: city_heading1,
+                                                                      budget: budget)
+        district1_investment1 = create(:budget_investment, :selected, heading: district_heading1,
+                                                                      budget: budget)
+        district1_investment2 = create(:budget_investment, :selected, heading: district_heading1,
+                                                                      budget: budget)
+        district2_investment1 = create(:budget_investment, :selected, heading: district_heading2,
+                                                                      budget: budget)
 
         visit budget_path(budget)
         click_link "City"
@@ -89,7 +94,8 @@ feature 'Ballots' do
         district_heading1 = create(:budget_heading, group: districts, name: "District 1")
         district_heading2 = create(:budget_heading, group: districts, name: "District 2")
 
-        city_investment = create(:budget_investment, :selected, heading: city_heading)
+        city_investment = create(:budget_investment, :selected, heading: city_heading,
+                                                                budget: budget)
 
         visit budget_path(budget)
         click_link "City"
@@ -102,8 +108,10 @@ feature 'Ballots' do
     context "Adding and Removing Investments" do
 
       scenario "Add a investment", :js do
-        investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
-        investment2 = create(:budget_investment, :selected, heading: new_york, price: 20000)
+        investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000,
+                                                            budget: budget)
+        investment2 = create(:budget_investment, :selected, heading: new_york, price: 20000,
+                                                            budget: budget)
 
         visit budget_path(budget)
         click_link "States"
@@ -131,7 +139,8 @@ feature 'Ballots' do
       end
 
       scenario "Removing a investment", :js do
-        investment = create(:budget_investment, :selected, heading: new_york, price: 10000)
+        investment = create(:budget_investment, :selected, heading: new_york, price: 10000,
+                                                           budget: budget)
         ballot = create(:budget_ballot, user: user, budget: budget)
         ballot.investments << investment
 
@@ -167,13 +176,19 @@ feature 'Ballots' do
     context "Balloting in multiple headings" do
 
       scenario "Independent progress bar for headings", :js do
-        city_heading      = create(:budget_heading, group: city,      name: "All city",   price: 10000000)
-        district_heading1 = create(:budget_heading, group: districts, name: "District 1", price: 1000000)
-        district_heading2 = create(:budget_heading, group: districts, name: "District 2", price: 2000000)
+        city_heading      = create(:budget_heading, group: city,      name: "All city",
+                                                    price: 10000000)
+        district_heading1 = create(:budget_heading, group: districts, name: "District 1",
+                                                    price: 1000000)
+        district_heading2 = create(:budget_heading, group: districts, name: "District 2",
+                                                    price: 2000000)
 
-        investment1 = create(:budget_investment, :selected, heading: city_heading,      price: 10000)
-        investment2 = create(:budget_investment, :selected, heading: district_heading1, price: 20000)
-        investment3 = create(:budget_investment, :selected, heading: district_heading2, price: 30000)
+        investment1 = create(:budget_investment, :selected, heading: city_heading, price: 10000,
+                                                            budget: budget)
+        investment2 = create(:budget_investment, :selected, heading: district_heading1,
+                                                            price: 20000, budget: budget)
+        investment3 = create(:budget_investment, :selected, heading: district_heading2,
+                                                            price: 30000, budget: budget)
 
         visit budget_path(budget)
         click_link "City"
@@ -231,7 +246,8 @@ feature 'Ballots' do
     end
 
     scenario "Display progress bar after first vote", :js do
-      investment = create(:budget_investment, :selected, heading: new_york, price: 10000)
+      investment = create(:budget_investment, :selected, heading: new_york, price: 10000,
+                                                         budget: budget)
 
       visit budget_investments_path(budget, heading_id: new_york.id)
 
@@ -246,7 +262,7 @@ feature 'Ballots' do
 
   context "Groups" do
 
-    let!(:investment) { create(:budget_investment, :selected, heading: california) }
+    let!(:investment) { create(:budget_investment, :selected, heading: california, budget: budget) }
 
     background { login_as(user) }
 
@@ -265,8 +281,8 @@ feature 'Ballots' do
     end
 
     scenario 'Change my heading', :js do
-      investment1 = create(:budget_investment, :selected, heading: california)
-      investment2 = create(:budget_investment, :selected, heading: new_york)
+      investment1 = create(:budget_investment, :selected, heading: california, budget: budget)
+      investment2 = create(:budget_investment, :selected, heading: new_york, budget: budget)
 
       ballot = create(:budget_ballot, user: user, budget: budget)
       ballot.investments << investment1
@@ -366,7 +382,7 @@ feature 'Ballots' do
   end
 
   scenario 'Removing investments from ballot', :js do
-    investment = create(:budget_investment, :selected, price: 10, heading: new_york)
+    investment = create(:budget_investment, :selected, price: 10, heading: new_york, budget: budget)
     ballot = create(:budget_ballot, user: user, budget: budget)
     ballot.investments << investment
 
@@ -384,8 +400,10 @@ feature 'Ballots' do
   end
 
   scenario 'Removing investments from ballot (sidebar)', :js do
-    investment1 = create(:budget_investment, :selected, price: 10000, heading: new_york)
-    investment2 = create(:budget_investment, :selected, price: 20000, heading: new_york)
+    investment1 = create(:budget_investment, :selected, price: 10000, heading: new_york,
+                                                        budget: budget)
+    investment2 = create(:budget_investment, :selected, price: 20000, heading: new_york,
+                                                        budget: budget)
 
     ballot = create(:budget_ballot, budget: budget, user: user)
     ballot.investments << investment1 << investment2
@@ -421,7 +439,7 @@ feature 'Ballots' do
   end
 
   scenario 'Back link after removing an investment from Ballot', :js do
-    investment = create(:budget_investment, :selected, heading: new_york, price: 10)
+    investment = create(:budget_investment, :selected, heading: new_york, price: 10, budget: budget)
 
     login_as(user)
     visit budget_investments_path(budget, heading_id: new_york.id)
@@ -445,7 +463,7 @@ feature 'Ballots' do
   context 'Permissions' do
 
     scenario 'User not logged in', :js do
-      investment = create(:budget_investment, :selected, heading: new_york)
+      investment = create(:budget_investment, :selected, heading: new_york, budget: budget)
 
       visit budget_investments_path(budget, heading_id: new_york.id)
 
@@ -458,7 +476,7 @@ feature 'Ballots' do
 
     scenario 'User not verified', :js do
       unverified_user = create(:user)
-      investment = create(:budget_investment, :selected, heading: new_york)
+      investment = create(:budget_investment, :selected, heading: new_york, budget: budget)
 
       login_as(unverified_user)
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -472,7 +490,7 @@ feature 'Ballots' do
 
     scenario 'User is organization', :js do
       org = create(:organization)
-      investment = create(:budget_investment, :selected, heading: new_york)
+      investment = create(:budget_investment, :selected, heading: new_york, budget: budget)
 
       login_as(org.user)
       visit budget_investments_path(budget, heading_id: new_york.id)
@@ -484,7 +502,7 @@ feature 'Ballots' do
     end
 
     scenario 'Unselected investments' do
-      investment = create(:budget_investment, heading: new_york, title: "WTF asdfasfd")
+      investment = create(:budget_investment, heading: new_york, title: "Unselect", budget: budget)
 
       login_as(user)
       visit budget_path(budget)
@@ -509,8 +527,8 @@ feature 'Ballots' do
     end
 
     scenario 'Different district', :js do
-      bi1 = create(:budget_investment, :selected, heading: california)
-      bi2 = create(:budget_investment, :selected, heading: new_york)
+      bi1 = create(:budget_investment, :selected, heading: california, budget: budget)
+      bi2 = create(:budget_investment, :selected, heading: new_york, budget: budget)
 
       ballot = create(:budget_ballot, budget: budget, user: user)
       ballot.investments << bi1
@@ -526,8 +544,8 @@ feature 'Ballots' do
     end
 
     scenario 'Insufficient funds (on page load)', :js do
-      bi1 = create(:budget_investment, :selected, heading: california, price: 600)
-      bi2 = create(:budget_investment, :selected, heading: california, price: 500)
+      bi1 = create(:budget_investment, :selected, heading: california, price: 600, budget: budget)
+      bi2 = create(:budget_investment, :selected, heading: california, price: 500, budget: budget)
 
       ballot = create(:budget_ballot, budget: budget, user: user)
       ballot.investments << bi1
@@ -543,8 +561,8 @@ feature 'Ballots' do
     end
 
     xscenario 'Insufficient funds (added after create)', :js do
-      bi1 = create(:budget_investment, :selected, heading: california, price: 600)
-      bi2 = create(:budget_investment, :selected, heading: california, price: 500)
+      bi1 = create(:budget_investment, :selected, heading: california, price: 600, budget: budget)
+      bi2 = create(:budget_investment, :selected, heading: california, price: 500, budget: budget)
 
       login_as(user)
       visit budget_investments_path(budget, heading_id: california.id)
@@ -566,8 +584,8 @@ feature 'Ballots' do
     end
 
     scenario 'Insufficient funds (removed after destroy)', :js do
-      bi1 = create(:budget_investment, :selected, heading: california, price: 600)
-      bi2 = create(:budget_investment, :selected, heading: california, price: 500)
+      bi1 = create(:budget_investment, :selected, heading: california, price: 600, budget: budget)
+      bi2 = create(:budget_investment, :selected, heading: california, price: 500, budget: budget)
 
       ballot = create(:budget_ballot, budget: budget, user: user)
       ballot.investments << bi1
@@ -594,8 +612,8 @@ feature 'Ballots' do
     end
 
     scenario 'Insufficient funds (removed after destroying from sidebar)', :js do
-      bi1 = create(:budget_investment, :selected, heading: california, price: 600)
-      bi2 = create(:budget_investment, :selected, heading: california, price: 500)
+      bi1 = create(:budget_investment, :selected, heading: california, price: 600, budget: budget)
+      bi2 = create(:budget_investment, :selected, heading: california, price: 500, budget: budget)
 
       ballot = create(:budget_ballot, budget: budget, user: user)
       ballot.investments << bi1
@@ -623,7 +641,8 @@ feature 'Ballots' do
     end
 
     scenario "Edge case voting a non-elegible investment", :js do
-      investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000)
+      investment1 = create(:budget_investment, :selected, heading: new_york, price: 10000,
+                                                          budget: budget)
 
       login_as(user)
       visit budget_path(budget)
@@ -648,7 +667,7 @@ feature 'Ballots' do
     scenario "Balloting is disabled when budget isn't in the balotting phase", :js do
       budget.update(phase: 'accepting')
 
-      bi1 = create(:budget_investment, :selected, heading: california, price: 600)
+      bi1 = create(:budget_investment, :selected, heading: california, price: 600, budget: budget)
 
       login_as(user)
 

--- a/spec/features/budgets/custom_urls_spec.rb
+++ b/spec/features/budgets/custom_urls_spec.rb
@@ -6,7 +6,9 @@ feature 'Custom urls' do
   let(:group)       { create(:budget_group,      name:  "Health",               budget: budget) }
   let!(:heading1)   { create(:budget_heading,    name:  "More hospitals",       group:  group)  }
   let!(:heading2)   { create(:budget_heading,    name:  "More medical centers", group:  group)  }
-  let!(:investment) { create(:budget_investment, title: "Pediatric's hospital", heading: heading1) }
+  let!(:investment) do
+    create(:budget_investment, title: "Pediatric's hospital", heading: heading1, budget: budget)
+  end
 
   scenario "budgets" do
     visit budget_path(budget)

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -24,11 +24,11 @@ feature 'Budget Investments' do
   end
 
   scenario 'Index' do
-    investments = [create(:budget_investment, heading: heading),
-                   create(:budget_investment, heading: heading),
-                   create(:budget_investment, :feasible, heading: heading)]
+    investments = [create(:budget_investment, heading: heading, budget: budget),
+                   create(:budget_investment, heading: heading, budget: budget),
+                   create(:budget_investment, :feasible, heading: heading, budget: budget)]
 
-    unfeasible_investment = create(:budget_investment, :unfeasible, heading: heading)
+    unfeasible_investment = create(:budget_investment, :unfeasible, heading: heading, budget: budget)
 
     visit budget_path(budget)
     click_link "Health"
@@ -46,8 +46,8 @@ feature 'Budget Investments' do
   scenario 'Index should show investment descriptive image only when is defined' do
     Setting['feature.allow_images'] = true
 
-    investment = create(:budget_investment, heading: heading)
-    investment_with_image = create(:budget_investment, heading: heading)
+    investment = create(:budget_investment, heading: heading, budget: budget)
+    investment_with_image = create(:budget_investment, heading: heading, budget: budget)
     image = create(:image, imageable: investment_with_image)
 
     visit budget_investments_path(budget, heading_id: heading.id)
@@ -65,9 +65,9 @@ feature 'Budget Investments' do
   context("Search") do
 
     scenario 'Search by text' do
-      investment1 = create(:budget_investment, heading: heading, title: "Get Schwifty")
-      investment2 = create(:budget_investment, heading: heading, title: "Schwifty Hello")
-      investment3 = create(:budget_investment, heading: heading, title: "Do not show me")
+      investment1 = create(:budget_investment, heading: heading, title: "Get Schwifty", budget: budget)
+      investment2 = create(:budget_investment, heading: heading, title: "Schwifty Hello", budget: budget)
+      investment3 = create(:budget_investment, heading: heading, title: "Do not show me", budget: budget)
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
@@ -88,9 +88,9 @@ feature 'Budget Investments' do
     context "Advanced search" do
 
       scenario "Search by text", :js do
-        bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty")
-        bdgt_invest2 = create(:budget_investment, heading: heading,title: "Schwifty Hello")
-        bdgt_invest3 = create(:budget_investment, heading: heading,title: "Do not show me")
+        bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty", budget: budget)
+        bdgt_invest2 = create(:budget_investment, heading: heading,title: "Schwifty Hello", budget: budget)
+        bdgt_invest3 = create(:budget_investment, heading: heading,title: "Do not show me", budget: budget)
 
         visit budget_investments_path(budget)
 
@@ -114,9 +114,9 @@ feature 'Budget Investments' do
           ana = create :user, official_level: 1
           john = create :user, official_level: 2
 
-          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest3 = create(:budget_investment, heading: heading, author: john)
+          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, author: john, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -137,9 +137,9 @@ feature 'Budget Investments' do
           ana = create :user, official_level: 2
           john = create :user, official_level: 3
 
-          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest3 = create(:budget_investment, heading: heading, author: john)
+          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, author: john, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -160,9 +160,9 @@ feature 'Budget Investments' do
           ana = create :user, official_level: 3
           john = create :user, official_level: 4
 
-          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest3 = create(:budget_investment, heading: heading, author: john)
+          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, author: john, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -183,9 +183,9 @@ feature 'Budget Investments' do
           ana = create :user, official_level: 4
           john = create :user, official_level: 5
 
-          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest3 = create(:budget_investment, heading: heading, author: john)
+          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, author: john, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -206,9 +206,9 @@ feature 'Budget Investments' do
           ana = create :user, official_level: 5
           john = create :user, official_level: 4
 
-          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana)
-          bdgt_invest3 = create(:budget_investment, heading: heading, author: john)
+          bdgt_invest1 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, author: ana, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, author: john, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -232,9 +232,9 @@ feature 'Budget Investments' do
         context "Predefined date ranges" do
 
           scenario "Last day", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 1.minute.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 1.hour.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 1.minute.ago, budget: budget)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 1.hour.ago, budget: budget)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 2.days.ago, budget: budget)
 
             visit budget_investments_path(budget)
 
@@ -252,9 +252,9 @@ feature 'Budget Investments' do
           end
 
           scenario "Last week", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 1.day.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 5.days.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 8.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 1.day.ago, budget: budget)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 5.days.ago, budget: budget)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 8.days.ago, budget: budget)
 
             visit budget_investments_path(budget)
 
@@ -272,9 +272,9 @@ feature 'Budget Investments' do
           end
 
           scenario "Last month", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 10.days.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 20.days.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 33.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 10.days.ago, budget: budget)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 20.days.ago, budget: budget)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 33.days.ago, budget: budget)
 
             visit budget_investments_path(budget)
 
@@ -292,9 +292,9 @@ feature 'Budget Investments' do
           end
 
           scenario "Last year", :js do
-            bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 300.days.ago)
-            bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 350.days.ago)
-            bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 370.days.ago)
+            bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 300.days.ago, budget: budget)
+            bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 350.days.ago, budget: budget)
+            bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 370.days.ago, budget: budget)
 
             visit budget_investments_path(budget)
 
@@ -314,9 +314,9 @@ feature 'Budget Investments' do
         end
 
         scenario "Search by custom date range", :js do
-          bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 3.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 9.days.ago)
+          bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 2.days.ago, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 3.days.ago, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 9.days.ago, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -336,9 +336,9 @@ feature 'Budget Investments' do
         end
 
         scenario "Search by custom invalid date range", :js do
-          bdgt_invest1 = create(:budget_investment, heading: heading,created_at: 2.days.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading,created_at: 3.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading,created_at: 9.days.ago)
+          bdgt_invest1 = create(:budget_investment, heading: heading, created_at: 2.days.ago, budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading, created_at: 3.days.ago, budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading, created_at: 9.days.ago, budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -361,9 +361,14 @@ feature 'Budget Investments' do
           ana  = create :user, official_level: 1
           john = create :user, official_level: 1
 
-          bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty",   author: ana,  created_at: 1.minute.ago)
-          bdgt_invest2 = create(:budget_investment, heading: heading,title: "Hello Schwifty", author: john, created_at: 2.days.ago)
-          bdgt_invest3 = create(:budget_investment, heading: heading,title: "Save the forest")
+          bdgt_invest1 = create(:budget_investment, heading: heading,title: "Get Schwifty",
+                                                    author: ana, created_at: 1.minute.ago,
+                                                    budget: budget)
+          bdgt_invest2 = create(:budget_investment, heading: heading,title: "Hello Schwifty",
+                                                    author: john, created_at: 2.days.ago,
+                                                    budget: budget)
+          bdgt_invest3 = create(:budget_investment, heading: heading,title: "Save the forest",
+                                                    budget: budget)
 
           visit budget_investments_path(budget)
 
@@ -425,10 +430,11 @@ feature 'Budget Investments' do
   context("Filters") do
 
     scenario 'by unfeasibility' do
-      investment1 = create(:budget_investment, :unfeasible, heading: heading, valuation_finished: true)
-      investment2 = create(:budget_investment, :feasible, heading: heading)
-      investment3 = create(:budget_investment, heading: heading)
-      investment4 = create(:budget_investment, :feasible, heading: heading)
+      investment1 = create(:budget_investment, :unfeasible, heading: heading, budget: budget,
+                                                            valuation_finished: true)
+      investment2 = create(:budget_investment, :feasible, heading: heading, budget: budget)
+      investment3 = create(:budget_investment, heading: heading, budget: budget)
+      investment4 = create(:budget_investment, :feasible, heading: heading, budget: budget)
 
       visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unfeasible")
 
@@ -478,7 +484,7 @@ feature 'Budget Investments' do
     before { budget.update(phase: 'selecting') }
 
     scenario "Default order is random" do
-      10.times { create(:budget_investment) }
+      10.times { create(:budget_investment, budget: budget) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
       order = all(".budget-investment h3").collect {|i| i.text }
@@ -490,7 +496,7 @@ feature 'Budget Investments' do
     end
 
     scenario "Random order after another order" do
-      10.times { create(:budget_investment) }
+      10.times { create(:budget_investment, budget: budget) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
       click_link "highest rated"
@@ -506,7 +512,7 @@ feature 'Budget Investments' do
 
     scenario 'Random order maintained with pagination' do
       per_page = Kaminari.config.default_per_page
-      (per_page + 2).times { create(:budget_investment, heading: heading) }
+      (per_page + 2).times { create(:budget_investment, heading: heading, budget: budget) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
@@ -523,7 +529,7 @@ feature 'Budget Investments' do
     end
 
     scenario 'Random order maintained when going back from show' do
-      10.times { |i| create(:budget_investment, heading: heading) }
+      10.times { |i| create(:budget_investment, heading: heading, budget: budget) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
@@ -537,7 +543,7 @@ feature 'Budget Investments' do
     end
 
     scenario "Investments are not repeated with random order" do
-      12.times { create(:budget_investment, heading: heading) }
+      12.times { create(:budget_investment, heading: heading, budget: budget) }
       # 12 instead of per_page + 2 because in each page there are 10 (in this case), not 25
 
       visit budget_investments_path(budget, order: 'random')
@@ -555,11 +561,14 @@ feature 'Budget Investments' do
     end
 
     scenario 'Proposals are ordered by confidence_score' do
-      best_proposal = create(:budget_investment, heading: heading, title: 'Best proposal')
+      best_proposal = create(:budget_investment, heading: heading, title: 'Best proposal',
+                                                 budget: budget)
       best_proposal.update_column(:confidence_score, 10)
-      worst_proposal = create(:budget_investment, heading: heading, title: 'Worst proposal')
+      worst_proposal = create(:budget_investment, heading: heading, title: 'Worst proposal',
+                                                  budget: budget)
       worst_proposal.update_column(:confidence_score, 2)
-      medium_proposal = create(:budget_investment, heading: heading, title: 'Medium proposal')
+      medium_proposal = create(:budget_investment, heading: heading, title: 'Medium proposal',
+                                                   budget: budget)
       medium_proposal.update_column(:confidence_score, 5)
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -576,7 +585,9 @@ feature 'Budget Investments' do
     end
 
     scenario 'Each user has a different and consistent random budget investment order when random_seed is disctint' do
-      (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
+      (Kaminari.config.default_per_page * 1.3).to_i.times do
+        create(:budget_investment, heading: heading, budget: budget)
+      end
 
       r1 = 1
       r2 = 2
@@ -615,7 +626,9 @@ feature 'Budget Investments' do
     end
 
     scenario 'Each user has a equal and consistent budget investment order when the random_seed is equal' do
-      (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
+      (Kaminari.config.default_per_page * 1.3).to_i.times do
+        create(:budget_investment, heading: heading, budget: budget)
+      end
 
       in_browser(:one) do
         visit budget_investments_path(budget, heading: heading, random_seed: '1')
@@ -634,11 +647,11 @@ feature 'Budget Investments' do
       voter = create(:user, :level_two)
       login_as(voter)
 
-      10.times { create(:budget_investment, heading: heading) }
+      10.times { create(:budget_investment, heading: heading, budget: budget) }
 
       voted_investments = []
       10.times do
-        investment = create(:budget_investment, heading: heading)
+        investment = create(:budget_investment, heading: heading, budget: budget)
         create(:vote, votable: investment, voter: voter)
         voted_investments << investment
       end
@@ -815,7 +828,7 @@ feature 'Budget Investments' do
     user = create(:user)
     login_as(user)
 
-    investment = create(:budget_investment, heading: heading)
+    investment = create(:budget_investment, heading: heading, budget: budget)
 
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
@@ -831,7 +844,9 @@ feature 'Budget Investments' do
 
   context "Show Investment's price & cost explanation" do
 
-    let(:investment) { create(:budget_investment, :selected_with_price, heading: heading) }
+    let(:investment) do
+      create(:budget_investment, :selected_with_price, heading: heading, budget: budget)
+    end
 
     context "When investment with price is selected" do
 
@@ -890,7 +905,7 @@ feature 'Budget Investments' do
   scenario 'Can access the community' do
     Setting['feature.community'] = true
 
-    investment = create(:budget_investment, heading: heading)
+    investment = create(:budget_investment, heading: heading, budget: budget)
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
     expect(page).to have_content "Access the community"
 
@@ -900,13 +915,13 @@ feature 'Budget Investments' do
   scenario 'Can not access the community' do
     Setting['feature.community'] = false
 
-    investment = create(:budget_investment, heading: heading)
+    investment = create(:budget_investment, heading: heading, budget: budget)
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
     expect(page).not_to have_content "Access the community"
   end
 
   scenario "Don't display flaggable buttons" do
-    investment = create(:budget_investment, heading: heading)
+    investment = create(:budget_investment, heading: heading, budget: budget)
 
     visit budget_investment_path(budget_id: budget.id, id: investment.id)
 
@@ -914,7 +929,7 @@ feature 'Budget Investments' do
   end
 
   scenario "Show back link contains heading id" do
-    investment = create(:budget_investment, heading: heading)
+    investment = create(:budget_investment, heading: heading, budget: budget)
     visit budget_investment_path(budget, investment)
 
     expect(page).to have_link "Go back", href: budget_investments_path(budget, heading_id: investment.heading)
@@ -986,7 +1001,7 @@ feature 'Budget Investments' do
 
   scenario "Show milestones", :js do
     user = create(:user)
-    investment = create(:budget_investment)
+    investment = create(:budget_investment, budget: budget)
     create(:budget_investment_milestone, investment: investment,
                                          description: "Last milestone with a link to https://consul.dev",
                                          publication_date: Date.tomorrow)
@@ -1014,7 +1029,7 @@ feature 'Budget Investments' do
 
   scenario "Show no_milestones text", :js do
     user = create(:user)
-    investment = create(:budget_investment)
+    investment = create(:budget_investment, budget: budget)
 
     login_as(user)
     visit budget_investment_path(budget_id: investment.budget.id, id: investment.id)
@@ -1062,7 +1077,7 @@ feature 'Budget Investments' do
     scenario "Admin cannot destroy budget investments" do
       admin = create(:administrator)
       user = create(:user, :level_two)
-      investment = create(:budget_investment, heading: heading, author: user)
+      investment = create(:budget_investment, heading: heading, author: user, budget: budget)
 
       login_as(admin.user)
       visit user_path(user)
@@ -1074,7 +1089,7 @@ feature 'Budget Investments' do
 
     scenario "Author can destroy while on the accepting phase" do
       user = create(:user, :level_two)
-      sp1 = create(:budget_investment, heading: heading, price: 10000, author: user)
+      sp1 = create(:budget_investment, heading: heading, price: 10000, author: user, budget: budget)
 
       login_as(user)
       visit user_path(user, tab: :budget_investments)
@@ -1100,8 +1115,10 @@ feature 'Budget Investments' do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
-        carabanchel_investment = create(:budget_investment, :selected, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, :selected, heading: salamanca)
+        carabanchel_investment = create(:budget_investment, :selected, heading: carabanchel,
+                                                                       budget: budget)
+        salamanca_investment   = create(:budget_investment, :selected, heading: salamanca,
+                                                                       budget: budget)
 
         login_as(author)
         visit budget_investments_path(budget, heading_id: carabanchel.id)
@@ -1115,8 +1132,8 @@ feature 'Budget Investments' do
         carabanchel = create(:budget_heading, group: group)
         salamanca   = create(:budget_heading, group: group)
 
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
+        carabanchel_investment = create(:budget_investment, heading: carabanchel, budget: budget)
+        salamanca_investment   = create(:budget_investment, heading: salamanca, budget: budget)
 
         create(:vote, votable: carabanchel_investment, voter: author)
 
@@ -1135,8 +1152,9 @@ feature 'Budget Investments' do
         another_heading1 = create(:budget_heading, group: group2)
         another_heading2 = create(:budget_heading, group: group2)
 
-        carabanchel_investment   = create(:budget_investment, heading: carabanchel)
-        another_group_investment = create(:budget_investment, heading: another_heading1)
+        carabanchel_investment   = create(:budget_investment, heading: carabanchel, budget: budget)
+        another_group_investment = create(:budget_investment, heading: another_heading1,
+                                                              budget: budget)
 
         create(:vote, votable: carabanchel_investment, voter: author)
 
@@ -1149,7 +1167,7 @@ feature 'Budget Investments' do
       end
 
       scenario "When supporting in a group with a single heading", :js do
-        all_city_investment = create(:budget_investment, heading: heading)
+        all_city_investment = create(:budget_investment, heading: heading, budget: budget)
 
         login_as(author)
         visit budget_investments_path(budget, heading_id: heading.id)
@@ -1222,8 +1240,8 @@ feature 'Budget Investments' do
 
     scenario "Index" do
       user = create(:user, :level_two)
-      sp1 = create(:budget_investment, :selected, heading: heading, price: 10000)
-      sp2 = create(:budget_investment, :selected, heading: heading, price: 20000)
+      sp1 = create(:budget_investment, :selected, heading: heading, price: 10000, budget: budget)
+      sp2 = create(:budget_investment, :selected, heading: heading, price: 20000, budget: budget)
 
       login_as(user)
       # visit budget_path(budget)
@@ -1246,11 +1264,17 @@ feature 'Budget Investments' do
     end
 
     scenario 'Order by cost (only when balloting)' do
-      mid_investment = create(:budget_investment, :selected, heading: heading, title: 'Build a nice house', price: 1000)
+      mid_investment = create(:budget_investment, :selected, heading: heading,
+                                                             title: 'Build a nice house',
+                                                             price: 1000, budget: budget)
       mid_investment.update_column(:confidence_score, 10)
-      low_investment = create(:budget_investment, :selected, heading: heading, title: 'Build an ugly house', price: 1000)
+      low_investment = create(:budget_investment, :selected, heading: heading,
+                                                             title: 'Build an ugly house',
+                                                             price: 1000, budget: budget)
       low_investment.update_column(:confidence_score, 5)
-      high_investment = create(:budget_investment, :selected, heading: heading, title: 'Build a skyscraper', price: 20000)
+      high_investment = create(:budget_investment, :selected, heading: heading,
+                                                              title: 'Build a skyscraper',
+                                                              price: 20000, budget: budget)
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
@@ -1268,7 +1292,7 @@ feature 'Budget Investments' do
 
     scenario "Show" do
       user = create(:user, :level_two)
-      sp1 = create(:budget_investment, :selected, heading: heading, price: 10000)
+      sp1 = create(:budget_investment, :selected, heading: heading, price: 10000, budget: budget)
 
       login_as(user)
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -1297,12 +1321,18 @@ feature 'Budget Investments' do
       carabanchel_heading = create(:budget_heading, group: group, name: "Carabanchel")
       new_york_heading    = create(:budget_heading, group: group, name: "New York")
 
-      sp1 = create(:budget_investment, :selected, price: 1, heading: global_heading)
-      sp2 = create(:budget_investment, :selected, price: 10, heading: global_heading)
-      sp3 = create(:budget_investment, :selected, price: 100, heading: global_heading)
-      sp4 = create(:budget_investment, :selected, price: 1000, heading: carabanchel_heading)
-      sp5 = create(:budget_investment, :selected, price: 10000, heading: carabanchel_heading)
-      sp6 = create(:budget_investment, :selected, price: 100000, heading: new_york_heading)
+      sp1 = create(:budget_investment, :selected, price: 1, heading: global_heading,
+                                                  budget: budget)
+      sp2 = create(:budget_investment, :selected, price: 10, heading: global_heading,
+                                                  budget: budget)
+      sp3 = create(:budget_investment, :selected, price: 100, heading: global_heading,
+                                                  budget: budget)
+      sp4 = create(:budget_investment, :selected, price: 1000, heading: carabanchel_heading,
+                                                  budget: budget)
+      sp5 = create(:budget_investment, :selected, price: 10000, heading: carabanchel_heading,
+                                                  budget: budget)
+      sp6 = create(:budget_investment, :selected, price: 100000, heading: new_york_heading,
+                                                  budget: budget)
 
       login_as(user)
       visit budget_path(budget)
@@ -1362,10 +1392,18 @@ feature 'Budget Investments' do
     end
 
     scenario 'Show unselected budget investments' do
-      investment1 = create(:budget_investment, :unselected, :feasible, heading: heading, valuation_finished: true)
-      investment2 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
-      investment3 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
-      investment4 = create(:budget_investment, :selected,   :feasible, heading: heading, valuation_finished: true)
+      investment1 = create(:budget_investment, :unselected, :feasible, heading: heading,
+                                                                       valuation_finished: true,
+                                                                       budget: budget)
+      investment2 = create(:budget_investment, :selected,   :feasible, heading: heading,
+                                                                       valuation_finished: true,
+                                                                       budget: budget)
+      investment3 = create(:budget_investment, :selected,   :feasible, heading: heading,
+                                                                       valuation_finished: true,
+                                                                       budget: budget)
+      investment4 = create(:budget_investment, :selected,   :feasible, heading: heading,
+                                                                       valuation_finished: true,
+                                                                       budget: budget)
 
       visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unselected")
 
@@ -1409,7 +1447,7 @@ feature 'Budget Investments' do
     end
 
     scenario "Do not display vote button for unselected investments in index" do
-      investment = create(:budget_investment, :unselected, heading: heading)
+      investment = create(:budget_investment, :unselected, heading: heading, budget: budget)
 
       visit budget_investments_path(budget_id: budget.id, heading_id: heading.id, filter: "unselected")
 
@@ -1418,7 +1456,7 @@ feature 'Budget Investments' do
     end
 
     scenario "Do not display vote button for unselected investments in show" do
-      investment = create(:budget_investment, :unselected, heading: heading)
+      investment = create(:budget_investment, :unselected, heading: heading, budget: budget)
 
       visit budget_investment_path(budget, investment)
 
@@ -1430,7 +1468,7 @@ feature 'Budget Investments' do
 
       scenario "Due to heading change" do
         user = create(:user, :level_two)
-        investment = create(:budget_investment, :selected, heading: heading)
+        investment = create(:budget_investment, :selected, heading: heading, budget: budget)
         heading2 = create(:budget_heading, group: group)
 
         ballot = create(:budget_ballot, user: user, budget: budget)
@@ -1451,7 +1489,7 @@ feature 'Budget Investments' do
 
       scenario "Due to being unfeasible" do
         user = create(:user, :level_two)
-        investment = create(:budget_investment, :selected, heading: heading)
+        investment = create(:budget_investment, :selected, heading: heading, budget: budget)
         heading2 = create(:budget_heading, group: group)
 
         ballot = create(:budget_ballot, user: user, budget: budget)
@@ -1479,8 +1517,8 @@ feature 'Budget Investments' do
     scenario "Back from show" do
       heading2 = create(:budget_heading, group: group)
 
-      investment1 = create(:budget_investment, heading: heading)
-      investment2 = create(:budget_investment, heading: heading2)
+      investment1 = create(:budget_investment, heading: heading, budget: budget)
+      investment2 = create(:budget_investment, heading: heading2, budget: budget)
 
       visit budget_investment_path(budget, investment1)
       click_link "Go back"
@@ -1492,9 +1530,15 @@ feature 'Budget Investments' do
   end
 
   context "Minimal view" do
-    let!(:investment1) { create(:budget_investment, heading: heading, tag_list: "Parks") }
-    let!(:investment2) { create(:budget_investment, heading: heading, tag_list: "Parks") }
-    let!(:investment3) { create(:budget_investment, heading: heading, tag_list: "Parks") }
+    let!(:investment1) do
+      create(:budget_investment, heading: heading, tag_list: "Parks", budget: budget)
+    end
+    let!(:investment2) do
+      create(:budget_investment, heading: heading, tag_list: "Parks", budget: budget)
+    end
+    let!(:investment3) do
+      create(:budget_investment, heading: heading, tag_list: "Parks", budget: budget)
+    end
 
     background do
       visit budget_path(budget)
@@ -1520,7 +1564,7 @@ feature 'Budget Investments' do
 
     scenario "Maintain pagination in minimal view" do
       per_page = 10
-      (per_page + 1).times { create(:budget_investment, heading: heading) }
+      (per_page + 1).times { create(:budget_investment, heading: heading, budget: budget) }
 
       visit budget_path(budget)
       click_link heading.group.name

--- a/spec/features/budgets/recommendation_spec.rb
+++ b/spec/features/budgets/recommendation_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 feature 'Recommendations' do
+  let(:budget) { create(:budget) }
+  let(:heading) { create(:budget_heading, group: create(:budget_group, budget: budget)) }
 
   scenario "Create by phase" do
-    heading = create(:budget_heading)
-    budget = heading.budget
 
-    investment_to_select = create(:budget_investment, :feasible, heading: heading)
-    investment_to_ballot = create(:budget_investment, :selected, heading: heading)
+    investment_to_select = create(:budget_investment, :feasible, heading: heading, budget: budget)
+    investment_to_ballot = create(:budget_investment, :selected, heading: heading, budget: budget)
 
     user = create(:user)
     login_as(user)
@@ -48,7 +48,7 @@ feature 'Recommendations' do
   end
 
   scenario "Create (errors)" do
-    investment = create(:budget_investment)
+    investment = create(:budget_investment, budget: budget)
 
     user = create(:user)
     login_as(user)
@@ -67,15 +67,13 @@ feature 'Recommendations' do
     user1 = create(:user)
     user2 = create(:user)
 
-    heading = create(:budget_heading)
+    investment1 = create(:budget_investment, heading: heading, budget: budget)
+    investment2 = create(:budget_investment, heading: heading, budget: budget)
+    investment3 = create(:budget_investment, heading: heading, budget: budget)
 
-    investment1 = create(:budget_investment, heading: heading)
-    investment2 = create(:budget_investment, heading: heading)
-    investment3 = create(:budget_investment, heading: heading)
-
-    recommendation1 = create(:budget_recommendation, user: user1, investment: investment1, budget: heading.budget)
-    recommendation2 = create(:budget_recommendation, user: user1, investment: investment2, budget: heading.budget)
-    recommendation3 = create(:budget_recommendation, user: user2, investment: investment3, budget: heading.budget)
+    recommendation1 = create(:budget_recommendation, user: user1, investment: investment1, budget: budget)
+    recommendation2 = create(:budget_recommendation, user: user1, investment: investment2, budget: budget)
+    recommendation3 = create(:budget_recommendation, user: user2, investment: investment3, budget: budget)
 
     login_as(user2)
     visit user_path(user1)
@@ -93,7 +91,7 @@ feature 'Recommendations' do
     user1 = create(:user)
     user2 = create(:user, :level_two)
 
-    investment = create(:budget_investment, :feasible)
+    investment = create(:budget_investment, :feasible, budget: budget)
     create(:budget_recommendation, budget_id: investment.budget_id, investment: investment, user: user1)
     investment.budget.update(phase: 'selecting')
 
@@ -114,7 +112,7 @@ feature 'Recommendations' do
     user1 = create(:user)
     user2 = create(:user, :level_two)
 
-    investment = create(:budget_investment, :selected)
+    investment = create(:budget_investment, :selected, budget: budget)
     budget = investment.budget
     budget.update!(phase: 'balloting')
     create(:budget_recommendation, budget_id: investment.budget_id, investment: investment, user: user1, phase: 'balloting')
@@ -132,7 +130,7 @@ feature 'Recommendations' do
   end
 
   scenario "Destroy" do
-    investment = create(:budget_investment)
+    investment = create(:budget_investment, budget: budget)
     user = create(:user)
     create(:budget_recommendation, investment: investment, user: user)
 

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -17,9 +17,9 @@ feature 'Votes' do
     feature 'Index' do
 
       scenario "Index shows user votes on proposals" do
-        investment1 = create(:budget_investment, heading: heading)
-        investment2 = create(:budget_investment, heading: heading)
-        investment3 = create(:budget_investment, heading: heading)
+        investment1 = create(:budget_investment, heading: heading, budget: budget)
+        investment2 = create(:budget_investment, heading: heading, budget: budget)
+        investment3 = create(:budget_investment, heading: heading, budget: budget)
         create(:vote, voter: @manuela, votable: investment1, vote_flag: true)
 
         visit budget_investments_path(budget, heading_id: heading.id)

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -9,14 +9,12 @@ feature 'Internal valuation comments on Budget::Investments' do
 
   background do
     Setting['feature.budgets'] = true
-    Setting['feature.budgets.valuators_allowed'] = true
     investment.valuators << valuator_user.valuator
     login_as(valuator_user)
   end
 
   after do
     Setting['feature.budgets'] = nil
-    Setting['feature.budgets.valuators_allowed'] = nil
   end
 
   context 'Show valuation comments' do

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -398,8 +398,7 @@ feature 'Emails' do
     end
 
     scenario "Unfeasible investment" do
-      Setting['feature.budgets.valuators_allowed'] = true
-
+      budget.update(phase: 'valuating')
       investment = create(:budget_investment, author: author, budget: budget)
 
       valuator = create(:valuator)

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -9,7 +9,6 @@ feature 'Valuation budget investments' do
 
   background do
     login_as(valuator.user)
-    Setting['feature.budgets.valuators_allowed'] = true
   end
 
   scenario 'Disabled with a feature flag' do
@@ -437,8 +436,8 @@ feature 'Valuation budget investments' do
       expect(page).to have_content('Only integer numbers', count: 2)
     end
 
-    scenario 'not visible to valuators unless setting enabled' do
-      Setting['feature.budgets.valuators_allowed'] = nil
+    scenario 'not visible to valuators when budget is not valuating' do
+      budget.update(phase: 'publishing_prices')
 
       investment = create(:budget_investment,
                            :visible_to_valuators,
@@ -452,8 +451,8 @@ feature 'Valuation budget investments' do
       to raise_error( ActionController::RoutingError)
     end
 
-    scenario 'visible to admins regardless of setting enabled' do
-      Setting['feature.budgets.valuators_allowed'] = nil
+    scenario 'visible to admins regardless of not being in valuating phase' do
+      budget.update(phase: 'publishing_prices')
 
       user = create(:user)
       admin = create(:administrator, user: user)

--- a/spec/models/budget/ballot/line_spec.rb
+++ b/spec/models/budget/ballot/line_spec.rb
@@ -5,7 +5,9 @@ describe Budget::Ballot::Line do
   let(:budget){ create(:budget) }
   let(:group){ create(:budget_group, budget: budget) }
   let(:heading){ create(:budget_heading, group: group, price: 10000000) }
-  let(:investment){ create(:budget_investment, :selected, price: 5000000, heading: heading) }
+  let(:investment) do
+    create(:budget_investment, :selected, price: 5000000, heading: heading, budget: budget)
+  end
   let(:ballot) { create(:budget_ballot, budget: budget) }
   let(:ballot_line) { build(:budget_ballot_line, ballot: ballot, investment: investment) }
 


### PR DESCRIPTION
References
==========
None

Objectives
==========
Setting['feature.budgets.valuators_allowed'] was bein used to prevent
valuators from editing and valuating investments, as a "switch".

We've budget phases now, and just by checking if current budget phase is
valuating will do the same but without having to remember changing the
setting value.

Visual Changes (if any)
=======================
None

Notes
=====================
We should remember to remove the `Setting['feature.budgets.valuators_allowed']` from PRE and PRO servers manually through console (don't consider creating a rake task for this, although if it was present at consul we should've)