### PR TITLE
Changed poll results message if the poll is not available (but all are public)

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -34,6 +34,9 @@ class PollsController < ApplicationController
   end
 
   def results
+    unless @poll.expired? && @poll.results_enabled?
+      redirect_to main_app.root_url, alert: t('polls.not_available')
+    end
   end
 
   def results_2017

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -9,9 +9,7 @@ module Abilities
       can :read, Poll
       can :results_2018, Poll
       can :stats_2018, Poll
-      can :results, Poll do |poll|
-        poll.expired? && poll.results_enabled?
-      end
+      can :results, Poll
       can :stats, Poll do |poll|
         poll.expired? && poll.stats_enabled?
       end

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -352,6 +352,7 @@ en:
     results:
       heading: "Results"
   polls:
+    not_available: Poll not available for public display
     results: Results
     stats: Statistics
     information: Information

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -352,6 +352,7 @@ es:
     results:
       heading: "Resultados"
   polls:
+    not_available: Encuesta no disponible para exhibición pública
     results: Resultados
     stats: Estadísticas
     information: Información

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -1,29 +1,35 @@
 section "Creating polls" do
 
   Poll.create(name: I18n.t('seeds.polls.current_poll'),
+              slug: I18n.t('seeds.polls.current_poll').parameterize,
               starts_at: 7.days.ago,
               ends_at:   7.days.from_now,
               geozone_restricted: false)
 
   Poll.create(name: I18n.t('seeds.polls.current_poll_geozone_restricted'),
+              slug: I18n.t('seeds.polls.current_poll_geozone_restricted').parameterize,
               starts_at: 5.days.ago,
               ends_at:   5.days.from_now,
               geozone_restricted: true,
               geozones: Geozone.reorder("RANDOM()").limit(3))
 
   Poll.create(name: I18n.t('seeds.polls.incoming_poll'),
+              slug: I18n.t('seeds.polls.incoming_poll').parameterize,
               starts_at: 1.month.from_now,
               ends_at:   2.months.from_now)
 
   Poll.create(name: I18n.t('seeds.polls.recounting_poll'),
+              slug: I18n.t('seeds.polls.recounting_poll').parameterize,
               starts_at: 15.days.ago,
               ends_at:   2.days.ago)
 
   Poll.create(name: I18n.t('seeds.polls.expired_poll_without_stats'),
+              slug: I18n.t('seeds.polls.expired_poll_without_stats').parameterize,
               starts_at: 2.months.ago,
               ends_at:   1.month.ago)
 
   Poll.create(name: I18n.t('seeds.polls.expired_poll_with_stats'),
+              slug: I18n.t('seeds.polls.expired_poll_with_stats').parameterize,
               starts_at: 2.months.ago,
               ends_at:   1.month.ago,
               results_enabled: true,

--- a/spec/features/polls/results_spec.rb
+++ b/spec/features/polls/results_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 feature 'Poll Results' do
+
+  scenario 'Does not show polls without enabled results' do
+    poll = create(:poll, results_enabled: false)
+    visit results_poll_path(poll)
+
+    expect(page).to have_content("Poll not available for public display")
+  end
+
+  scenario 'Does not show incomplete polls' do
+    poll = create(:poll, ends_at: Date.yesterday)
+    visit results_poll_path(poll)
+
+    expect(page).to have_content("Poll not available for public display")
+  end
+
+
   scenario 'List each Poll question', :js do
     user1 = create(:user, :level_two)
     user2 = create(:user, :level_two)


### PR DESCRIPTION
References
==========
* https://github.com/AyuntamientoMadrid/consul/issues/1364

Objectives
==========
* Changed message when anyone goes to poll/id/results and the poll results are not available

Visual Changes (if any)
=======================
![screenshot from 2018-03-15 17-39-45](https://user-images.githubusercontent.com/33748390/37510623-17317128-28fc-11e8-8d32-4ca904c793df.png)

Notes
=====================
* The problem was given because abilities were used to not show poll results not available, so it does for poll stats, maybe it would be interesting to do the same to indicate that given a poll their stats are not available