### PR TITLE
Fix for flaky spec: Poll Officing Officing dashboard available for multiple sessions

### DIFF
--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -157,6 +157,8 @@ feature 'Poll Officing' do
       expect(page).to have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
+      expect(page).to have_selector('#residence_document_type')
+
       select 'DNI', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "12345678Z"
       fill_in 'residence_year_of_birth', with: '1980'
@@ -174,6 +176,8 @@ feature 'Poll Officing' do
       expect(page).to have_content("Here you can validate user documents and store voting results")
 
       visit new_officing_residence_path
+      expect(page).to have_selector('#residence_document_type')
+
       select 'Passport', from: 'residence_document_type'
       fill_in 'residence_document_number', with: "12345678A"
       fill_in 'residence_year_of_birth', with: '1980'


### PR DESCRIPTION
References
==========
* https://github.com/AyuntamientoMadrid/consul/issues/1200

Objectives
==========
* Fix the flaky, i seems to happen when the container of the selector for dni/passport isn't present. At first it looked like an error due the date used for the 2 poll_shift created (as it was [here](https://github.com/AyuntamientoMadrid/consul/pull/1343) ) but a quick check using different dates provoked a different error, so suspicions recalled about a race condition in the selector container. The solution that I proposes here is just  check the existence of the container using have_selector, which waits for js to be completed

Visual Changes (if any)
=======================
* none

Notes
=====================
* none