### PR TITLE
changed have_content to have_selector, now it waits until javascript shows the text

### DIFF
--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -186,7 +186,7 @@ feature 'Commenting debates' do
 
     click_button 'Publish comment'
 
-    expect(page).to have_content "Can't be blank"
+    expect(page).to have_selector("#new_comment .callout.alert", text: "Can't be blank")
   end
 
   scenario 'Reply', :js do


### PR DESCRIPTION

References
==========
issue https://github.com/AyuntamientoMadrid/consul/issues/1252

Objectives
==========
It solves an flaky error caused by a race condition, javascript loads too slowly so the test continues and fails

Visual Changes (if any)
=======================
None

Notes
=====================
The change is subtle but using have_selector capybara waits until the container is ready, I think that will fix the flaky
