### PR TITLE
added have_selector to ensure the existence of the select residence_document_type

### DIFF
--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -37,6 +37,9 @@ feature 'Residence' do
         click_link "Validate document"
       end
 
+      expect(page).to have_selector('#new_residence .small-12.medium-6',
+                                    text: 'Document type')
+
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "12345678Z"
       fill_in 'residence_year_of_birth', with: '1980'
@@ -52,6 +55,10 @@ feature 'Residence' do
       within("#side_menu") do
         click_link "Validate document"
       end
+
+      expect(page).to have_selector('#new_residence .small-12.medium-6',
+                                    text: 'Document type')
+
 
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "00012345678Z"
@@ -84,6 +91,9 @@ feature 'Residence' do
         click_link "Validate document"
       end
 
+      expect(page).to have_selector('#new_residence .small-12.medium-6',
+                                    text: 'Document type')
+
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "9999999A"
       fill_in 'residence_year_of_birth', with: '1980'
@@ -106,6 +116,9 @@ feature 'Residence' do
       within("#side_menu") do
         click_link "Validate document"
       end
+
+      expect(page).to have_selector('#new_residence .small-12.medium-6',
+                                    text: 'Document type')
 
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "12345678Z"


### PR DESCRIPTION
References
==========
https://github.com/AyuntamientoMadrid/consul/issues/1209

Objectives
==========
It fixes some flakys on spec/features/officing/residence_spec.rb caused by an select wich  shuld be loaded through ajax

Visual Changes (if any)
=======================
none

Notes
=====================
as can be seen [here](http://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FNode%2FActions%3Aselect) is suposed that select waits until the select its available, but the flaky happens when the select is no loaded, so I added some assertions which includes have_selector, and this one I am sure that waits for ajax to finish