### PR TITLE
Flaky spec: Admin banners magement Edit banner with live refresh

### DIFF
--- a/spec/features/admin/banners_spec.rb
+++ b/spec/features/admin/banners_spec.rb
@@ -111,14 +111,7 @@ feature 'Admin banners magement' do
                               post_started_at: (Time.current + 4.days),
                               post_ended_at:   (Time.current + 10.days))
 
-    visit admin_root_path
-
-    within('#side_menu') do
-      click_link "Banners"
-      click_link "Manage banners"
-    end
-
-    click_link "Edit banner"
+    visit edit_admin_banner_path(banner1.id)
 
     select 'Banner style 1', from: 'banner_style'
     select 'Banner image 2', from: 'banner_image'


### PR DESCRIPTION
References
==========
**Related issue**: #1216

Objectives
==========
There was a flaky test that failed in `spec/features/admin/banners_spec.rb` file. It happened when the test reached the edit banner page because it couldn't found the `#banner_style` element of the form.

The edit page is accessed through a `XMLHttpRequest` (`XHR`), as seen in the image.

![xhr01](https://user-images.githubusercontent.com/31625251/37699421-cbbb57a0-2ce7-11e8-85a8-1a20703b03d8.gif)

According to [MDN web docs](https://developer.mozilla.org/es/docs/Web/API/XMLHttpRequest), this type of request is a JavasCript object that let us get information from an URL without loading the whole page AND is widely used in AJAX programming. Turbolinks use this type of request, as read in their [GitHub page](https://github.com/turbolinks/turbolinks#navigating-with-turbolinks):

> Turbolinks changes the browser’s URL using the History API, requests the new page using XMLHttpRequest, and then renders the HTML response.

What I think is that, in this case, it's acts similar to an AJAX request and it generates a race condition between the 'Edit' link click and the `select 'Banner style 1', from: 'banner_style'` instruction.

```
[...]
         within('#side_menu') do
           click_link "Banners"
           click_link "Manage banners"
         end
 
         click_link "Edit banner"
HERE -> 
         select 'Banner style 1', from: 'banner_style'    #The line that fails
[...]
```

When it tries to select the option from the banner, it isn't there because the page didn't have enough time to load.

The solution I propose is to access directly to the 'Edit' page, without using the UI at all. This way, the requested that are made are not AJAX or XHR, so there is no race condition there.

![xhr02](https://user-images.githubusercontent.com/31625251/37699428-d145630a-2ce7-11e8-89f3-9833314e4d70.gif)

Visual Changes
=======================
There aren't, it's a flaky.

Notes
=====================
Nothing to mention.
