### PR TITLE
Add Valuator Group name validation & related specs

### DIFF
--- a/app/models/valuator_group.rb
+++ b/app/models/valuator_group.rb
@@ -2,4 +2,6 @@ class ValuatorGroup < ActiveRecord::Base
   has_many :valuators
   has_many :valuator_group_assignments, dependent: :destroy, class_name: 'Budget::ValuatorGroupAssignment'
   has_many :investments, through: :valuator_group_assignments, class_name: 'Budget::Investment'
+
+  validates :name, presence: true, uniqueness: true
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,6 +63,7 @@ FactoryBot.define do
   end
 
   factory :valuator_group, class: ValuatorGroup do
+    sequence(:name) { |n| "Valuator Group #{n}" }
   end
 
   factory :identity do

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -381,6 +381,28 @@ describe Budget::Investment do
     end
   end
 
+  describe "#by_valuator_group" do
+    let(:valuator) { create(:valuator) }
+    let(:valuator_group) { create(:valuator_group, valuators: [valuator]) }
+    let!(:assigned_investment) do
+      create(:budget_investment, valuator_groups: [valuator_group])
+    end
+    let!(:second_assigned_investment) do
+      create(:budget_investment, valuator_groups: [valuator_group])
+    end
+
+    before do
+      create(:budget_investment, valuators: [valuator], valuator_groups: [create(:valuator_group)])
+    end
+
+    it "returns investments assigned to a valuator's group" do
+      by_valuator_group = described_class.by_valuator_group(valuator.valuator_group_id)
+
+      expect(by_valuator_group.size).to eq(2)
+      expect(by_valuator_group).to contain_exactly(assigned_investment, second_assigned_investment)
+    end
+  end
+
   describe "scopes" do
     describe "valuation_open" do
       it "returns all investments with false valuation_finished" do

--- a/spec/models/valuator_group_spec.rb
+++ b/spec/models/valuator_group_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe ValuatorGroup do
+
+  describe 'Validations' do
+    it "should be valid" do
+      expect(build(:valuator_group)).to be_valid
+    end
+
+    it "should not be valid without a name" do
+      expect(build(:valuator_group, name: nil)).not_to be_valid
+    end
+
+    it "should not be valid with the same name as an existing one" do
+      create(:valuator_group, name: 'The Valuators')
+
+      expect(build(:valuator_group, name: 'The Valuators')).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
References
==========
In my way to achieve issue https://github.com/consul/consul/issues/2461 I've found some things that I'm trying to fix in independent PR's to avoid mixing objectives.

Objectives
==========
- ValuatorGroup#name needs to be present and unique
- Budget::Investment#by_valuator_group scope needs to be tested

Visual Changes (if any)
=======================
None

Notes
=====================
None