### PR TITLE
Fix valuation heading filters

### DIFF
--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -74,18 +74,25 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
 
     def heading_filters
       investments = @budget.investments.by_valuator(current_user.valuator.try(:id))
-                           .valuation_open.select(:heading_id).all.to_a
+                                       .visible_to_valuators.distinct
+      investment_headings = Budget::Heading.where(id: investments.pluck(:heading_id).uniq)
+                                           .order(name: :asc)
 
-      [ { name: t('valuation.budget_investments.index.headings_filter_all'),
-          id: nil,
-          pending_count: investments.size
-        }
-      ] + Budget::Heading.where(id: investments.map(&:heading_id).uniq).order(name: :asc).collect do |h|
-        { name: h.name,
-          id: h.id,
-          pending_count: investments.count{|x| x.heading_id == h.id}
-        }
-      end
+      all_headings_filter = [
+                              {
+                                name: t('valuation.budget_investments.index.headings_filter_all'),
+                                id: nil,
+                                count: investments.size
+                              }
+                            ]
+
+      filters = investment_headings.inject(all_headings_filter) do |filters, heading|
+                  filters << {
+                               name: heading.name,
+                               id: heading.id,
+                               count: investments.select{|i| i.heading_id == heading.id}.size
+                             }
+                end
     end
 
     def params_for_current_valuator

--- a/app/views/valuation/budget_investments/index.html.erb
+++ b/app/views/valuation/budget_investments/index.html.erb
@@ -9,7 +9,7 @@
       <% slice.each do |filter| %>
         <%= link_to valuation_budget_budget_investments_path(budget_id: @budget.id, heading_id: filter[:id]),
                     class: "#{'active' if params[:heading_id].to_s == filter[:id].to_s}" do %>
-          <%= filter[:name] %>&nbsp;(<%= filter[:pending_count] %>)
+          <%= filter[:name] %> (<%= filter[:count] %>)
         <% end %>
       <% end %>
     </div>

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -91,39 +91,77 @@ feature 'Valuation budget investments' do
 
   scenario "Index filtering by heading", :js do
     group = create(:budget_group, budget: budget)
-    heading1 = create(:budget_heading, name: "District 9", group: group)
-    heading2 = create(:budget_heading, name: "Down to the river", group: group)
-    investment1 = create(:budget_investment, :visible_to_valuators, title: "Realocate visitors",
-                                                                    heading: heading1, group: group,
-                                                                    budget: budget)
-    investment2 = create(:budget_investment, :visible_to_valuators, title: "Destroy the city",
-                                                                    heading: heading2, group: group,
-                                                                    budget: budget)
-    investment1.valuators << valuator
-    investment2.valuators << valuator
+    valuating_heading = create(:budget_heading, name: "Only Valuating", group: group)
+    valuating_finished_heading = create(:budget_heading, name: "Valuating&Finished", group: group)
+    finished_heading = create(:budget_heading, name: "Only Finished", group: group)
+    create(:budget_investment, :visible_to_valuators, title: "Valuating Investment ONE",
+                                                      heading: valuating_heading,
+                                                      group: group,
+                                                      budget: budget,
+                                                      valuators: [valuator])
+    create(:budget_investment, :visible_to_valuators, title: "Valuating Investment TWO",
+                                                      heading: valuating_finished_heading,
+                                                      group: group,
+                                                      budget: budget,
+                                                      valuators: [valuator])
+    create(:budget_investment, :visible_to_valuators, :finished, title: "Finished ONE",
+                                                                 heading: valuating_finished_heading,
+                                                                 group: group,
+                                                                 budget: budget,
+                                                                 valuators: [valuator])
+    create(:budget_investment, :visible_to_valuators, :finished, title: "Finished TWO",
+                                                                 heading: finished_heading,
+                                                                 group: group,
+                                                                 budget: budget,
+                                                                 valuators: [valuator])
 
     visit valuation_budget_budget_investments_path(budget)
 
-    expect(page).to have_link("Realocate visitors")
-    expect(page).to have_link("Destroy the city")
+    expect(page).to have_link("Valuating Investment ONE")
+    expect(page).to have_link("Valuating Investment TWO")
+    expect(page).not_to have_link("Finished ONE")
+    expect(page).not_to have_link("Finished TWO")
 
-    expect(page).to have_content "All headings (2)"
-    expect(page).to have_content "District 9 (1)"
-    expect(page).to have_content "Down to the river (1)"
+    expect(page).to have_link('All headings (4)')
+    expect(page).to have_link('Only Valuating (1)')
+    expect(page).to have_link('Valuating&Finished (2)')
+    expect(page).to have_link('Only Finished (1)')
 
-    click_link "District 9", exact: false
+    click_link "Only Valuating (1)", exact: false
+    expect(page).to have_link("Valuating Investment ONE")
+    expect(page).not_to have_link("Valuating Investment TWO")
+    expect(page).not_to have_link("Finished ONE")
+    expect(page).not_to have_link("Finished TWO")
 
-    expect(page).to have_link("Realocate visitors")
-    expect(page).not_to have_link("Destroy the city")
+    click_link 'Valuation finished'
+    expect(page).not_to have_link("Valuating Investment ONE")
+    expect(page).not_to have_link("Valuating Investment TWO")
+    expect(page).not_to have_link("Finished ONE")
+    expect(page).not_to have_link("Finished TWO")
 
-    click_link "Down to the river", exact: false
+    click_link "Valuating&Finished (2)", exact: false
+    expect(page).not_to have_link("Valuating Investment ONE")
+    expect(page).to have_link("Valuating Investment TWO")
+    expect(page).not_to have_link("Finished ONE")
+    expect(page).not_to have_link("Finished TWO")
 
-    expect(page).to have_link("Destroy the city")
-    expect(page).not_to have_link("Realocate visitors")
+    click_link 'Valuation finished'
+    expect(page).not_to have_link("Valuating Investment ONE")
+    expect(page).not_to have_link("Valuating Investment TWO")
+    expect(page).to have_link("Finished ONE")
+    expect(page).not_to have_link("Finished TWO")
 
-    click_link "All headings", exact: false
-    expect(page).to have_link("Realocate visitors")
-    expect(page).to have_link("Destroy the city")
+    click_link "Only Finished (1)", exact: false
+    expect(page).not_to have_link("Valuating Investment ONE")
+    expect(page).not_to have_link("Valuating Investment TWO")
+    expect(page).not_to have_link("Finished ONE")
+    expect(page).not_to have_link("Finished TWO")
+
+    click_link 'Valuation finished'
+    expect(page).not_to have_link("Valuating Investment ONE")
+    expect(page).not_to have_link("Valuating Investment TWO")
+    expect(page).not_to have_link("Finished ONE")
+    expect(page).to have_link("Finished TWO")
   end
 
   scenario "Current filter is properly highlighted" do

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -25,188 +25,190 @@ feature 'Valuation budget investments' do
     expect(page).to have_link "Valuation", href: valuation_root_path
   end
 
-  scenario 'Index shows budget investments assigned to current valuator' do
-    investment1 = create(:budget_investment, :visible_to_valuators, budget: budget)
-    investment2 = create(:budget_investment, :visible_to_valuators, budget: budget)
+  feature 'Index' do
+    scenario 'Index shows budget investments assigned to current valuator' do
+      investment1 = create(:budget_investment, :visible_to_valuators, budget: budget)
+      investment2 = create(:budget_investment, :visible_to_valuators, budget: budget)
 
-    investment1.valuators << valuator
+      investment1.valuators << valuator
 
-    visit valuation_budget_budget_investments_path(budget)
+      visit valuation_budget_budget_investments_path(budget)
 
-    expect(page).to have_content(investment1.title)
-    expect(page).not_to have_content(investment2.title)
-  end
-
-  scenario 'Index shows no budget investment to admins no valuators' do
-    investment1 = create(:budget_investment, :visible_to_valuators, budget: budget)
-    investment2 = create(:budget_investment, :visible_to_valuators, budget: budget)
-
-    investment1.valuators << valuator
-
-    logout
-    login_as create(:administrator).user
-    visit valuation_budget_budget_investments_path(budget)
-
-    expect(page).not_to have_content(investment1.title)
-    expect(page).not_to have_content(investment2.title)
-  end
-
-  scenario 'Index orders budget investments by votes' do
-    investment10  = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                      cached_votes_up: 10)
-    investment100 = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                      cached_votes_up: 100)
-    investment1   = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                      cached_votes_up: 1)
-
-    investment1.valuators << valuator
-    investment10.valuators << valuator
-    investment100.valuators << valuator
-
-    visit valuation_budget_budget_investments_path(budget)
-
-    expect(investment100.title).to appear_before(investment10.title)
-    expect(investment10.title).to appear_before(investment1.title)
-  end
-
-  scenario 'Index displays investments paginated' do
-    per_page = Kaminari.config.default_per_page
-    (per_page + 2).times do
-      investment = create(:budget_investment, :visible_to_valuators, budget: budget)
-      investment.valuators << valuator
+      expect(page).to have_content(investment1.title)
+      expect(page).not_to have_content(investment2.title)
     end
 
-    visit valuation_budget_budget_investments_path(budget)
+    scenario 'Index shows no budget investment to admins no valuators' do
+      investment1 = create(:budget_investment, :visible_to_valuators, budget: budget)
+      investment2 = create(:budget_investment, :visible_to_valuators, budget: budget)
 
-    expect(page).to have_css('.budget_investment', count: per_page)
-    within("ul.pagination") do
-      expect(page).to have_content("1")
-      expect(page).to have_content("2")
-      expect(page).not_to have_content("3")
-      click_link "Next", exact: false
+      investment1.valuators << valuator
+
+      logout
+      login_as create(:administrator).user
+      visit valuation_budget_budget_investments_path(budget)
+
+      expect(page).not_to have_content(investment1.title)
+      expect(page).not_to have_content(investment2.title)
     end
 
-    expect(page).to have_css('.budget_investment', count: 2)
-  end
+    scenario 'Index orders budget investments by votes' do
+      investment10  = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                        cached_votes_up: 10)
+      investment100 = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                        cached_votes_up: 100)
+      investment1   = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                        cached_votes_up: 1)
 
-  scenario "Index filtering by heading", :js do
-    group = create(:budget_group, budget: budget)
-    valuating_heading = create(:budget_heading, name: "Only Valuating", group: group)
-    valuating_finished_heading = create(:budget_heading, name: "Valuating&Finished", group: group)
-    finished_heading = create(:budget_heading, name: "Only Finished", group: group)
-    create(:budget_investment, :visible_to_valuators, title: "Valuating Investment ONE",
-                                                      heading: valuating_heading,
-                                                      group: group,
-                                                      budget: budget,
-                                                      valuators: [valuator])
-    create(:budget_investment, :visible_to_valuators, title: "Valuating Investment TWO",
-                                                      heading: valuating_finished_heading,
-                                                      group: group,
-                                                      budget: budget,
-                                                      valuators: [valuator])
-    create(:budget_investment, :visible_to_valuators, :finished, title: "Finished ONE",
-                                                                 heading: valuating_finished_heading,
-                                                                 group: group,
-                                                                 budget: budget,
-                                                                 valuators: [valuator])
-    create(:budget_investment, :visible_to_valuators, :finished, title: "Finished TWO",
-                                                                 heading: finished_heading,
-                                                                 group: group,
-                                                                 budget: budget,
-                                                                 valuators: [valuator])
+      investment1.valuators << valuator
+      investment10.valuators << valuator
+      investment100.valuators << valuator
 
-    visit valuation_budget_budget_investments_path(budget)
+      visit valuation_budget_budget_investments_path(budget)
 
-    expect(page).to have_link("Valuating Investment ONE")
-    expect(page).to have_link("Valuating Investment TWO")
-    expect(page).not_to have_link("Finished ONE")
-    expect(page).not_to have_link("Finished TWO")
+      expect(investment100.title).to appear_before(investment10.title)
+      expect(investment10.title).to appear_before(investment1.title)
+    end
 
-    expect(page).to have_link('All headings (4)')
-    expect(page).to have_link('Only Valuating (1)')
-    expect(page).to have_link('Valuating&Finished (2)')
-    expect(page).to have_link('Only Finished (1)')
+    scenario 'Index displays investments paginated' do
+      per_page = Kaminari.config.default_per_page
+      (per_page + 2).times do
+        investment = create(:budget_investment, :visible_to_valuators, budget: budget)
+        investment.valuators << valuator
+      end
 
-    click_link "Only Valuating (1)", exact: false
-    expect(page).to have_link("Valuating Investment ONE")
-    expect(page).not_to have_link("Valuating Investment TWO")
-    expect(page).not_to have_link("Finished ONE")
-    expect(page).not_to have_link("Finished TWO")
+      visit valuation_budget_budget_investments_path(budget)
 
-    click_link 'Valuation finished'
-    expect(page).not_to have_link("Valuating Investment ONE")
-    expect(page).not_to have_link("Valuating Investment TWO")
-    expect(page).not_to have_link("Finished ONE")
-    expect(page).not_to have_link("Finished TWO")
+      expect(page).to have_css('.budget_investment', count: per_page)
+      within("ul.pagination") do
+        expect(page).to have_content("1")
+        expect(page).to have_content("2")
+        expect(page).not_to have_content("3")
+        click_link "Next", exact: false
+      end
 
-    click_link "Valuating&Finished (2)", exact: false
-    expect(page).not_to have_link("Valuating Investment ONE")
-    expect(page).to have_link("Valuating Investment TWO")
-    expect(page).not_to have_link("Finished ONE")
-    expect(page).not_to have_link("Finished TWO")
+      expect(page).to have_css('.budget_investment', count: 2)
+    end
 
-    click_link 'Valuation finished'
-    expect(page).not_to have_link("Valuating Investment ONE")
-    expect(page).not_to have_link("Valuating Investment TWO")
-    expect(page).to have_link("Finished ONE")
-    expect(page).not_to have_link("Finished TWO")
+    scenario "Index filtering by heading", :js do
+      group = create(:budget_group, budget: budget)
+      valuating_heading = create(:budget_heading, name: "Only Valuating", group: group)
+      valuating_finished_heading = create(:budget_heading, name: "Valuating&Finished", group: group)
+      finished_heading = create(:budget_heading, name: "Only Finished", group: group)
+      create(:budget_investment, :visible_to_valuators, title: "Valuating Investment ONE",
+                                                        heading: valuating_heading,
+                                                        group: group,
+                                                        budget: budget,
+                                                        valuators: [valuator])
+      create(:budget_investment, :visible_to_valuators, title: "Valuating Investment TWO",
+                                                        heading: valuating_finished_heading,
+                                                        group: group,
+                                                        budget: budget,
+                                                        valuators: [valuator])
+      create(:budget_investment, :visible_to_valuators, :finished, title: "Finished ONE",
+                                                                   heading: valuating_finished_heading,
+                                                                   group: group,
+                                                                   budget: budget,
+                                                                   valuators: [valuator])
+      create(:budget_investment, :visible_to_valuators, :finished, title: "Finished TWO",
+                                                                   heading: finished_heading,
+                                                                   group: group,
+                                                                   budget: budget,
+                                                                   valuators: [valuator])
 
-    click_link "Only Finished (1)", exact: false
-    expect(page).not_to have_link("Valuating Investment ONE")
-    expect(page).not_to have_link("Valuating Investment TWO")
-    expect(page).not_to have_link("Finished ONE")
-    expect(page).not_to have_link("Finished TWO")
+      visit valuation_budget_budget_investments_path(budget)
 
-    click_link 'Valuation finished'
-    expect(page).not_to have_link("Valuating Investment ONE")
-    expect(page).not_to have_link("Valuating Investment TWO")
-    expect(page).not_to have_link("Finished ONE")
-    expect(page).to have_link("Finished TWO")
-  end
+      expect(page).to have_link("Valuating Investment ONE")
+      expect(page).to have_link("Valuating Investment TWO")
+      expect(page).not_to have_link("Finished ONE")
+      expect(page).not_to have_link("Finished TWO")
 
-  scenario "Current filter is properly highlighted" do
-    filters_links = {'valuating' => 'Under valuation',
-                     'valuation_finished' => 'Valuation finished'}
+      expect(page).to have_link('All headings (4)')
+      expect(page).to have_link('Only Valuating (1)')
+      expect(page).to have_link('Valuating&Finished (2)')
+      expect(page).to have_link('Only Finished (1)')
 
-    visit valuation_budget_budget_investments_path(budget)
+      click_link "Only Valuating (1)", exact: false
+      expect(page).to have_link("Valuating Investment ONE")
+      expect(page).not_to have_link("Valuating Investment TWO")
+      expect(page).not_to have_link("Finished ONE")
+      expect(page).not_to have_link("Finished TWO")
 
-    expect(page).not_to have_link(filters_links.values.first)
-    filters_links.keys.drop(1).each { |filter| expect(page).to have_link(filters_links[filter]) }
+      click_link 'Valuation finished'
+      expect(page).not_to have_link("Valuating Investment ONE")
+      expect(page).not_to have_link("Valuating Investment TWO")
+      expect(page).not_to have_link("Finished ONE")
+      expect(page).not_to have_link("Finished TWO")
 
-    filters_links.each_pair do |current_filter, link|
-      visit valuation_budget_budget_investments_path(budget, filter: current_filter)
+      click_link "Valuating&Finished (2)", exact: false
+      expect(page).not_to have_link("Valuating Investment ONE")
+      expect(page).to have_link("Valuating Investment TWO")
+      expect(page).not_to have_link("Finished ONE")
+      expect(page).not_to have_link("Finished TWO")
 
-      expect(page).not_to have_link(link)
+      click_link 'Valuation finished'
+      expect(page).not_to have_link("Valuating Investment ONE")
+      expect(page).not_to have_link("Valuating Investment TWO")
+      expect(page).to have_link("Finished ONE")
+      expect(page).not_to have_link("Finished TWO")
 
-      (filters_links.keys - [current_filter]).each do |filter|
-        expect(page).to have_link(filters_links[filter])
+      click_link "Only Finished (1)", exact: false
+      expect(page).not_to have_link("Valuating Investment ONE")
+      expect(page).not_to have_link("Valuating Investment TWO")
+      expect(page).not_to have_link("Finished ONE")
+      expect(page).not_to have_link("Finished TWO")
+
+      click_link 'Valuation finished'
+      expect(page).not_to have_link("Valuating Investment ONE")
+      expect(page).not_to have_link("Valuating Investment TWO")
+      expect(page).not_to have_link("Finished ONE")
+      expect(page).to have_link("Finished TWO")
+    end
+
+    scenario "Current filter is properly highlighted" do
+      filters_links = {'valuating' => 'Under valuation',
+                       'valuation_finished' => 'Valuation finished'}
+
+      visit valuation_budget_budget_investments_path(budget)
+
+      expect(page).not_to have_link(filters_links.values.first)
+      filters_links.keys.drop(1).each { |filter| expect(page).to have_link(filters_links[filter]) }
+
+      filters_links.each_pair do |current_filter, link|
+        visit valuation_budget_budget_investments_path(budget, filter: current_filter)
+
+        expect(page).not_to have_link(link)
+
+        (filters_links.keys - [current_filter]).each do |filter|
+          expect(page).to have_link(filters_links[filter])
+        end
       end
     end
-  end
 
-  scenario "Index filtering by valuation status" do
-    valuating = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                  title: "Ongoing valuation")
-    valuated  = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                  title: "Old idea",
-                                                                  valuation_finished: true)
-    valuating.valuators << valuator
-    valuated.valuators << valuator
+    scenario "Index filtering by valuation status" do
+      valuating = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                    title: "Ongoing valuation")
+      valuated  = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                    title: "Old idea",
+                                                                    valuation_finished: true)
+      valuating.valuators << valuator
+      valuated.valuators << valuator
 
-    visit valuation_budget_budget_investments_path(budget)
+      visit valuation_budget_budget_investments_path(budget)
 
-    expect(page).to have_content("Ongoing valuation")
-    expect(page).not_to have_content("Old idea")
+      expect(page).to have_content("Ongoing valuation")
+      expect(page).not_to have_content("Old idea")
 
-    visit valuation_budget_budget_investments_path(budget, filter: 'valuating')
+      visit valuation_budget_budget_investments_path(budget, filter: 'valuating')
 
-    expect(page).to have_content("Ongoing valuation")
-    expect(page).not_to have_content("Old idea")
+      expect(page).to have_content("Ongoing valuation")
+      expect(page).not_to have_content("Old idea")
 
-    visit valuation_budget_budget_investments_path(budget, filter: 'valuation_finished')
+      visit valuation_budget_budget_investments_path(budget, filter: 'valuation_finished')
 
-    expect(page).not_to have_content("Ongoing valuation")
-    expect(page).to have_content("Old idea")
+      expect(page).not_to have_content("Ongoing valuation")
+      expect(page).to have_content("Old idea")
+    end
   end
 
   feature 'Show' do


### PR DESCRIPTION
References
==========
In my way to achieve issue https://github.com/consul/consul/issues/2461 I've found some issue in the valuation panel heading filters

Objectives
==========
Fix heading filters by correctly creating a scenario spec that covers all combinations and checks right behaviour is met.

Visual Changes (if any)
=======================
No real visual changes, only right behaviour.

Notes
=====================
Check each commit to easily understand changes, as the second commit just encloses all the "Index related" scenarios in a:
```ruby
feature 'Index' do
...
end
```
and the indentation changes makes it look like a lot of "real" changes