### PR TITLE
Use user locale instead of default locale to format currencies 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
   end
 
   def format_price(number)
-    number_to_currency(number, precision: 0, locale: I18n.default_locale)
+    number_to_currency(number, precision: 0, locale: I18n.locale)
   end
 
   def kaminari_path(url)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,10 +54,6 @@ module ApplicationHelper
     SiteCustomization::ContentBlock.block_for(name, locale)
   end
 
-  def format_price(number)
-    number_to_currency(number, precision: 0, locale: I18n.locale)
-  end
-
   def kaminari_path(url)
     "#{root_url.chomp("\/")}#{url}"
   end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -129,7 +129,7 @@ class Budget < ActiveRecord::Base
   def formatted_amount(amount)
     ActionController::Base.helpers.number_to_currency(amount,
                                                       precision: 0,
-                                                      locale: I18n.default_locale,
+                                                      locale: I18n.locale,
                                                       unit: currency_symbol)
   end
 

--- a/app/views/budgets/results/_results_table.html.erb
+++ b/app/views/budgets/results/_results_table.html.erb
@@ -21,7 +21,7 @@
         <% if results_type == :compatible %>
           <th scope="col" class="text-right">
             <small><%= t("budgets.results.amount_available") %></small><br>
-            <%= format_price(heading_price) %><br>
+            <%= @budget.formatted_amount(heading_price) %><br>
           </th>
         <% end %>
       </tr>
@@ -53,12 +53,12 @@
               <%= investment.ballot_lines_count %>
             </td>
             <td class="text-center">
-              <%= format_price investment.price %>
+              <%= @budget.formatted_amount(investment.price) %>
             </td>
             <% if results_type == :compatible %>
               <td class="small text-right"
-                  title="<%= format_price(amount_available) %> - <%= format_price(investment.price) %>">
-                  <%= format_price amount_available - investment.price %>
+                  title="<%= @budget.formatted_amount(amount_available) %> - <%= @budget.formatted_amount(investment.price) %>">
+                  <%= @budget.formatted_amount(amount_available - investment.price) %>
                   <% amount_available -= investment.price if investment.winner? %>
               </td>
             <% end %>

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -228,4 +228,38 @@ describe Budget do
       expect(finished_phase.prev_phase).to eq(reviewing_ballots_phase)
     end
   end
+
+  describe "#formatted_amount" do
+    after do
+      I18n.locale = :en
+    end
+
+    it "correctly formats Euros with Spanish" do
+      budget.update(currency_symbol: '€')
+      I18n.locale = :es
+
+      expect(budget.formatted_amount(1000.00)).to eq ('1.000 €')
+    end
+
+    it "correctly formats Dollars with Spanish" do
+      budget.update(currency_symbol: '$')
+      I18n.locale = :es
+
+      expect(budget.formatted_amount(1000.00)).to eq ('1.000 $')
+    end
+
+    it "correctly formats Dollars with English" do
+      budget.update(currency_symbol: '$')
+      I18n.locale = :en
+
+      expect(budget.formatted_amount(1000.00)).to eq ('$1,000')
+    end
+
+    it "correctly formats Euros with English" do
+      budget.update(currency_symbol: '€')
+      I18n.locale = :en
+
+      expect(budget.formatted_amount(1000.00)).to eq ('€1,000')
+    end
+  end
 end


### PR DESCRIPTION
References
==========
Consul PR https://github.com/consul/consul/pull/2443

Objectives
==========
All currencies are formatted using the default locale language (I18n.default_locale) instead of the user selected language. We need to use the user language to format currencies

Visual Changes (if any)
=======================
Check original PR 🙏 

Notes
=====================
Deploying to PRE as a feature branch to test!