### PR TITLE
Fix for the bug happened on milestones index of a Budget::Investment created from a SpendingProposal

### DIFF
--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -1,4 +1,10 @@
-<%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
+<% path = if @milestone.new_record?
+    admin_budget_budget_investment_budget_investment_milestones_path(@investment.budget, @investment.id)
+  else
+    admin_budget_budget_investment_budget_investment_milestone_path(@investment.budget, @investment.id, @milestone.id)
+  end %>
+
+<%= form_for [:admin, @investment.budget, @investment, @milestone], url: path do |f| %>
 
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime), maxlength: Budget::Investment::Milestone.title_max_length %>
   <%= f.text_area :description, rows: 5 %>

--- a/app/views/admin/budget_investments/show.html.erb
+++ b/app/views/admin/budget_investments/show.html.erb
@@ -69,6 +69,6 @@
 
 <p>
   <%= link_to t("admin.budget_investments.show.new_milestone"),
-              new_admin_budget_budget_investment_budget_investment_milestone_path(@budget, @investment),
+              new_admin_budget_budget_investment_budget_investment_milestone_path(@budget, @investment.id),
               class: "button hollow" %>
 </p>

--- a/spec/features/admin/budget_investment_milestones_spec.rb
+++ b/spec/features/admin/budget_investment_milestones_spec.rb
@@ -102,4 +102,22 @@ feature 'Admin budget investment milestones' do
     end
   end
 
+  context "create from updated spending proposal" do
+
+    scenario "Add milestone" do
+      investment = create(:budget_investment, original_spending_proposal_id: 8)
+      visit admin_budget_budget_investment_path(investment.budget, investment)
+
+      click_link 'Create new milestone'
+
+      fill_in 'budget_investment_milestone_description', with: 'New description milestone1'
+      fill_in 'budget_investment_milestone_publication_date', with: Date.current
+
+      click_button 'Create milestone'
+
+      expect(page).to have_content 'New description milestone1'
+      expect(page).to have_content Date.current
+    end
+  end
+
 end


### PR DESCRIPTION
References
==========
* https://github.com/AyuntamientoMadrid/consul/issues/1288

Objectives
==========
* Fix the error wich happens when an admin goes to the milestones page of a Budget::Investment created form an old SpendingProposal. The problem was 2 paths using @investment.original_spending_proposal_id (from the to_param method) instead of @investment.id

Visual Changes (if any)
=======================
* none

Notes
=====================
* none
