### PR TITLE
[WIP] Configure timecop gem to avoid stalled CI jobs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,6 +125,10 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.expect_with(:rspec) { |c| c.syntax = :expect }
+
+  config.after(:each) do
+    Timecop.return
+  end
 end
 
 # Parallel build helper configuration for travis


### PR DESCRIPTION
References
==========
Related Travis CI builds:
* [Build 419, job 2](https://travis-ci.org/wairbut-m2c-aytomadrid/consul/jobs/355525925)
* [Build 349, job 3](https://travis-ci.org/wairbut-m2c-aytomadrid/consul/jobs/352906447)
* [Build 356, job 5](https://travis-ci.org/wairbut-m2c-aytomadrid/consul/jobs/353205919)

Related links:
* [Common Build Problems - Travis CI](https://docs.travis-ci.com/user/common-build-problems/#Ruby%3A-tests-frozen-and-cancelled-after-10-minute-log-silence)

Objectives
==========
@iagirre and I have been noticing that some Travis CI jobs are getting stalled after 10 minutes without receiving output —this PR aims to fix that by correctly configuring the [`timecop`](https://rubygems.org/gems/timecop) gem

Visual Changes (if any)
=======================
None

Notes
=====================
None
