### PR TITLE
[WIP] Recommendations index

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -18,7 +18,7 @@
 // 16. Flags
 // 17. Activity
 // 18. Banners
-// 19. Recommended Section Home
+// 19. Recommendations
 // 20. Documents
 // 21. Related content
 // 22. Images
@@ -2271,8 +2271,8 @@ table {
   }
 }
 
-// 19. Recommended Section Home
-// ----------------------------
+// 19. Recommendations
+// -------------------
 
 .home-page {
 
@@ -2411,6 +2411,54 @@ table {
       margin: 0 auto;
     }
   }
+}
+
+.recommended-index {
+  background: #fafafa;
+  border-bottom: 1px solid #eee;
+  margin-bottom: $line-height;
+  margin-top: rem-calc(-25);
+  padding: $line-height 0;
+
+  @include breakpoint(medium) {
+    padding-top: 0;
+  }
+
+  h2 {
+    font-size: $small-font-size;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    font-size: $base-font-size;
+    margin-bottom: 0;
+  }
+
+  a {
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .recommendation {
+    background: #fff;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.15);
+    display: block;
+    margin-bottom: $line-height / 4;
+    padding: $line-height / 2;
+
+    &:hover {
+      box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.15);
+    }
+  }
+}
+
+.hide-recommendations {
+  color: $text-light;
+  position: absolute;
+  right: 12px;
+  top: rem-calc(-18);
 }
 
 // 20. Documents

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -6,6 +6,7 @@ class DebatesController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show, :map]
   before_action :set_view, only: :index
+  before_action :debates_recommendations, only: :index, if: :current_user
 
   feature_flag :debates
 
@@ -63,4 +64,7 @@ class DebatesController < ApplicationController
       @view = (params[:view] == "minimal") ? "minimal" : "default"
     end
 
+    def debates_recommendations
+      @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
+    end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -9,6 +9,7 @@ class ProposalsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
   before_action :destroy_map_location_association, only: :update
   before_action :set_view, only: :index
+  before_action :proposals_recommendations, only: :index, if: :current_user
 
   feature_flag :proposals
 
@@ -170,5 +171,9 @@ class ProposalsController < ApplicationController
 
     def load_rank
       @proposal_rank ||= Proposal.rank(@proposal)
+    end
+
+    def proposals_recommendations
+      @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
     end
 end

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -40,6 +40,10 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
+  <% if feature?("user.recommendations_on_proposals") && @recommended_proposals.present? %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals %>
+  <% end %>
+
   <div class="row">
     <div id="proposals" class="proposals-list small-12 medium-9 column">
 

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -35,6 +35,10 @@
     <%= render "shared/section_header", i18n_namespace: "debates.index.section_header", image: "debates" %>
   <% end %>
 
+  <% if feature?("user.recommendations_on_debates") && @recommended_debates.present? %>
+    <%= render "shared/recommended_index", recommended: @recommended_debates %>
+  <% end %>
+
   <div class="row">
     <div id="debates" class="debates-list small-12 medium-9 column">
 

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -37,6 +37,10 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
+  <% if feature?("user.recommendations_on_proposals") && @recommended_proposals.present? %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals %>
+  <% end %>
+
   <div class="row">
     <div id="proposals" class="proposals-list small-12 medium-9 column">
 

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -1,0 +1,29 @@
+<div class="recommended-index">
+  <div class="row relative" data-equalizer data-equalizer-on="medium">
+    <div class="small-12 column">
+      <h2 class="show-for-sr"><%= t("shared.recommended_index.title") %></h2>
+    </div>
+
+    <%= link_to "#", title: t("shared.recommended_index.hide"),
+                     class: "float-right-medium small hide-recommendations" do %>
+      <span class="icon-x"></span>
+      <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
+    <% end %>
+
+    <% recommended.each_with_index do |recommended, index| %>
+      <div class="small-12 medium-6 large-4 column end">
+        <%= link_to recommended_path(recommended) do %>
+          <div class="recommendation" data-equalizer-watch>
+            <h3><%= recommended.title %></h3>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="small-12 column">
+      <%= link_to t("shared.recommended_index.see_more"),
+                  current_path_with_query_params(order: "recommendations"),
+                  class: "float-right-medium small" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_section_header.html.erb
+++ b/app/views/shared/_section_header.html.erb
@@ -3,7 +3,9 @@
     <div class="small-12 column" data-magellan>
       <%= image_tag "help/help_icon_#{image}.png", alt: t("#{i18n_namespace}.icon_alt"), class: "align-top" %>
       <h1 class="inline-block"><%= t("#{i18n_namespace}.title") %></h1>
-      <%= link_to t("#{i18n_namespace}.help"), "#section_help", class: "float-right" %>
+      <div class="float-right-medium">
+        <%= link_to t("#{i18n_namespace}.help"), "#section_help" %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -658,6 +658,10 @@ en:
       title: View mode
       cards: Cards
       list: List
+    recommended_index:
+        title: Recommendations
+        see_more: See more recommendations
+        hide: Hide recommendations
   social:
     blog: "%{org} Blog"
     facebook: "%{org} Facebook"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -53,6 +53,7 @@ en:
       user:
         recommendations: Recommendeds
         skip_verification: Skip user verification
+        recommendations_on_debates: Recommendeds on debates
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -54,6 +54,7 @@ en:
         recommendations: Recommendeds
         skip_verification: Skip user verification
         recommendations_on_debates: Recommendeds on debates
+        recommendations_on_proposals: Recommendeds on proposals
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -652,6 +652,10 @@ es:
       title: Modo de vista
       cards: Tarjetas
       list: Lista
+    recommended_index:
+        title: Recomendaciones
+        see_more: Ver más recomendaciones
+        hide: Ocultar recomendaciones
   social:
     blog: "Blog de %{org}"
     facebook: "Facebook de %{org}"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -54,6 +54,7 @@ es:
         recommendations: Recomendaciones
         skip_verification: Omitir verificación de usuarios
         recommendations_on_debates: Recomendaciones en debates
+        recommendations_on_proposals: Recomendaciones en propuestas
       community: Comunidad en propuestas y proyectos de gasto
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -53,6 +53,7 @@ es:
       user:
         recommendations: Recomendaciones
         skip_verification: Omitir verificación de usuarios
+        recommendations_on_debates: Recomendaciones en debates
       community: Comunidad en propuestas y proyectos de gasto
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,6 +82,7 @@ Setting['feature.budgets'] = true
 Setting['feature.signature_sheets'] = true
 Setting['feature.legislation'] = true
 Setting['feature.user.recommendations'] = true
+Setting['feature.user.recommendations_on_debates'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,6 +83,7 @@ Setting['feature.signature_sheets'] = true
 Setting['feature.legislation'] = true
 Setting['feature.user.recommendations'] = true
 Setting['feature.user.recommendations_on_debates'] = true
+Setting['feature.user.recommendations_on_proposals'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -467,16 +467,33 @@ feature 'Debates' do
 
       background do
         Setting['feature.user.recommendations'] = true
+        Setting['feature.user.recommendations_on_debates'] = true
       end
 
       after do
         Setting['feature.user.recommendations'] = nil
+        Setting['feature.user.recommendations_on_debates'] = nil
       end
 
       scenario 'Debates can not ordered by recommendations when there is not an user logged', :js do
         visit debates_path
 
         expect(page).not_to have_selector('a', text: 'recommendations')
+      end
+
+      scenario 'Show recommended debates on index header' do
+        proposal = create(:proposal, tag_list: "Sport")
+        user = create(:user)
+        create(:follow, followable: proposal, user: user)
+        login_as(user)
+
+        visit debates_path
+
+        expect(page).to have_css('.recommendation', count: 3)
+        expect(page).to have_link "Best"
+        expect(page).to have_link "Medium"
+        expect(page).to have_link "Worst"
+        expect(page).to have_link "See more recommendations"
       end
 
       scenario 'Should display text when there are not recommendeds results', :js do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -780,16 +780,33 @@ feature 'Proposals' do
 
       before do
         Setting['feature.user.recommendations'] = true
+        Setting['feature.user.recommendations_on_proposals'] = true
       end
 
       after do
         Setting['feature.user.recommendations'] = nil
+        Setting['feature.user.recommendations_on_proposals'] = nil
       end
 
       scenario 'Proposals can not ordered by recommendations when there is not an user logged', :js do
         visit proposals_path
 
         expect(page).not_to have_selector('a', text: 'recommendations')
+      end
+
+      scenario 'Show recommended proposals on index header' do
+        proposal = create(:proposal, tag_list: "Sport")
+        user = create(:user)
+        create(:follow, followable: proposal, user: user)
+        login_as(user)
+
+        visit proposals_path
+
+        expect(page).to have_css('.recommendation', count: 3)
+        expect(page).to have_link "Best"
+        expect(page).to have_link "Medium"
+        expect(page).to have_link "Worst"
+        expect(page).to have_link "See more recommendations"
       end
 
       scenario 'Should display text when there are not recommendeds results', :js do


### PR DESCRIPTION
References
==========
Related issue: https://github.com/consul/consul/issues/2212

Objectives
==========
Adds recommendations items on index views.

Pending ⚠️ 
==========
- Make the **X close icon** functional to close the recommendations.
- Add in "My account" two **checkboxes to enable/disable** this new features.

Screenshots of these pending things on https://github.com/consul/consul/issues/2212

Screenshots
==

**Recommendations on debates index**

<img width="1220" alt="debates_close" src="https://user-images.githubusercontent.com/631897/38020305-25f3e7ae-327a-11e8-9f23-a65216698a9a.png">

**Recommendations on proposals index (mobile size)**

<img width="398" alt="screen shot 2018-03-28 at 11 34 52" src="https://user-images.githubusercontent.com/631897/38021029-15ff7834-327c-11e8-8303-b3115d8f33e5.png">

Notes
==

Backport this PR to CONSUL when merged 🤓 