### PR TITLE
User segment for users that haven't supported in budget

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -542,6 +542,7 @@ en:
       feasible_and_undecided_investment_authors: "Authors of some investment in the current budget that does not comply with: [valuation finished unfesasible]"
       selected_investment_authors: Authors of selected investments in the current budget
       winner_investment_authors: Authors of winner investments in the current budget
+      not_supported_on_current_budget: Users that haven't supported investments on current budget
       invalid_recipients_segment: "Recipients user segment is invalid"
     newsletters:
       create_success: Newsletter created successfully

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -542,6 +542,7 @@ es:
       feasible_and_undecided_investment_authors: "Usuarios autores de algún proyecto de gasto en los actuales presupuestos que no cumpla: [evaluación finalizada inviable]"
       selected_investment_authors: Usuarios autores de proyectos de gasto seleccionadas en los actuales presupuestos
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
+      not_supported_on_current_budget: Usuarios que no han apoyado proyectos de los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"
     newsletters:
       create_success: Newsletter creada correctamente

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -6,6 +6,7 @@ class UserSegments
                 feasible_and_undecided_investment_authors
                 selected_investment_authors
                 winner_investment_authors
+                not_supported_on_current_budget
                 beta_testers)
 
   def self.all_users
@@ -36,6 +37,17 @@ class UserSegments
 
   def self.winner_investment_authors
     author_ids(current_budget_investments.winners.pluck(:author_id).uniq)
+  end
+
+  def self.not_supported_on_current_budget
+    author_ids(
+      User.where(
+                  'id NOT IN (SELECT DISTINCT(voter_id) FROM votes'\
+                  ' WHERE votable_type = ? AND votes.votable_id IN (?))',
+                  'Budget::Investment',
+                  current_budget_investments.pluck(:id)
+                )
+    )
   end
 
   def self.beta_testers

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -173,6 +173,23 @@ describe UserSegments do
     end
   end
 
+  describe "#not_supported_on_current_budget" do
+    it "only returns users that haven't supported investments on current budget" do
+      investment1 = create(:budget_investment)
+      investment2 = create(:budget_investment)
+      budget = create(:budget)
+      investment1.vote_by(voter: user1, vote: 'yes')
+      investment2.vote_by(voter: user2, vote: 'yes')
+      investment1.update(budget: budget)
+      investment2.update(budget: budget)
+
+      not_supported_on_current_budget = described_class.not_supported_on_current_budget
+      expect(not_supported_on_current_budget).to include user3
+      expect(not_supported_on_current_budget).not_to include user1
+      expect(not_supported_on_current_budget).not_to include user2
+    end
+  end
+
   describe "#beta_testers" do
     let(:beta_testers) do
       %w(aranacm@madrid.es bertocq@gmail.com mariajecheca@gmail.com


### PR DESCRIPTION
References
==========
Direct product request

Objectives
==========
Create a segment that returns all users that haven't supported investments on current budget

Visual Changes (if any)
=======================
None

Notes
=====================
This PR will need a backport to Consul as its not a segment specific to madrid's needs