### PR TITLE
Show group assigned investments to valuators

### DIFF
--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -113,9 +113,13 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def restrict_access_to_assigned_items
+      valuator = current_user.valuator
       return if current_user.administrator? ||
                 Budget::ValuatorAssignment.exists?(investment_id: params[:id],
-                                                   valuator_id: current_user.valuator.id)
+                                                   valuator_id: valuator&.id) ||
+                Budget::ValuatorGroupAssignment.exists?(investment_id: params[:id],
+                                                        valuator_group: valuator&.valuator_group)
+
       raise ActionController::RoutingError.new('Not Found')
     end
 

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -16,8 +16,10 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
 
   def index
     @heading_filters = heading_filters
+
     @investments = if current_user.valuator? && @budget.present?
-                     @budget.investments.visible_to_valuators.scoped_filter(params_for_current_valuator, @current_filter)
+                     @budget.investments.accesible_by_valuator(current_user.valuator)
+                            .scoped_filter(params, @current_filter)
                             .order(cached_votes_up: :desc)
                             .page(params[:page])
                    else
@@ -73,8 +75,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def heading_filters
-      investments = @budget.investments.by_valuator(current_user.valuator.try(:id))
-                                       .visible_to_valuators.distinct
+      investments = @budget.investments.accesible_by_valuator(current_user.valuator)
       investment_headings = Budget::Heading.where(id: investments.pluck(:heading_id).uniq)
                                            .order(name: :asc)
 
@@ -96,8 +97,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def params_for_current_valuator
-      Budget::Investment.filter_params(params).merge(valuator_id: current_user.valuator.id,
-                                                     budget_id: @budget.id)
+      Budget::Investment.filter_params(params)
     end
 
     def valuation_params

--- a/app/controllers/valuation/budgets_controller.rb
+++ b/app/controllers/valuation/budgets_controller.rb
@@ -6,12 +6,10 @@ class Valuation::BudgetsController < Valuation::BaseController
 
   def index
     @budget = current_budget
-    if @budget.present?
-      @investments_with_valuation_open = {}
-      @investments_with_valuation_open = @budget.investments
-                                                .by_valuator(current_user.valuator.try(:id))
-                                                .valuation_open
-                                                .count
+    valuator = current_user.valuator
+    if @budget.present? && valuator.present?
+      @assigned_investments_count = @budget.investments.accesible_by_valuator(valuator)
+                                           .valuation_open.count
     end
   end
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -87,6 +87,11 @@ class Budget
     scope :by_tag,            ->(tag_name)          { tagged_with(tag_name) }
     scope :by_valuator,       ->(valuator_id)       { where("budget_valuator_assignments.valuator_id = ?", valuator_id).joins(:valuator_assignments) }
     scope :by_valuator_group, ->(valuator_group_id) { where("budget_valuator_group_assignments.valuator_group_id = ?", valuator_group_id).joins(:valuator_group_assignments) }
+    scope :accesible_by_valuator, ->(valuator) do
+      direct_access = by_valuator(valuator&.id)
+      group_access = by_valuator_group(valuator&.valuator_group_id)
+      visible_to_valuators.where(id: (direct_access.pluck(:id) + group_access.pluck(:id)).uniq)
+    end
 
     scope :for_render, -> { includes(:heading) }
 

--- a/app/views/valuation/budget_investments/show.html.erb
+++ b/app/views/valuation/budget_investments/show.html.erb
@@ -36,15 +36,29 @@
 <p><strong><%= t("valuation.budget_investments.show.assigned_valuators") %>:</strong></p>
 <div id="assigned_valuators">
   <ul>
-    <% @investment.valuators.each do |valuator| %>
-      <li><%= valuator.name_and_email %></li>
-    <% end %>
-
     <% if @investment.valuators.empty? %>
       <li><%= t("valuation.budget_investments.show.undefined") %></li>
+    <% else %>
+      <% @investment.valuators.each do |valuator| %>
+        <li><%= valuator.name_and_email %></li>
+      <% end %>
     <% end %>
   </ul>
 </div>
+
+<p><strong><%= t("valuation.budget_investments.show.assigned_valuator_groups") %>:</strong></p>
+<div id="assigned_valuator_groups">
+  <ul>
+    <% if @investment.valuator_groups.empty? %>
+      <li><%= t("valuation.budget_investments.show.undefined") %></li>
+    <% else %>
+      <% @investment.valuator_groups.each do |valuator_group| %>
+        <li><%= valuator_group.name %></li>
+      <% end %>
+    <% end %>
+  </ul>
+</div>
+
 
 <h2><%= t("valuation.budget_investments.show.dossier") %></h2>
 <p>

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -18,7 +18,7 @@
         <%= t("budgets.phase.#{@budget.phase}") %>
       </td>
       <td>
-        <%= @investments_with_valuation_open %>
+        <%= @assigned_investments_count %>
       </td>
       <td>
         <%= link_to t("valuation.budgets.index.evaluate"),

--- a/config/locales/en/seeds.yml
+++ b/config/locales/en/seeds.yml
@@ -36,6 +36,11 @@ en:
       groups:
         all_city: All City
         districts: Districts
+      valuator_groups:
+        culture_and_sports: Culture & Sports
+        gender_and_diversity: Gender & Diversity Policies
+        urban_development: Sustainable Urban Development
+        equity_and_employment: Equity & Employment
     polls:
       current_poll: "Current Poll"
       current_poll_geozone_restricted: "Current Poll Geozone Restricted"

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -56,6 +56,7 @@ en:
         responsibles: Responsibles
         assigned_admin: Assigned admin
         assigned_valuators: Assigned valuators
+        assigned_valuator_groups: Assigned valuator groups
       edit:
         dossier: Dossier
         price_html: "Price (%{currency})"

--- a/config/locales/es/seeds.yml
+++ b/config/locales/es/seeds.yml
@@ -36,6 +36,11 @@ es:
       groups:
         all_city: Toda la Ciudad
         districts: Distritos
+      valuator_groups:
+        culture_and_sports: Cultura y Deportes
+        gender_and_diversity: Políticas de Género y Diversidad
+        urban_development: Desarrollo Urbano Sostenible
+        equity_and_employment: Equidad y Empleo
     polls:
       current_poll: "Votación Abierta"
       current_poll_geozone_restricted: "Votación Abierta restringida por geozona"

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -56,6 +56,7 @@ es:
         responsibles: Responsables
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados
+        assigned_valuator_groups: Grupos de evaluadores asignados
       edit:
         dossier: Informe
         price_html: "Coste (%{currency}) <small>(dato público)</small>"

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -118,9 +118,26 @@ section "Winner Investments" do
   end
 end
 
-section "Creating Valuation Assignments" do
+section "Creating Valuator Groups Assignments" do
+  valuators_count = Valuator.count
+  ValuatorGroup.create(name: I18n.t('seeds.budgets.valuator_groups.culture_and_sports'),
+                       valuators: [Valuator.find(1), Valuator.find(2)])
+  ValuatorGroup.create(name: I18n.t('seeds.budgets.valuator_groups.gender_and_diversity'),
+                       valuators: [Valuator.find(3), Valuator.find(4)])
+  ValuatorGroup.create(name: I18n.t('seeds.budgets.valuator_groups.urban_development'),
+                       valuators: [Valuator.find(5), Valuator.find(6)])
+  ValuatorGroup.create(name: I18n.t('seeds.budgets.valuator_groups.equity_and_employment'),
+                       valuators: [Valuator.find(7), Valuator.find(8)])
+end
+
+section "Creating Valuation direct Assignments" do
   (1..50).to_a.sample.times do
-    Budget::Investment.all.sample.valuators << Valuator.first
+    Budget::Investment.all.sample.valuators << Valuator.all.sample
+  end
+end
+section "Creating Valuation Group Assignments" do
+  (1..50).to_a.sample.times do
+    Budget::Investment.all.sample.valuator_groups << ValuatorGroup.all.sample
   end
 end
 

--- a/db/dev_seeds/users.rb
+++ b/db/dev_seeds/users.rb
@@ -39,11 +39,13 @@ section "Creating Users" do
                  confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
                  verified_at: Time.current, document_number: unique_document_number)
 
-  valuator = create_user('valuator@madrid.es', 'valuator')
-  valuator.create_valuator
-  valuator.update(residence_verified_at: Time.current,
-                  confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
-                  verified_at: Time.current, document_number: unique_document_number)
+  10.times do |i|
+    valuator = create_user("valuator#{i}@madrid.es", "Valuator #{i}")
+    valuator.create_valuator
+    valuator.update(residence_verified_at: Time.current,
+                    confirmed_phone: Faker::PhoneNumber.phone_number, document_type: "1",
+                    verified_at: Time.current, document_number: unique_document_number)
+  end
 
   poll_officer = create_user('poll_officer@madrid.es', 'Paul O. Fisher')
   poll_officer.create_poll_officer

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -231,7 +231,7 @@ feature 'Valuation budget investments' do
       investment.valuators << [valuator, second_valuator]
     end
 
-    scenario 'visible for assigned valuators' do
+    scenario 'visible for directly assigned valuators' do
       investment.update(visible_to_valuators: true)
 
       visit valuation_budget_budget_investments_path(budget)
@@ -250,6 +250,32 @@ feature 'Valuation budget investments' do
       within('#assigned_valuators') do
         expect(page).to have_content('Rachel (rachel@valuators.org)')
         expect(page).to have_content('Rick (rick@valuators.org)')
+      end
+    end
+
+    scenario 'visible for group assigned valuators' do
+      second_valuator_group = create(:valuator_group, name: 'Valuators II',
+                                                      valuators: [second_valuator])
+      investment.update(visible_to_valuators: true,
+                        valuators: [valuator],
+                        valuator_groups: [second_valuator_group])
+
+      logout
+      login_as(second_valuator.user)
+
+      visit valuation_budget_budget_investments_path(budget)
+
+      click_link investment.title
+
+      expect(page).to have_content(investment.title)
+
+      within('#assigned_valuators') do
+        expect(page).to have_content('Rachel (rachel@valuators.org)')
+        expect(page).not_to have_content('Rick (rick@valuators.org)')
+      end
+
+      within('#assigned_valuator_groups') do
+        expect(page).to have_content('Valuators II')
       end
     end
 

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -6,6 +6,9 @@ feature 'Valuation budget investments' do
   let(:valuator) do
     create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
   end
+  let(:valuator_group) do
+    create(:valuator_group, name: 'The Valuators Group', valuators: [valuator])
+  end
 
   background do
     login_as(valuator.user)
@@ -27,15 +30,23 @@ feature 'Valuation budget investments' do
 
   feature 'Index' do
     scenario 'Index shows budget investments assigned to current valuator' do
-      investment1 = create(:budget_investment, :visible_to_valuators, budget: budget)
-      investment2 = create(:budget_investment, :visible_to_valuators, budget: budget)
+      individual_access = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                            valuators: [valuator])
+      individual_and_group_access = create(:budget_investment, visible_to_valuators: true,
+                                                               budget: budget,
+                                                               valuators: [valuator],
+                                                               valuator_groups: [valuator_group])
+      group_access = create(:budget_investment, visible_to_valuators: true, budget: budget,
+                                                valuator_groups: [valuator_group])
+      no_access = create(:budget_investment, :visible_to_valuators, budget: budget)
 
-      investment1.valuators << valuator
 
       visit valuation_budget_budget_investments_path(budget)
 
-      expect(page).to have_content(investment1.title)
-      expect(page).not_to have_content(investment2.title)
+      expect(page).to have_content(individual_access.title)
+      expect(page).to have_content(individual_and_group_access.title)
+      expect(page).to have_content(group_access.title)
+      expect(page).not_to have_content(no_access.title)
     end
 
     scenario 'Index shows no budget investment to admins no valuators' do
@@ -54,15 +65,14 @@ feature 'Valuation budget investments' do
 
     scenario 'Index orders budget investments by votes' do
       investment10  = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                        cached_votes_up: 10)
+                                                                        cached_votes_up: 10,
+                                                                        valuators: [valuator])
       investment100 = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                        cached_votes_up: 100)
+                                                                        cached_votes_up: 100,
+                                                                        valuators: [valuator])
       investment1   = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                        cached_votes_up: 1)
-
-      investment1.valuators << valuator
-      investment10.valuators << valuator
-      investment100.valuators << valuator
+                                                                        cached_votes_up: 1,
+                                                                        valuators: [valuator])
 
       visit valuation_budget_budget_investments_path(budget)
 
@@ -73,8 +83,8 @@ feature 'Valuation budget investments' do
     scenario 'Index displays investments paginated' do
       per_page = Kaminari.config.default_per_page
       (per_page + 2).times do
-        investment = create(:budget_investment, :visible_to_valuators, budget: budget)
-        investment.valuators << valuator
+        investment = create(:budget_investment, :visible_to_valuators, budget: budget,
+                                                                       valuators: [valuator])
       end
 
       visit valuation_budget_budget_investments_path(budget)
@@ -95,26 +105,19 @@ feature 'Valuation budget investments' do
       valuating_heading = create(:budget_heading, name: "Only Valuating", group: group)
       valuating_finished_heading = create(:budget_heading, name: "Valuating&Finished", group: group)
       finished_heading = create(:budget_heading, name: "Only Finished", group: group)
-      create(:budget_investment, :visible_to_valuators, title: "Valuating Investment ONE",
-                                                        heading: valuating_heading,
-                                                        group: group,
-                                                        budget: budget,
-                                                        valuators: [valuator])
-      create(:budget_investment, :visible_to_valuators, title: "Valuating Investment TWO",
-                                                        heading: valuating_finished_heading,
-                                                        group: group,
-                                                        budget: budget,
-                                                        valuators: [valuator])
-      create(:budget_investment, :visible_to_valuators, :finished, title: "Finished ONE",
-                                                                   heading: valuating_finished_heading,
-                                                                   group: group,
-                                                                   budget: budget,
-                                                                   valuators: [valuator])
-      create(:budget_investment, :visible_to_valuators, :finished, title: "Finished TWO",
-                                                                   heading: finished_heading,
-                                                                   group: group,
-                                                                   budget: budget,
-                                                                   valuators: [valuator])
+
+      create(:budget_investment, visible_to_valuators: true, title: "Valuating Investment ONE",
+                                 heading: valuating_heading, group: group, budget: budget,
+                                 valuators: [valuator])
+      create(:budget_investment, visible_to_valuators: true, title: "Valuating Investment TWO",
+                                 heading: valuating_finished_heading, group: group, budget: budget,
+                                 valuator_groups: [valuator_group])
+      create(:budget_investment, :finished, visible_to_valuators: true, title: "Finished ONE",
+                                            heading: valuating_finished_heading, group: group,
+                                            budget: budget, valuator_groups: [valuator_group])
+      create(:budget_investment, :finished, visible_to_valuators: true, title: "Finished TWO",
+                                            heading: finished_heading, group: group, budget: budget,
+                                            valuators: [valuator])
 
       visit valuation_budget_budget_investments_path(budget)
 
@@ -187,12 +190,12 @@ feature 'Valuation budget investments' do
 
     scenario "Index filtering by valuation status" do
       valuating = create(:budget_investment, :visible_to_valuators, budget: budget,
-                                                                    title: "Ongoing valuation")
+                                                                    title: "Ongoing valuation",
+                                                                    valuators: [valuator])
       valuated  = create(:budget_investment, :visible_to_valuators, budget: budget,
                                                                     title: "Old idea",
-                                                                    valuation_finished: true)
-      valuating.valuators << valuator
-      valuated.valuators << valuator
+                                                                    valuation_finished: true,
+                                                                    valuators: [valuator])
 
       visit valuation_budget_budget_investments_path(budget)
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -403,6 +403,49 @@ describe Budget::Investment do
     end
   end
 
+  describe "#accesible_by_valuator" do
+    let!(:visible_individually_assigned_investment) do
+      create(:budget_investment, :visible_to_valuators, valuators: [valuator])
+    end
+    let!(:invisible_individually_assigned_investment) do
+      create(:budget_investment, valuators: [valuator])
+    end
+    let!(:visible_group_assigned_investment) do
+      create(:budget_investment, :visible_to_valuators, valuator_groups: [valuator_group])
+    end
+    let!(:invisible_group_assigned_investment) do
+      create(:budget_investment, valuator_groups: [valuator_group])
+    end
+    let!(:visible_double_assigned_investment) do
+      create(:budget_investment, :visible_to_valuators, valuators: [valuator],
+                                                        valuator_groups: [valuator_group])
+    end
+    let!(:invisible_double_assigned_investment) do
+      create(:budget_investment, valuators: [valuator], valuator_groups: [valuator_group])
+    end
+
+    let(:valuator) { create(:valuator) }
+    let(:valuator_group) { create(:valuator_group, valuators: [valuator]) }
+
+    before do
+      second_valuator = create(:valuator)
+      second_valuator_group = create(:valuator_group, valuators: [second_valuator])
+      create(:budget_investment, :visible_to_valuators, valuators: [second_valuator],
+                                                        valuator_groups: [second_valuator_group])
+      create(:budget_investment, valuators: [second_valuator],
+                                 valuator_groups: [second_valuator_group])
+    end
+
+    it "returns investments assigned to a valuator directly or through its valuator group" do
+      accesible_by_valuator = described_class.accesible_by_valuator(valuator)
+
+      expect(accesible_by_valuator.size).to eq(3)
+      expect(accesible_by_valuator).to contain_exactly(visible_individually_assigned_investment,
+                                                       visible_double_assigned_investment,
+                                                       visible_group_assigned_investment)
+    end
+  end
+
   describe "scopes" do
     describe "valuation_open" do
       it "returns all investments with false valuation_finished" do


### PR DESCRIPTION
References
==========
This PR accomplishes https://github.com/consul/consul/issues/2461 and its based on https://github.com/AyuntamientoMadrid/consul/pull/1357 & https://github.com/AyuntamientoMadrid/consul/pull/1358 refactor&fixes PRs

Objectives
==========
Valuators have a ValuatorGroup that can get investments assigned to it.    Valuators should see those investments as well as directly assigned ones

Visual Changes (if any)
=======================
None, just increased the investments list to display

Notes
=====================
None