### PR TITLE
Add missing `logout` on comments/topics#update scenario

### DIFF
--- a/spec/features/comments/topics_spec.rb
+++ b/spec/features/comments/topics_spec.rb
@@ -1013,15 +1013,17 @@ feature 'Commenting topics from budget investments' do
   end
 
   feature 'Voting comments' do
-
     background do
       @manuela = create(:user, verified_at: Time.current)
       @pablo = create(:user)
       @investment = create(:budget_investment)
       @topic = create(:topic, community: @investment.community)
       @comment = create(:comment, commentable: @topic)
-
       login_as(@manuela)
+    end
+
+    after do
+      logout
     end
 
     scenario 'Show' do


### PR DESCRIPTION
References
==========
* Related PRs: #1212, #1241

Objectives
==========
* Adds missing `logout` on `comments/topics#update` scenario (under `Commenting topics from budget investments` feature) to mitigate a possible flaky

Visual Changes (if any)
=======================
* None

Notes
=====================
* The commit for this PR is already included in the consul/consul#2448 backport
