### PR TITLE
Improve budgets map performance

### DIFF
--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -71,9 +71,18 @@ App.Map =
       $(zoomInputSelector).val ''
       return
 
-    contentPopup = (title,investment,budget) ->
-      content = "<a href='/budgets/#{budget}/investments/#{investment}'>#{title}</a>"
-      return  content
+    openMarkerPopup = (e) ->
+      marker = e.target
+
+      $.ajax 'investments/' + marker.options['id'] + '/json_data',
+        type: 'GET'
+        dataType: 'json'
+        success: (data) ->
+          e.target.bindPopup(getPopupContent(data)).openPopup()
+
+    getPopupContent = (data) ->
+      content = "<a href='/budgets/#{data['budget_id']}/investments/#{data['investment_id']}'>#{data['investment_title']}</a>"
+      return content
 
     mapCenterLatLng  = new (L.LatLng)(mapCenterLatitude, mapCenterLongitude)
     map              = L.map(element.id).setView(mapCenterLatLng, zoom)
@@ -90,8 +99,10 @@ App.Map =
     if addMarkerInvestments
       for i in addMarkerInvestments
         if App.Map.validCoordinates(i)
-          add_marker=createMarker(i.lat , i.long)
-          add_marker.bindPopup(contentPopup(i.investment_title, i.investment_id, i.budget_id))
+          marker = createMarker(i.lat, i.long)
+          marker.options['id'] = i.id
+
+          marker.on 'click', openMarkerPopup
 
   toogleMap: ->
       $('.map').toggle()

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -16,7 +16,7 @@ class BudgetsController < ApplicationController
 
   def index
     @finished_budgets = @budgets.finished.order(created_at: :desc)
-    # @budgets_coordinates = current_budget_map_locations
+    @budgets_coordinates = current_budget_map_locations
   end
 
   private

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -67,15 +67,6 @@ module BudgetsHelper
   end
 
   def current_budget_map_locations
-    current_budget.investments.map do |investment|
-      next unless investment.map_location.present?
-      {
-        lat: investment.map_location.latitude,
-        long: investment.map_location.longitude,
-        investment_title: investment.title,
-        investment_id: investment.id,
-        budget_id: current_budget.id
-      }
-    end.flatten.compact
+    MapLocation.where(investment_id: current_budget.investments).map { |l| l.json_data }
   end
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -24,7 +24,7 @@ module Abilities
       can [:search, :read], Annotation
       can [:read], Budget
       can [:read], Budget::Group
-      can [:read, :print], Budget::Investment
+      can [:read, :print, :json_data], Budget::Investment
       can :read_results, Budget, phase: "finished"
       can :read_stats, Budget, phase: ['reviewing_ballots', 'finished']
       can :new, DirectMessage

--- a/app/models/map_location.rb
+++ b/app/models/map_location.rb
@@ -9,4 +9,12 @@ class MapLocation < ActiveRecord::Base
     latitude.present? && longitude.present? && zoom.present?
   end
 
+  def json_data
+    {
+      id: id,
+      lat: latitude,
+      long: longitude
+    }
+  end
+
 end

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -98,7 +98,7 @@
       </div>
 
       <% unless current_budget.informing? %>
-        <% if false %>
+        <% cache [@budgets_coordinates] do %>
           <div id="map">
             <h3><%= t("budgets.index.map") %></h3>
             <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>

--- a/config/routes/budget.rb
+++ b/config/routes/budget.rb
@@ -17,3 +17,5 @@ scope '/participatory_budget' do
     post :vote, on: :member
   end
 end
+
+get 'investments/:id/json_data', to: :json_data, controller: 'budgets/investments'


### PR DESCRIPTION
References
==========
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1314

Objectives
==========
There's a need to decrease the loading time of the budgets' main page. The problem is how we are getting the information needed to render the investments location map.

The changes I made to achieve it are:
- For the immediate loading of the data, we just need the investments geographical locations, so that's the only information it's realtime rendered with the rest of the page.
- To get the information showed in the popup of each marker, an ajax call is performed when the user clicks in the marker.


