### PR TITLE
Replace valuators_allowed setting for checking if budget is valuating

### DIFF
--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -100,8 +100,8 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def restrict_access
-      unless current_user.administrator? || Setting['feature.budgets.valuators_allowed'].present?
-        raise ActionController::RoutingError.new('Not Found')
+      unless current_user.administrator? || current_budget.valuating?
+        raise CanCan::AccessDenied.new(I18n.t('valuation.budget_investments.not_in_valuating_phase'))
       end
     end
 

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -74,6 +74,7 @@ en:
       notice:
         valuate: "Dossier updated"
       valuation_comments: Valuation comments
+      not_in_valuating_phase: Investments can only be valuated when Budget is in valuating phase
     spending_proposals:
       index:
         geozone_filter_all: All zones

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -74,6 +74,7 @@ es:
       notice:
         valuate: "Dossier actualizado"
       valuation_comments: Comentarios de evaluación
+      not_in_valuating_phase: Los proyectos sólo pueden ser evaluados cuando el Presupuesto este en fase de evaluación
     spending_proposals:
       index:
         geozone_filter_all: Todos los ámbitos de actuación

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -37,7 +37,6 @@ section "Creating Settings" do
   Setting.create(key: 'feature.spending_proposal_features.open_results_page', value: nil)
 
   Setting.create(key: 'feature.budgets', value: "true")
-  Setting.create(key: 'feature.budgets.valuators_allowed', value: "true")
   Setting.create(key: 'feature.twitter_login', value: "true")
   Setting.create(key: 'feature.facebook_login', value: "true")
   Setting.create(key: 'feature.google_login', value: "true")

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1259,7 +1259,7 @@ feature 'Admin budget investments' do
     end
 
     scenario "Unmark as visible to valuator", :js do
-      Setting['feature.budgets.valuators_allowed'] = true
+      budget.update(phase: 'valuating')
 
       valuator = create(:valuator)
       admin = create(:administrator)

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -5,7 +5,9 @@ feature 'Internal valuation comments on Budget::Investments' do
   let(:valuator_user) { create(:valuator).user }
   let(:admin_user) { create(:administrator).user }
   let(:budget) { create(:budget, :valuating) }
-  let(:investment) { create(:budget_investment, budget: budget) }
+  let(:group) { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group) }
+  let(:investment) { create(:budget_investment, budget: budget, group: group, heading: heading) }
 
   background do
     Setting['feature.budgets'] = true

--- a/spec/features/comments/budget_investments_valuation_spec.rb
+++ b/spec/features/comments/budget_investments_valuation_spec.rb
@@ -9,14 +9,12 @@ feature 'Internal valuation comments on Budget::Investments' do
 
   background do
     Setting['feature.budgets'] = true
-    Setting['feature.budgets.valuators_allowed'] = true
     investment.valuators << valuator_user.valuator
     login_as(valuator_user)
   end
 
   after do
     Setting['feature.budgets'] = nil
-    Setting['feature.budgets.valuators_allowed'] = nil
   end
 
   context 'Show valuation comments' do

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -398,8 +398,7 @@ feature 'Emails' do
     end
 
     scenario "Unfeasible investment" do
-      Setting['feature.budgets.valuators_allowed'] = true
-
+      budget.update(phase: 'valuating')
       investment = create(:budget_investment, author: author, budget: budget)
 
       valuator = create(:valuator)

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -399,7 +399,7 @@ feature 'Emails' do
 
     scenario "Unfeasible investment" do
       budget.update(phase: 'valuating')
-      investment = create(:budget_investment, author: author, budget: budget)
+      investment = create(:budget_investment, author: author, budget: budget, heading: heading)
 
       valuator = create(:valuator)
       investment.valuators << valuator

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -9,7 +9,6 @@ feature 'Valuation budget investments' do
 
   background do
     login_as(valuator.user)
-    Setting['feature.budgets.valuators_allowed'] = true
   end
 
   scenario 'Disabled with a feature flag' do
@@ -437,8 +436,8 @@ feature 'Valuation budget investments' do
       expect(page).to have_content('Only integer numbers', count: 2)
     end
 
-    scenario 'not visible to valuators unless setting enabled' do
-      Setting['feature.budgets.valuators_allowed'] = nil
+    scenario 'not visible to valuators when budget is not valuating' do
+      budget.update(phase: 'publishing_prices')
 
       investment = create(:budget_investment,
                            :visible_to_valuators,
@@ -446,14 +445,13 @@ feature 'Valuation budget investments' do
       investment.valuators << [valuator]
 
       login_as(valuator.user)
-      visit valuation_budget_budget_investment_path(budget, investment)
+      visit edit_valuation_budget_budget_investment_path(budget, investment)
 
-      expect{ click_link 'Edit dossier' }.
-      to raise_error( ActionController::RoutingError)
+      expect(page).to have_content('Investments can only be valuated when Budget is in valuating phase')
     end
 
-    scenario 'visible to admins regardless of setting enabled' do
-      Setting['feature.budgets.valuators_allowed'] = nil
+    scenario 'visible to admins regardless of not being in valuating phase' do
+      budget.update(phase: 'publishing_prices')
 
       user = create(:user)
       admin = create(:administrator, user: user)

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -245,7 +245,10 @@ feature 'Valuation budget investments' do
   feature 'Valuate' do
     let(:admin) { create(:administrator) }
     let(:investment) do
-      create(:budget_investment, :visible_to_valuators, budget: budget, price: nil,
+      group = create(:budget_group, budget: budget)
+      heading = create(:budget_heading, group: group)
+      create(:budget_investment, :visible_to_valuators, heading: heading, group: group,
+                                                        budget: budget, price: nil,
                                                         administrator: admin)
     end
 


### PR DESCRIPTION
References
==========
This is an alternative take to https://github.com/AyuntamientoMadrid/consul/pull/1341/commits

Objectives
==========
Setting['feature.budgets.valuators_allowed'] was bein used to prevent
valuators from editing and valuating investments, as a "switch".

We've budget phases now, and just by checking if current budget phase is
valuating will do the same but without having to remember changing the
setting value.


Visual Changes (if any)
=======================
Explanatory error message appears (instead of a 404 error) when the valuator tries to access dossier edit outside valuation phase

![screen shot 2018-03-12 at 16 40 00](https://user-images.githubusercontent.com/983242/37293623-1f7596f6-2614-11e8-9305-f694a1788708.jpg)

Notes
=====================
We should remember to remove the Setting['feature.budgets.valuators_allowed'] from PRE and PRO servers manually through console (don't consider creating a rake task for this, although if it was present at consul we should've)

