### PR TITLE
Flaky spec: Residence Verify booth Unable to find visible css "#officing-booth"

### DIFF
--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -121,11 +121,20 @@ feature 'Residence' do
   end
 
   scenario "Verify booth", :js do
+    allow(Date).to receive_messages(
+                          :current => Date.new(2018,1,1),
+                          :today => Date.new(2018,1,1))
+    allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
+
     booth = create(:poll_booth)
     poll = create(:poll)
 
-    ba = create(:poll_booth_assignment, poll: poll, booth: booth)
-    oa = create(:poll_officer_assignment, officer: officer, booth_assignment: ba)
+    booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+    officer_assignment = create(:poll_officer_assignment,
+                officer: officer,
+                booth_assignment: booth_assignment,
+                date: Date.current)
+
     create(:poll_shift, officer: officer, booth: booth, date: Date.current)
 
     login_as(officer.user)


### PR DESCRIPTION
References
==========
* **Related Issue:** #1210

Objectives
==========
### Explain why the test is flaky, or under which conditions/scenario it fails randomly

(The explanation is the same as in #1342, #1343 and #1349 PRs because the problem is exactly the same).

What happened here was that, at the moment the test tries to reach the residence verification page, the message that it's supposed to appear (announcing the booth choosen for that officer) is not there. In this case, because there is only one booth created, the test should not pass through the page to choose it (and it doesn't pass, in fact), so the booth should be choosen automatically. The problem is that the date of each officer assignment is different from Date.current, so, for the app, there aren't any booths for today and there is no message, what generates the test to fail.

I realized that the problem could be in the moment of creating the officer assignments. If they are created at 23:59:59 and the rest of the test is executed after 00:00:00, the dates for the objects and the `Date.current` (used to check if there are any shifts today) won't be the same, because the shift will be for, lets say, 07/03/2018 and Date.current will be 08/03/2018.

To prove that, I forced in the factory the dates of the `officer_assignments` to an earlier date, and it failed in the exact same way as the reported ones.


### Explain why your PR fixes it

I stubbed the Date and Time clases to force them to give me a date I can controll. I set that date (01/01/2018) to the objects that depend on it. This way, it doesn't matter when the test is executed, for him it will always be the same date.

Visual Changes (if any)
=======================
There aren't, is a flaky.

Notes
=====================
- In this case, I only stubbed them in the failing scenario, because is the only one that depends on dates.
