### PR TITLE
Flaky spec: booth_spec.rb

### DIFF
--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 feature 'Booth' do
 
+  before do
+    allow(Date).to receive(:current).and_return Date.new(2018,1,1)
+    allow(Date).to receive(:today).and_return Date.new(2018,1,1)
+    allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
+  end
+
   scenario "Officer with no booth assignments today" do
     officer = create(:poll_officer)
 
@@ -12,7 +18,7 @@ feature 'Booth' do
 
   scenario "Officer with booth assignments another day" do
     officer = create(:poll_officer)
-    create(:poll_officer_assignment, officer: officer, date: 1.day.from_now)
+    create(:poll_officer_assignment, officer: officer, date: Date.current + 1.day)
 
     login_through_form_as_officer(officer.user)
 
@@ -26,7 +32,7 @@ feature 'Booth' do
     booth = create(:poll_booth)
 
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 
@@ -45,8 +51,8 @@ feature 'Booth' do
     ba1 = create(:poll_booth_assignment, poll: poll, booth: booth1)
     ba2 = create(:poll_booth_assignment, poll: poll, booth: booth2)
 
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 
@@ -73,9 +79,9 @@ feature 'Booth' do
     ba2 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
     ba3 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
 
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.today)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.today)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.today)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba1, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba2, date: Date.current)
+    create(:poll_officer_assignment, officer: officer, booth_assignment: ba3, date: Date.current)
 
     login_through_form_as_officer(officer.user)
 


### PR DESCRIPTION
References
==========
* **Related Issues:** #1202, #1203 and #1204

Objectives
==========
Fix the flaky that appeared in `spec/features/officing/booth_spec.rb:53`, `spec/features/officing/booth_spec.rb:82` and `spec/features/officing/booth_spec.rb:33`.

### Explain why the test is flaky, or under which conditions/scenario it fails randomly

**(This explanation is the same as in #1342 PR because the problem is exactly the same).**

The problems was that the tests were not reaching to the residence verification page, so they failed in their assertions. To figure out what was going on there, I studied the flow the test follows so that I could find the scenarios where it would crash, and, after doing it, step by step, I determined that the test will fail when:

- There are more than 1 `officer_assignments` (booths) for this user, so the page will redirect to the select booth page.
- There aren't any `officer_assignments`, so that the user can't even reach the target page (it redirects to the root).

The code that determines that is:
```
# app/controller/officing/base_controller.rb
	[...]

	def load_officer_assignment
      @officer_assignments ||= current_user.poll_officer.officer_assignments.where(date: Time.current.to_date)
    end

    def verify_officer_assignment
      if @officer_assignments.blank?
        redirect_to officing_root_path, notice: t("officing.residence.flash.not_allowed")
      end
    end

    def verify_booth
      return unless current_booth.blank?
      booths = todays_booths_for_officer(current_user.poll_officer)
      case booths.count
      when 0
        redirect_to officing_root_path
      when 1
        session[:booth_id] = booths.first.id
      else
        redirect_to new_officing_booth_path
      end
    end

    [...]

    def todays_booths_for_officer(officer)
      officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
    end
```

After trying to reproduce it (without success), I saw the new piece of information about the probable failing hours, and I realized that the problem could be in the moment of creating the objects. If the `officer_assignment` are created at 23:59:59 and the rest of the test is executed after 00:00:00, the dates for the objects and the `Date.current` (used to check if there are any shifts today) won't be the same, because the shift will be for, lets say, 07/03/2018 and Date.current will be 08/03/2018.

To prove that, I forced in the factory the dates of the `officer_assignments` to an earlier date, and it failed in the exact same way as the reported ones.


### Explain why your PR fixes it

I stubed the Date and Time clases to force them to give me a date I can controll. I set that date (01/01/2018) to the objects that depend on it (`poll_shift`, `officer_assignment` and `polls`). This way, it doesn't matter when the test is executed, for it will always be the same date.

Visual Changes (if any)
=======================
There aren't, is a flaky.

Notes
=====================
- I added stubs for `Date.current`, `Date.today` and `Time.current` (this are all the functions used to check the shifts and officer assignments) so that they all return a predefined date: 01/01/2018.
- I stubed them in a before block, so that it works for all the test.
- I set that date to the objects that depend on it (`officer_assignment`).
