### PR TITLE
Fix for invalid authenticity token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,10 @@ class ApplicationController < ActionController::Base
   respond_to :html
   helper_method :current_budget
 
+  def handle_unverified_request
+    redirect_to :back, :flash => { :error => t("form.invalid_authenticity_token") }
+  end
+
   private
 
     def authenticate_http_basic

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -168,6 +168,7 @@ en:
       user_not_found: User not found
       invalid_date_range: "Invalid date range"
   form:
+    invalid_authenticity_token: Invalid authenticity token, please try again.
     accept_terms: I agree to the %{policy} and the %{conditions}
     accept_terms_title: I agree to the Privacy Policy and the Terms and conditions of use
     conditions: Terms and conditions of use

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -168,6 +168,7 @@ es:
       user_not_found: Usuario no encontrado
       invalid_date_range: "El rango de fechas no es válido"
   form:
+    invalid_authenticity_token: Formulario inseguro, intentelo de nuevo.
     accept_terms: Acepto la %{policy} y las %{conditions}
     accept_terms_title: Acepto la Política de privacidad y las Condiciones de uso
     conditions: Condiciones de uso

--- a/spec/features/application_spec.rb
+++ b/spec/features/application_spec.rb
@@ -1,14 +1,10 @@
 require 'rails_helper'
 
-Rails.application.configure do
-  config.action_controller.allow_forgery_protection = true
-end
-
 feature "Application" do
 
-  let(:user)  { create(:user) }
+  let(:user) { create(:user) }
 
-  scenario 'protects from forgery on forms', :js do
+  scenario 'protects from forgery on forms', :js, with_csrf_protection: true do
     login_as(user)
     visit account_path
 

--- a/spec/features/application_spec.rb
+++ b/spec/features/application_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+Rails.application.configure do
+  config.action_controller.allow_forgery_protection = true
+end
+
+feature "Application" do
+
+  let(:user)  { create(:user) }
+
+  scenario 'protects from forgery on forms', :js do
+    login_as(user)
+    visit account_path
+
+    fill_in 'account_username', with: 'Larry Bird'
+
+    page.execute_script("$('input[name=authenticity_token]').attr('value','not_secure_token')")
+
+    click_button 'Save changes'
+
+    expect(page).to have_content "Invalid authenticity token, please try again."
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,18 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 Dir["./spec/shared/**/*.rb"].sort.each  { |f| require f }
 
 RSpec.configure do |config|
+
+  config.around(:each, :with_csrf_protection) do |example|
+    orig = ActionController::Base.allow_forgery_protection
+
+    begin
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = orig
+    end
+  end
+
   config.use_transactional_fixtures = false
 
   config.filter_run :focus


### PR DESCRIPTION
References
==========
* https://github.com/AyuntamientoMadrid/consul/issues/1298

Objectives
==========
* Fixed an error that occurred if someone who used the application in several tabs (and who had the session started), Log out in one tab, when trying to navigate to other private pages (in other tab), the server does not correctly recognize the action to log out and crashes

Visual Changes (if any)
=======================
* None

Notes
=====================
* Its the same error on [Agendas](https://github.com/AyuntamientoMadrid/agendas/pull/333) fixed by @vicentemendozam 
