### PR TITLE
Flaky spec: Voter Origin Trying to vote in booth and then in web

### DIFF
--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -4,7 +4,7 @@ feature "Voter" do
 
   context "Origin" do
 
-    let(:poll) { create(:poll, :current) }
+    let(:poll) { create(:poll, :current, starts_at: "2017-12-01", ends_at: "2018-02-01") }
     let(:question) { create(:poll_question, poll: poll) }
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
@@ -12,11 +12,17 @@ feature "Voter" do
     let!(:answer_yes) { create(:poll_question_answer, question: question, title: 'Yes') }
     let!(:answer_no) { create(:poll_question_answer, question: question, title: 'No') }
 
+    before do
+      allow(Date).to receive(:current).and_return Date.new(2018,1,1)
+      allow(Date).to receive(:today).and_return Date.new(2018,1,1)
+      allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
+    end
+
     background do
       create(:geozone, :in_census)
       create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
       booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
     end
 
     scenario "Voting via web - Standard", :js do


### PR DESCRIPTION
References
==========
* **Related Issue:** #1195

Objectives
==========
Fix the flaky that appeared in `spec/features/polls/voter_spec.rb:142`.
### Explain why the test is flaky, or under which conditions/scenario it fails randomly

The problems was that the test was not reaching to the residence verification page, so it couldn't find the select box for the DNI (and that's the error reported in the issue). To figure out what was going on there, I studied the flow that the test follows so that I could find the scenarios where it would crash, and, after doing it, step by step, I determined that the test will fail when:

- There are more than 1 `officer_assignments` (booths) for this user, so the page will redirect to the select booth page, instead to the residence verification page.
- There aren't any `officer_assignments`, so that the user can't even reach the target page (it redirects to the root).

The code that determines that is (this functions are run in `before_action` blocks):
```
# app/controller/officing/base_controller.rb
	[...]

	def load_officer_assignment
      @officer_assignments ||= current_user.poll_officer.officer_assignments.where(date: Time.current.to_date)
    end

    def verify_officer_assignment
      if @officer_assignments.blank?
        redirect_to officing_root_path, notice: t("officing.residence.flash.not_allowed")
      end
    end

    def verify_booth
      return unless current_booth.blank?
      booths = todays_booths_for_officer(current_user.poll_officer)
      case booths.count
      when 0
        redirect_to officing_root_path
      when 1
        session[:booth_id] = booths.first.id
      else
        redirect_to new_officing_booth_path
      end
    end

    [...]

    def todays_booths_for_officer(officer)
      officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
    end
```

After trying to reproduce it (without success), I saw the new piece of information about the probable failing hours, and I realized that the problem could be in the moment of creating the objects. If the `officer_assignments` are created at 23:59:59 and the rest of the test is executed after 00:00:00, the dates for the objects and the `Date.current` (used to check if there are any shifts today) won't be the same, because the shift will be for, lets say, 07/03/2018 and `Date.current` will be 08/03/2018, so, there are no shifts and we find the first scenario described above.

To prove that, I forced in the `factories.rb` the dates of the `officer_assignments` to an earlier date, and it failed in the exact same way as the reported one.


### Explain why your PR fixes it

I stubed the Date and Time clases to force them to give me a date I can control. I set that date (01/01/2018) to the objects that depend on it (`poll_shift`, `officer_assignment` and `polls`). This way, it doesn't matter when the test is executed because for him it will always be the same date.

Thank you to @raul-fuentes  for reminding me about the stubs and mocks :tada:

Visual Changes (if any)
=======================
There aren't, is a flaky.

Notes
=====================
- I added stubs for `Date.current`, `Date.today` and `Time.current` (this are all the functions used to check the shifts and officer assignments) so that they all return a predefined date: 01/01/2018.
- I stubed them in a before block, so that it works for all the test.
- I set that date to the objects that depend on it (`poll_shift`, `officer_assignment` and `polls`). Take into account that `polls` have not a Date, they have a range (defined by `starts_at` and `ends_at`), so I set the `start_at` at 2017/12/01 and the `ends_at` at 2018/02/01.
