### PR TITLE
Test suite maintenance

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -563,8 +563,8 @@ feature 'Admin budget investments' do
 
       click_link 'Advanced filters'
 
-      page.check('advanced_filters_feasible')
-      click_button "Filter"
+      within('#advanced_filters') { check('advanced_filters_feasible') }
+      click_button('Filter')
 
       expect(page).to have_css(".budget_investment", count: 2)
       expect(page).to have_content("Educate the children")
@@ -582,7 +582,6 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More hostals")
 
       expect(page).to have_content('Selected')
-
     end
 
     scenario "See results button appears when budget status is finished" do
@@ -1067,8 +1066,9 @@ feature 'Admin budget investments' do
       expect(page).to have_content(winner_bi.title)
 
       click_link 'Advanced filters'
-      within('#advanced_filters') { find(:css, "#advanced_filters_feasible").set(true) }
-      click_button 'Filter'
+
+      within('#advanced_filters') { check('advanced_filters_feasible') }
+      click_button('Filter')
 
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
@@ -1076,9 +1076,12 @@ feature 'Admin budget investments' do
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      within('#advanced_filters') { find(:css, "#advanced_filters_selected").set(true) }
-      within('#advanced_filters') { find(:css, "#advanced_filters_feasible").set(false) }
-      click_button 'Filter'
+      within('#advanced_filters') do
+        check('advanced_filters_selected')
+        uncheck('advanced_filters_feasible')
+      end
+
+      click_button('Filter')
 
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
@@ -1098,8 +1101,9 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       click_link 'Advanced filters'
-      within('#advanced_filters') { find(:css, "#advanced_filters_undecided").set(true) }
-      click_button 'Filter'
+
+      within('#advanced_filters') { check('advanced_filters_undecided') }
+      click_button('Filter')
 
       expect(page).to have_content(undecided_bi.title)
       expect(page).not_to have_content(winner_bi.title)
@@ -1108,8 +1112,8 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_vf_bi.title)
 
-      within('#advanced_filters') { find(:css, "#advanced_filters_unfeasible").set(true) }
-      click_button 'Filter'
+      within('#advanced_filters') { check('advanced_filters_unfeasible') }
+      click_button('Filter')
 
       expect(page).to have_content(undecided_bi.title)
       expect(page).to have_content(unfeasible_bi.title)
@@ -1152,8 +1156,9 @@ feature 'Admin budget investments' do
       end
 
       click_link 'Advanced filters'
-      within('#advanced_filters') { find(:css, "#advanced_filters_selected").set(true) }
-      click_button 'Filter'
+
+      within('#advanced_filters') { check('advanced_filters_selected') }
+      click_button('Filter')
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
         expect(page).not_to have_link('Select')
@@ -1165,9 +1170,8 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
       click_link 'Advanced filters'
 
-      within('#advanced_filters') { find(:css, "#advanced_filters_selected").set(true) }
-
-      click_button 'Filter'
+      within('#advanced_filters') { check('advanced_filters_selected') }
+      click_button('Filter')
 
       expect(page).to have_content('There are 2 investments')
 

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -73,11 +73,14 @@ feature 'Admin legislation processes' do
   end
 
   context 'Update' do
-    scenario 'Remove summary text', js: true do
-      process = create(:legislation_process,
-                       title: 'An example legislation process',
-                       summary: 'Summarizing the process',
-                       description: 'Description of the process')
+    let!(:process) do
+      create(:legislation_process,
+             title: 'An example legislation process',
+             summary: 'Summarizing the process',
+             description: 'Description of the process')
+    end
+
+    scenario 'Remove summary text' do
       visit admin_root_path
 
       within('#side_menu') do
@@ -100,11 +103,7 @@ feature 'Admin legislation processes' do
       expect(page).to have_content 'Description of the process'
     end
 
-    scenario 'Deactivate draft publication', js: true do
-      process = create(:legislation_process,
-                       title: 'An example legislation process',
-                       summary: 'Summarizing the process',
-                       description: 'Description of the process')
+    scenario 'Deactivate draft publication' do
       visit admin_root_path
 
       within('#side_menu') do

--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -2,14 +2,13 @@ require 'rails_helper'
 include ActionView::Helpers::DateHelper
 
 feature 'Commenting topics from proposals' do
-  let(:user) { create :user }
+  let(:user)     { create :user }
   let(:proposal) { create :proposal }
 
-  scenario 'Index', :js do
-
+  scenario 'Index' do
     community = proposal.community
     topic = create(:topic, community: community)
-    3.times { create(:comment, commentable: topic) }
+    create_list(:comment, 3, commentable: topic)
 
     visit community_topic_path(community, topic)
 
@@ -23,7 +22,7 @@ feature 'Commenting topics from proposals' do
     end
   end
 
-  scenario 'Show', :js do
+  scenario 'Show' do
     community = proposal.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, commentable: topic)
@@ -559,14 +558,13 @@ feature 'Commenting topics from proposals' do
 end
 
 feature 'Commenting topics from budget investments' do
-  let(:user) { create :user }
+  let(:user)       { create :user }
   let(:investment) { create :budget_investment }
 
-  scenario 'Index', :js do
-
+  scenario 'Index' do
     community = investment.community
     topic = create(:topic, community: community)
-    3.times { create(:comment, commentable: topic) }
+    create_list(:comment, 3, commentable: topic)
 
     visit community_topic_path(community, topic)
 
@@ -580,7 +578,7 @@ feature 'Commenting topics from budget investments' do
     end
   end
 
-  scenario 'Show', :js do
+  scenario 'Show' do
     community = investment.community
     topic = create(:topic, community: community)
     parent_comment = create(:comment, commentable: topic)

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -25,69 +25,64 @@ feature 'Emails' do
   end
 
   context 'Proposal comments' do
-    scenario "Send email on proposal comment" do
-      user = create(:user, email_on_comment: true)
-      proposal = create(:proposal, author: user)
+    let(:user)     { create(:user, email_on_comment: true) }
+    let(:proposal) { create(:proposal, author: user) }
+
+    scenario 'Send email on proposal comment' do
       comment_on(proposal)
 
       email = open_last_email
       expect(email).to have_subject('Someone has commented on your citizen proposal')
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_body_text(proposal_path(proposal))
+      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text(account_path)
     end
 
     scenario 'Do not send email about own proposal comments' do
-      user = create(:user, email_on_comment: true)
-      proposal = create(:proposal, author: user)
       comment_on(proposal, user)
-
-      expect { open_last_email }.to raise_error "No email has been sent!"
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
 
     scenario 'Do not send email about proposal comment unless set in preferences' do
-      user = create(:user, email_on_comment: false)
-      proposal = create(:proposal, author: user)
+      user.update(email_on_comment: false)
       comment_on(proposal)
-
-      expect { open_last_email }.to raise_error "No email has been sent!"
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
   end
 
   context 'Debate comments' do
-    scenario "Send email on debate comment" do
-      user = create(:user, email_on_comment: true)
-      debate = create(:debate, author: user)
+    let(:user)   { create(:user, email_on_comment: true) }
+    let(:debate) { create(:debate, author: user) }
+
+    scenario 'Send email on debate comment' do
       comment_on(debate)
 
       email = open_last_email
       expect(email).to have_subject('Someone has commented on your debate')
       expect(email).to deliver_to(debate.author)
       expect(email).to have_body_text(debate_path(debate))
-      expect(email).to have_body_text(I18n.t("mailers.config.manage_email_subscriptions"))
+      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
       expect(email).to have_body_text(account_path)
     end
 
     scenario 'Do not send email about own debate comments' do
-      user = create(:user, email_on_comment: true)
-      debate = create(:debate, author: user)
       comment_on(debate, user)
-
-      expect { open_last_email }.to raise_error "No email has been sent!"
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
 
     scenario 'Do not send email about debate comment unless set in preferences' do
-      user = create(:user, email_on_comment: false)
-      debate = create(:debate, author: user)
+      user.update(email_on_comment: false)
       comment_on(debate)
-
-      expect { open_last_email }.to raise_error "No email has been sent!"
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
   end
 
   context 'Budget investments comments' do
+    let(:user)       { create(:user, email_on_comment: true) }
+    let(:investment) { create(:budget_investment, author: user, budget: create(:budget)) }
+
     scenario 'Send email on budget investment comment' do
-      user = create(:user, email_on_comment: true)
-      investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment)
 
       email = open_last_email
@@ -99,30 +94,23 @@ feature 'Emails' do
     end
 
     scenario 'Do not send email about own budget investments comments' do
-      user = create(:user, email_on_comment: true)
-      investment = create(:budget_investment, author: user, budget: create(:budget))
       comment_on(investment, user)
-
-      expect { open_last_email }.to raise_error 'No email has been sent!'
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
 
     scenario 'Do not send email about budget investment comment unless set in preferences' do
-      user = create(:user, email_on_comment: false)
-      investment = create(:budget_investment, author: user, budget: create(:budget))
+      user.update(email_on_comment: false)
       comment_on(investment)
-
-      expect { open_last_email }.to raise_error 'No email has been sent!'
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
   end
 
   context 'Topic comments' do
-    before do
-      @proposal = create(:proposal)
-    end
+    let(:user)     { create(:user, email_on_comment: true) }
+    let(:proposal) { create(:proposal) }
+    let(:topic)    { create(:topic, author: user, community: proposal.community) }
 
     scenario 'Send email on topic comment' do
-      user = create(:user, email_on_comment: true)
-      topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic)
 
       email = open_last_email
@@ -134,26 +122,22 @@ feature 'Emails' do
     end
 
     scenario 'Do not send email about own topic comments' do
-      user = create(:user, email_on_comment: true)
-      topic = create(:topic, author: user, community: @proposal.community)
       comment_on(topic, user)
-
-      expect { open_last_email }.to raise_error 'No email has been sent!'
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
 
     scenario 'Do not send email about topic comment unless set in preferences' do
-      user = create(:user, email_on_comment: false)
-      topic = create(:topic, author: user, community: @proposal.community)
+      user.update(email_on_comment: false)
       comment_on(topic)
-
-      expect { open_last_email }.to raise_error 'No email has been sent!'
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
   end
 
   context 'Poll comments' do
+    let(:user) { create(:user, email_on_comment: true) }
+    let(:poll) { create(:poll, author: user) }
+
     scenario 'Send email on poll comment' do
-      user = create(:user, email_on_comment: true)
-      poll = create(:poll, author: user)
       comment_on(poll)
 
       email = open_last_email
@@ -165,25 +149,21 @@ feature 'Emails' do
     end
 
     scenario 'Do not send email about own poll comments' do
-      user = create(:user, email_on_comment: true)
-      poll = create(:poll, author: user)
       comment_on(poll, user)
-
-      expect { open_last_email }.to raise_error 'No email has been sent!'
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
 
     scenario 'Do not send email about poll question comment unless set in preferences' do
-      user = create(:user, email_on_comment: false)
-      poll = create(:poll, author: user)
+      user.update(email_on_comment: false)
       comment_on(poll)
-
-      expect { open_last_email }.to raise_error 'No email has been sent!'
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
   end
 
   context 'Comment replies' do
-    scenario "Send email on comment reply", :js do
-      user = create(:user, email_on_comment_reply: true)
+    let(:user) { create(:user, email_on_comment_reply: true) }
+
+    scenario 'Send email on comment reply', :js do
       reply_to(user)
 
       email = open_last_email
@@ -191,22 +171,19 @@ feature 'Emails' do
       expect(email).to deliver_to(user)
       expect(email).not_to have_body_text(debate_path(Comment.first.commentable))
       expect(email).to have_body_text(comment_path(Comment.last))
-      expect(email).to have_body_text(I18n.t("mailers.config.manage_email_subscriptions"))
+      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
       expect(email).to have_body_text(account_path)
     end
 
-    scenario "Do not send email about own replies to own comments", :js do
-      user = create(:user, email_on_comment_reply: true)
+    scenario 'Do not send email about own replies to own comments', :js do
       reply_to(user, user)
-
-      expect { open_last_email }.to raise_error "No email has been sent!"
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
 
-    scenario "Do not send email about comment reply unless set in preferences", :js do
-      user = create(:user, email_on_comment_reply: false)
+    scenario 'Do not send email about comment reply unless set in preferences', :js do
+      user.update(email_on_comment_reply: false)
       reply_to(user)
-
-      expect { open_last_email }.to raise_error "No email has been sent!"
+      expect { open_last_email }.to raise_error('No email has been sent!')
     end
   end
 

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -188,12 +188,16 @@ feature 'Emails' do
   end
 
   scenario "Email depending on user's locale" do
-    sign_up
+    visit root_path(locale: :es)
+
+    click_link 'Registrarse'
+    fill_in_signup_form
+    click_button 'Registrarse'
 
     email = open_last_email
-    expect(email).to have_subject('Confirmation instructions')
     expect(email).to deliver_to('manuela@consul.dev')
     expect(email).to have_body_text(user_confirmation_path)
+    expect(email).to have_subject('Instrucciones de confirmación')
   end
 
   xscenario "Email on unfeasible spending proposal" do

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -35,7 +35,7 @@ feature 'Emails' do
       expect(email).to have_subject('Someone has commented on your citizen proposal')
       expect(email).to deliver_to(proposal.author)
       expect(email).to have_body_text(proposal_path(proposal))
-      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 
@@ -62,7 +62,7 @@ feature 'Emails' do
       expect(email).to have_subject('Someone has commented on your debate')
       expect(email).to deliver_to(debate.author)
       expect(email).to have_body_text(debate_path(debate))
-      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 
@@ -89,7 +89,7 @@ feature 'Emails' do
       expect(email).to have_subject('Someone has commented on your investment')
       expect(email).to deliver_to(investment.author)
       expect(email).to have_body_text(budget_investment_path(investment.budget, investment))
-      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 
@@ -117,7 +117,7 @@ feature 'Emails' do
       expect(email).to have_subject('Someone has commented on your topic')
       expect(email).to deliver_to(topic.author)
       expect(email).to have_body_text(community_topic_path(topic, community_id: topic.community_id))
-      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 
@@ -144,7 +144,7 @@ feature 'Emails' do
       expect(email).to have_subject('Someone has commented on your poll')
       expect(email).to deliver_to(poll.author)
       expect(email).to have_body_text(poll_path(poll))
-      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 
@@ -171,7 +171,7 @@ feature 'Emails' do
       expect(email).to deliver_to(user)
       expect(email).not_to have_body_text(debate_path(Comment.first.commentable))
       expect(email).to have_body_text(comment_path(Comment.last))
-      expect(email).to have_body_text(I18n.t('mailers.config.manage_email_subscriptions'))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 
@@ -486,7 +486,7 @@ feature 'Emails' do
       expect(email).to deliver_to(user1)
       expect(email).not_to have_body_text(poll_path(poll))
       expect(email).to have_body_text(comment_path(Comment.last))
-      expect(email).to have_body_text(I18n.t("mailers.config.manage_email_subscriptions"))
+      expect(email).to have_body_text('To stop receiving these emails change your settings in')
       expect(email).to have_body_text(account_path)
     end
 

--- a/spec/lib/census_caller_spec.rb
+++ b/spec/lib/census_caller_spec.rb
@@ -4,14 +4,18 @@ describe CensusCaller do
   let(:api) { described_class.new }
 
   describe '#call' do
-    it "returns data from local_census_records if census API is not available" do
-      census_api_response = CensusApi::Response.new(get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {}, datos_vivienda: {}}})
+    it 'returns data from local_census_records if census API is not available' do
+      census_api_response = CensusApi::Response.new(get_habita_datos_response: {
+          get_habita_datos_return: { datos_habitante: {}, datos_vivienda: {} }
+        }
+      )
+
       local_census_response = LocalCensus::Response.new(create(:local_census_record))
 
-      CensusApi.any_instance.stub(:call).and_return(census_api_response)
-      LocalCensus.any_instance.stub(:call).and_return(local_census_response)
+      expect_any_instance_of(CensusApi).to   receive(:call).and_return(census_api_response)
+      expect_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
 
-      allow(CensusApi).to receive(:call).with(1, "12345678A")
+      allow(CensusApi).to   receive(:call).with(1, "12345678A")
       allow(LocalCensus).to receive(:call).with(1, "12345678A")
 
       response = api.call(1, "12345678A")
@@ -20,11 +24,16 @@ describe CensusCaller do
     end
 
     it "returns data from census API if it's available and valid" do
-      census_api_response = CensusApi::Response.new(get_habita_datos_response: {get_habita_datos_return: {datos_habitante: {item: {fecha_nacimiento_string: "1-1-1980"}}}})
+      census_api_response = CensusApi::Response.new(get_habita_datos_response: {
+        get_habita_datos_return: {
+          datos_habitante: { item: { fecha_nacimiento_string: "1-1-1980" } }
+        }
+      })
+
       local_census_response = LocalCensus::Response.new(create(:local_census_record))
 
-      CensusApi.any_instance.stub(:call).and_return(census_api_response)
-      LocalCensus.any_instance.stub(:call).and_return(local_census_response)
+      expect_any_instance_of(CensusApi).to  receive(:call).and_return(census_api_response)
+      allow_any_instance_of(LocalCensus).to receive(:call).and_return(local_census_response)
 
       allow(CensusApi).to receive(:call).with(1, "12345678A")
       allow(LocalCensus).to receive(:call).with(1, "12345678A")

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -128,7 +128,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect(page).to have_css ".loading-bar.complete"
     end
 
-    scenario "Should update loading bar style after unvalid file upload", :js do
+    scenario "Should update loading bar style after invalid file upload", :js do
       login_as user_to_login
       visit send(path, arguments)
 
@@ -149,7 +149,7 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
       expect_document_has_cached_attachment(0, ".pdf")
     end
 
-    scenario "Should not update document cached_attachment field after unvalid file upload", :js do
+    scenario "Should not update document cached_attachment field after invalid file upload", :js do
       login_as user_to_login
       visit send(path, arguments)
 

--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -1,4 +1,7 @@
-shared_examples "nested imageable" do |imageable_factory_name, path, imageable_path_arguments, fill_resource_method_name, submit_button, imageable_success_notice, has_many_images = false|
+shared_examples "nested imageable" do |imageable_factory_name, path,
+                                       imageable_path_arguments, fill_resource_method_name,
+                                       submit_button, imageable_success_notice,
+                                       has_many_images = false|
   include ActionView::Helpers
   include ImagesHelper
   include ImageablesHelper
@@ -125,7 +128,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_cached_attachment(".jpg")
     end
 
-    scenario "Should not update image cached_attachment field after unvalid file upload", :js do
+    scenario "Should not update image cached_attachment field after invalid file upload", :js do
       login_as user
       visit send(path, arguments)
 
@@ -138,7 +141,7 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
       expect_image_has_cached_attachment("")
     end
 
-    scenario "Should show nested image errors after unvalid form submit", :js do
+    scenario "Should show nested image errors after invalid form submit", :js do
       login_as user
       visit send(path, arguments)
 

--- a/spec/shared/models/document_validations.rb
+++ b/spec/shared/models/document_validations.rb
@@ -32,8 +32,8 @@ shared_examples "document validations" do |documentable_factory|
     end
   end
 
-  it "is not valid for attachments larger than documentable max_file_size definition" do
-    document.stub(:attachment_file_size).and_return(maxfilesize.megabytes + 1.byte)
+  it 'is not valid for attachments larger than documentable max_file_size definition' do
+    allow(document).to receive(:attachment_file_size).and_return(maxfilesize.megabytes + 1.byte)
     max_size_error_message = "must be in between 0 Bytes and #{maxfilesize} MB"
 
     expect(document).not_to be_valid


### PR DESCRIPTION
References
==========
* No issues or PRs related

Related links:
* [RSpec's new message expectation syntax](http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/)
* [RSpec Mocks docs](https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance)

Objectives
==========
* Fixed example to properly test emails are being sent based on current user's locale
* Fixed RSpec's deprecation warnings for old `stub` syntax usage
* DRY several `features/emails` examples
* Refactored some tests to use the `.check` & `.uncheck` API to interact directly with the UI rather than with the DOM
* Fixed some `rubocop` warnings
* Disabled JS driver usage on some scenarios as they work without it
* Fixed typos

Visual Changes (if any)
=======================
None

Notes
=====================
* Pending backport to CONSUL once approved & merged into `master`
