### PR TITLE
Allow users to support in multiple headings per group

### DIFF
--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -16,7 +16,7 @@ class Admin::BudgetGroupsController < Admin::BaseController
   private
 
     def budget_group_params
-      params.require(:budget_group).permit(:name)
+      params.require(:budget_group).permit(:name, :max_votable_headings)
     end
 
     def load_budget

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -248,17 +248,18 @@ class Budget
     end
 
     def valid_heading?(user)
-      reclassification?(user) || !different_heading_assigned?(user)
+      reclassification?(user) ||
+      voted_in?([heading.id], user) ||
+      can_vote_in_another_heading?(user)
+    end
+
+    def can_vote_in_another_heading?(user)
+      headings_voted_by_user(user).count < group.max_votable_headings
     end
 
     def reclassification?(user)
       headings_voted_by_user(user).count > 1 &&
       headings_voted_by_user(user).include?(heading_id)
-    end
-
-    def different_heading_assigned?(user)
-      other_heading_ids = group.heading_ids - [heading.id]
-      voted_in?(other_heading_ids, user)
     end
 
     def voted_in?(heading_ids, user)

--- a/app/views/admin/budgets/_group_form.html.erb
+++ b/app/views/admin/budgets/_group_form.html.erb
@@ -8,6 +8,19 @@
                       maxlength: 50,
                       placeholder: t("admin.budgets.form.group"),
                       class: "input-group-field" %>
+
+    <% if group.persisted? %>
+      <div class="small-12 medium-6 large-4">
+        <%= f.label :name, t("admin.budgets.form.max_votable_headings") %>
+
+        <%= f.select :max_votable_headings,
+                     (1..group.headings.count),
+                     label: false,
+                     placeholder: t("admin.budgets.form.max_votable_headings"),
+                     class: "input-group-field" %>
+      </div>
+    <% end %>
+
     <div class="input-group-button">
       <%= f.submit button_title, class: "button success" %>
     </div>

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -19,7 +19,7 @@
           title: t('budgets.investments.investment.support_title'),
           method: "post",
           remote: (display_support_alert?(investment) ? false: true ),
-          data:   (display_support_alert?(investment) ? { confirm: t('budgets.investments.investment.confirm_group')} : nil),
+          data:   (display_support_alert?(investment) ? { confirm: t('budgets.investments.investment.confirm_group', count: investment.group.max_votable_headings)} : nil),
           "aria-hidden" => css_for_aria_hidden(reason) do %>
         <%= t("budgets.investments.investment.give_support") %>
       <% end %>
@@ -30,7 +30,8 @@
     <div class="js-participation-not-allowed participation-not-allowed" style='display:none' aria-hidden="false">
       <p>
         <small>
-          <%= t("votes.budget_investments.#{reason}",
+          <%= t("votes.budget_investments.#{reason}", 
+                count: investment.group.max_votable_headings,
                 verify_account: link_to(t("votes.verify_account"), verification_path),
                 signin: link_to(t("votes.signin"), new_user_session_path),
                 signup: link_to(t("votes.signup"), new_user_registration_path)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -202,6 +202,7 @@ ignore_unused:
   - users.show.delete_spending_proposal
   - verification.letter.create.flash.offices_url
   - verification.letter.new.offices_url
+  - votes.budget_investments.different_heading_assigned*
   - layouts.header.open_city_title
   - admin.stats.polls.current
   - admin.stats.polls.expired

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -42,4 +42,6 @@ en:
       heading_disclaimer: "*** Data about headings refer to the heading where each user voted, not necessarily the one that person is registered on."
   votes:
     budget_investments:
-      different_heading_assigned: "You can only support investment projects in one district"
+      different_heading_assigned: 
+        one: "You can only support investment projects in %{count} district"
+        other: "You can only support investment projects in %{count} districts"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -25,7 +25,9 @@ es:
         already_added: "Ya has añadido este proyecto de gasto"
         already_supported: Ya has apoyado este proyecto. ¡Compártelo!
         support_title: Apoyar este proyecto
-        confirm_group: "Sólo puedes apoyar proyectos en un distrito. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
+        confirm_group: 
+          one: "Sólo puedes apoyar proyectos en %{count} distrito. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
+          other: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
       header:
         different_heading_assigned_html: "Ya has votado proyectos de otro distrito: %{heading_link}"
     stats:
@@ -62,4 +64,6 @@ es:
       heading_disclaimer: "*** Los datos de distrito se refieren al distrito en el que el usuario ha votado, no necesariamente en el que está empadronado."
   votes:
     budget_investments:
-      different_heading_assigned: "Sólo puedes apoyar proyectos de gasto de un distrito"
+      different_heading_assigned: 
+        one: "Sólo puedes apoyar proyectos de gasto de %{count} distrito"
+        other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -25,9 +25,6 @@ es:
         already_added: "Ya has añadido este proyecto de gasto"
         already_supported: Ya has apoyado este proyecto. ¡Compártelo!
         support_title: Apoyar este proyecto
-        confirm_group: 
-          one: "Sólo puedes apoyar proyectos en %{count} distrito. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
-          other: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
       header:
         different_heading_assigned_html: "Ya has votado proyectos de otro distrito: %{heading_link}"
     stats:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -122,6 +122,7 @@ en:
         table_amount: Amount
         table_population: Population
         population_info: "Budget Heading population field is used for Statistic purposes at the end of the Budget to show for each Heading that represents an area with population what percentage voted. The field is optional so you can leave it empty if it doesn't apply."
+        max_votable_headings: "Maxium number of headings in which a user can vote"
       winners:
         calculate: Calculate Winner Investments
         calculated: Winners being calculated, it may take a minute.

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -133,8 +133,8 @@ en:
         already_supported: You have already supported this investment project. Share it!
         support_title: Support this project
         confirm_group: 
-          one: "You can only support investments in %{count} heading. If you continue you cannot change your decision. Are you sure?"
-          other: "You can only support investments in %{count} headings. If you continue you cannot change your decision. Are you sure?"
+          one: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
+          other: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
         supports:
           one: 1 support
           other: "%{count} supports"

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -132,7 +132,9 @@ en:
         already_added: You have already added this investment project
         already_supported: You have already supported this investment project. Share it!
         support_title: Support this project
-        confirm_group: "You can only support investments in one heading. If you continue you cannot change your decision. Are you sure?"
+        confirm_group: 
+          one: "You can only support investments in %{count} heading. If you continue you cannot change your decision. Are you sure?"
+          other: "You can only support investments in %{count} headings. If you continue you cannot change your decision. Are you sure?"
         supports:
           one: 1 support
           other: "%{count} supports"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -122,6 +122,7 @@ es:
         table_amount: Cantidad
         table_population: Población
         population_info: "El campo población de las partidas presupuestarias se usa con fines estadísticos únicamente, con el objetivo de mostrar el porcentaje de votos habidos en cada partida que represente un área con población. Es un campo opcional, así que puedes dejarlo en blanco si no aplica."
+        max_votable_headings: "Máximo número de partidas en que un usuario puede votar"
       winners:
         calculate: Calcular propuestas ganadoras
         calculated: Calculando ganadoras, puede tardar un minuto.

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -132,7 +132,9 @@ es:
         already_added: Ya has añadido este proyecto de gasto
         already_supported: Ya has apoyado este proyecto de gasto. ¡Compártelo!
         support_title: Apoyar este proyecto
-        confirm_group: "Sólo puedes apoyar proyectos de una partida. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
+        confirm_group: 
+          one: "Sólo puedes apoyar proyectos de %{count} partida. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
+          other: "Sólo puedes apoyar proyectos de %{count} partidas. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
         supports:
           zero: Sin apoyos
           one: 1 apoyo

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -133,8 +133,8 @@ es:
         already_supported: Ya has apoyado este proyecto de gasto. ¡Compártelo!
         support_title: Apoyar este proyecto
         confirm_group: 
-          one: "Sólo puedes apoyar proyectos de %{count} partida. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
-          other: "Sólo puedes apoyar proyectos de %{count} partidas. Si sigues adelante no podrás cambiar esta decisión. ¿Estás seguro?"
+          one: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar la elección de este distrito. ¿Estás seguro?"
+          other: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar la elección de este distrito. ¿Estás seguro?"
         supports:
           zero: Sin apoyos
           one: 1 apoyo

--- a/db/migrate/20180320104823_add_max_votable_headings_to_budget_groups.rb
+++ b/db/migrate/20180320104823_add_max_votable_headings_to_budget_groups.rb
@@ -1,0 +1,5 @@
+class AddMaxVotableHeadingsToBudgetGroups < ActiveRecord::Migration
+  def change
+    add_column :budget_groups, :max_votable_headings, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222120017) do
+ActiveRecord::Schema.define(version: 20180320104823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,8 +143,9 @@ ActiveRecord::Schema.define(version: 20180222120017) do
 
   create_table "budget_groups", force: :cascade do |t|
     t.integer "budget_id"
-    t.string  "name",      limit: 50
+    t.string  "name",                 limit: 50
     t.string  "slug"
+    t.integer "max_votable_headings",            default: 1
   end
 
   add_index "budget_groups", ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -65,4 +65,49 @@ feature 'Admin can change the groups name' do
     expect(page).to have_content('has already been taken')
   end
 
+  context "Maximum votable headings" do
+
+    background do
+      3.times { create(:budget_heading, group: group) }
+    end
+
+    scenario "Defaults to 1 heading per group", :js do
+      visit admin_budget_path(group.budget)
+
+      within("#budget_group_#{group.id}") do
+        click_link 'Edit group'
+
+        expect(page).to have_select('budget_group_max_votable_headings', selected: '1')
+      end
+    end
+
+    scenario "Update", :js do
+      visit admin_budget_path(group.budget)
+
+      within("#budget_group_#{group.id}") do
+        click_link 'Edit group'
+
+        select '2', from: 'budget_group_max_votable_headings'
+        click_button 'Save group'
+      end
+
+      visit admin_budget_path(group.budget)
+
+      within("#budget_group_#{group.id}") do
+        click_link 'Edit group'
+
+        expect(page).to have_select('budget_group_max_votable_headings', selected: '2')
+      end
+    end
+
+    scenario "Do not display maxium votable headings' select in new form", :js do
+      visit admin_budget_path(group.budget)
+
+      click_link 'Add new group'
+
+      expect(page).to have_field('budget_group_name')
+      expect(page).to_not have_field('budget_group_max_votable_headings')
+    end
+
+  end
 end

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -103,5 +103,74 @@ feature 'Votes' do
         expect(page).not_to have_css("budget_investment_#{investment.id}_votes")
       end
     end
+
+    context "Voting in multiple headings of a single group" do
+
+      let(:new_york) { heading }
+      let(:san_francisco) { create(:budget_heading, group: group) }
+      let(:third_heading) { create(:budget_heading, group: group) }
+
+      let!(:new_york_investment) { create(:budget_investment, heading: new_york) }
+      let!(:san_francisco_investment) { create(:budget_investment, heading: san_francisco) }
+      let!(:third_heading_investment) { create(:budget_investment, heading: third_heading) }
+
+      background do
+        group.update(max_votable_headings: 2)
+      end
+
+      scenario "From Index", :js do
+        visit budget_investments_path(budget, heading_id: new_york.id)
+
+        within("#budget_investment_#{new_york_investment.id}") do
+          find('.in-favor a').click
+
+          expect(page).to have_content "1 support"
+          expect(page).to have_content "You have already supported this investment project. Share it!"
+        end
+
+        visit budget_investments_path(budget, heading_id: san_francisco.id)
+
+        within("#budget_investment_#{san_francisco_investment.id}") do
+          find('.in-favor a').click
+
+          expect(page).to have_content "1 support"
+          expect(page).to have_content "You have already supported this investment project. Share it!"
+        end
+
+        visit budget_investments_path(budget, heading_id: third_heading.id)
+
+        within("#budget_investment_#{third_heading_investment.id}") do
+          find('.in-favor a').click
+
+          expect(page).to have_content "You can only support investment projects in 2 districts"
+
+          expect(page).to_not have_content "1 support"
+          expect(page).to_not have_content "You have already supported this investment project. Share it!"
+        end
+      end
+
+      scenario "From show", :js do
+        visit budget_investment_path(budget, new_york_investment)
+
+        find('.in-favor a').click
+        expect(page).to have_content "1 support"
+        expect(page).to have_content "You have already supported this investment project. Share it!"
+
+        visit budget_investment_path(budget, san_francisco_investment)
+
+        find('.in-favor a').click
+        expect(page).to have_content "1 support"
+        expect(page).to have_content "You have already supported this investment project. Share it!"
+
+        visit budget_investment_path(budget, third_heading_investment)
+
+        find('.in-favor a').click
+        expect(page).to have_content "You can only support investment projects in 2 districts"
+
+        expect(page).to_not have_content "1 support"
+        expect(page).to_not have_content "You have already supported this investment project. Share it!"
+      end
+
+    end
   end
 end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -754,6 +754,20 @@ describe Budget::Investment do
         expect(salamanca_investment.valid_heading?(user)).to eq(false)
       end
 
+      it "accepts votes in multiple headings of the same group" do
+        group.update(max_votable_headings: 2)
+
+        carabanchel = create(:budget_heading, group: group)
+        salamanca   = create(:budget_heading, group: group)
+
+        carabanchel_investment = create(:budget_investment, heading: carabanchel)
+        salamanca_investment   = create(:budget_investment, heading: salamanca)
+
+        create(:vote, votable: carabanchel_investment, voter: user)
+
+        expect(salamanca_investment.valid_heading?(user)).to eq(true)
+      end
+
       it "allows votes in a group with a single heading" do
         all_city_investment = create(:budget_investment, heading: heading)
         expect(all_city_investment.valid_heading?(user)).to eq(true)
@@ -815,6 +829,35 @@ describe Budget::Investment do
         expect(carabanchel_investment.valid_heading?(user)).to eq(true)
         expect(salamanca_investment.valid_heading?(user)).to eq(true)
         expect(latina_investment.valid_heading?(user)).to eq(false)
+      end
+
+      describe "#can_vote_in_another_heading?" do
+
+        let(:districts)   { create(:budget_group, budget: budget) }
+        let(:carabanchel) { create(:budget_heading, group: districts) }
+        let(:salamanca)   { create(:budget_heading, group: districts) }
+        let(:latina)      { create(:budget_heading, group: districts) }
+
+        let(:carabanchel_investment) { create(:budget_investment, heading: carabanchel) }
+        let(:salamanca_investment)   { create(:budget_investment, heading: salamanca) }
+        let(:latina_investment)      { create(:budget_investment, heading: latina) }
+
+        it "returns true if the user has voted in less headings than the maximum" do
+          districts.update(max_votable_headings: 2)
+
+          create(:vote, votable: carabanchel_investment, voter: user)
+
+          expect(salamanca_investment.can_vote_in_another_heading?(user)).to eq(true)
+        end
+
+        it "returns false if the user has already voted in the maximum number of headings" do
+          districts.update(max_votable_headings: 2)
+
+          create(:vote, votable: carabanchel_investment, voter: user)
+          create(:vote, votable: salamanca_investment, voter: user)
+
+          expect(latina_investment.can_vote_in_another_heading?(user)).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
References
==========
**Issue**: https://github.com/consul/consul/issues/2320

Objectives
==========
Allow users to support in multiple headings of a single group by changing the maxium number of votable headings from the admin section

Visual Changes
=======================
![35875304-189dbd78-0b6f-11e8-84aa-a9e2d480e828](https://user-images.githubusercontent.com/4169/37759593-5cacfcba-2db4-11e8-9df1-1d3d8da3da30.jpg)

![35875305-18be5998-0b6f-11e8-984e-49fb1033d42c](https://user-images.githubusercontent.com/4169/37759609-65b2eb9e-2db4-11e8-8347-311bd8f7d612.jpg)

Notes
=====================
Now that we have the option of voting in multiple headings per group, the method of voting in a `different heading assigned` has become deprecated and thus removed. 

Instead, knowing if a user can vote in a new heading, depends on the maximum votable headings per group variable. 

Also, if a user has already been granted permission to support in a heading, we assume it has permissions to support in it throughout the phase, even if the maximum number of votable headings is decreased during the support phase.