### PR TITLE
Add max heading number in Budget Group list

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1120,6 +1120,17 @@ table {
   }
 }
 
+.max-headings-label {
+  color: $text-medium;
+  font-size: $small-font-size;
+  margin-left: $line-height / 2;
+}
+
+.current-of-max-headings {
+  color: #000;
+  font-weight: bold;
+}
+
 // 11. Newsletters
 // -----------------
 

--- a/app/views/admin/budget_groups/update.js.erb
+++ b/app/views/admin/budget_groups/update.js.erb
@@ -2,5 +2,6 @@
   $("#group-form-<%= @group.id %>").html('<%= j render("admin/budgets/group_form", group: @group, budget: @group.budget, button_title: t("admin.budgets.form.submit"), id: "group-form-#{@group.id}", css_class: "group-toggle-#{@group.id}" ) %>');
 <% else %>
   $("#group-name-<%= @group.id %>").html('<%= @group.name %>')
+  $("#max-heading-label-<%=@group.id%>").html('<%= j render("admin/budgets/max_headings_label", current: @group.max_votable_headings, max: @group.headings.count, group: @group) %>')
   $(".group-toggle-<%= @group.id %>").toggle()
 <% end %>

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -1,8 +1,13 @@
+<% max_headings_label = t('admin.budgets.form.current_of_max_headings', current: group.max_votable_headings, max: group.headings.count ) %>
 <table>
   <thead>
     <tr>
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
+        <span class="max_headings_label" style="margin-left: 10px; font-size: 0.9em; color: gray;">
+          <%= t("admin.budgets.form.max_votable_headings")%>
+          <strong style="font-weight: bold; color: black;"><%= max_headings_label %></strong>
+        </span>
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
         <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -1,13 +1,11 @@
-<% max_headings_label = t('admin.budgets.form.current_of_max_headings', current: group.max_votable_headings, max: group.headings.count ) %>
 <table>
   <thead>
     <tr>
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
-        <span class="max_headings_label" style="margin-left: 10px; font-size: 0.9em; color: gray;">
-          <%= t("admin.budgets.form.max_votable_headings")%>
-          <strong style="font-weight: bold; color: black;"><%= max_headings_label %></strong>
-        </span>
+
+        <%= content_tag(:span, (render 'admin/budgets/max_headings_label', current: group.max_votable_headings, max: group.headings.count, group: group if group.max_votable_headings), class:"max-headings-label group-toggle-#{group.id}", id:"max-heading-label-#{group.id}") %>
+
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
         <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>

--- a/app/views/admin/budgets/_max_headings_label.html.erb
+++ b/app/views/admin/budgets/_max_headings_label.html.erb
@@ -1,0 +1,5 @@
+<%= t("admin.budgets.form.max_votable_headings")%>
+<%= content_tag(:strong,
+                t('admin.budgets.form.current_of_max_headings', current: current, max: max ),
+                class:"current-of-max-headings") %>
+

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -122,7 +122,7 @@ en:
         table_amount: Amount
         table_population: Population
         population_info: "Budget Heading population field is used for Statistic purposes at the end of the Budget to show for each Heading that represents an area with population what percentage voted. The field is optional so you can leave it empty if it doesn't apply."
-        max_votable_headings: "Maxium number of headings in which a user can vote"
+        max_votable_headings: "Maximum number of headings in which a user can vote"
         current_of_max_headings: "%{current} of %{max}"
       winners:
         calculate: Calculate Winner Investments

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -123,6 +123,7 @@ en:
         table_population: Population
         population_info: "Budget Heading population field is used for Statistic purposes at the end of the Budget to show for each Heading that represents an area with population what percentage voted. The field is optional so you can leave it empty if it doesn't apply."
         max_votable_headings: "Maxium number of headings in which a user can vote"
+        current_of_max_headings: "%{current} of %{max}"
       winners:
         calculate: Calculate Winner Investments
         calculated: Winners being calculated, it may take a minute.

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -123,6 +123,7 @@ es:
         table_population: Población
         population_info: "El campo población de las partidas presupuestarias se usa con fines estadísticos únicamente, con el objetivo de mostrar el porcentaje de votos habidos en cada partida que represente un área con población. Es un campo opcional, así que puedes dejarlo en blanco si no aplica."
         max_votable_headings: "Máximo número de partidas en que un usuario puede votar"
+        current_of_max_headings: "%{current} de %{max}"
       winners:
         calculate: Calcular propuestas ganadoras
         calculated: Calculando ganadoras, puede tardar un minuto.

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -49,7 +49,7 @@ feature 'Admin can change the groups name' do
     scenario "Defaults to 1 heading per group", :js do
       visit admin_budget_path(group.budget)
 
-      expect(page).to have_content('Maxium number of headings in which a user can vote 1 of 3')
+      expect(page).to have_content('Maximum number of headings in which a user can vote 1 of 3')
 
       within("#budget_group_#{group.id}") do
         click_link 'Edit group'
@@ -68,8 +68,7 @@ feature 'Admin can change the groups name' do
         click_button 'Save group'
       end
 
-      visit admin_budget_path(group.budget)
-      expect(page).to have_content('Maxium number of headings in which a user can vote 2 of 3')
+      expect(page).to have_content('Maximum number of headings in which a user can vote 2 of 3')
 
       within("#budget_group_#{group.id}") do
         click_link 'Edit group'
@@ -78,13 +77,13 @@ feature 'Admin can change the groups name' do
       end
     end
 
-    scenario "Do not display maxium votable headings' select in new form", :js do
+    scenario "Do not display maximum votable headings' select in new form", :js do
       visit admin_budget_path(group.budget)
 
       click_link 'Add new group'
 
       expect(page).to have_field('budget_group_name')
-      expect(page).to_not have_field('budget_group_max_votable_headings')
+      expect(page).not_to have_field('budget_group_max_votable_headings')
     end
 
   end

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -49,6 +49,8 @@ feature 'Admin can change the groups name' do
     scenario "Defaults to 1 heading per group", :js do
       visit admin_budget_path(group.budget)
 
+      expect(page).to have_content('Maxium number of headings in which a user can vote 1 of 3')
+
       within("#budget_group_#{group.id}") do
         click_link 'Edit group'
 
@@ -67,6 +69,7 @@ feature 'Admin can change the groups name' do
       end
 
       visit admin_budget_path(group.budget)
+      expect(page).to have_content('Maxium number of headings in which a user can vote 2 of 3')
 
       within("#budget_group_#{group.id}") do
         click_link 'Edit group'


### PR DESCRIPTION
References
==========
**Related issue:** #1384

Objectives
==========
Add a label to see the maxium number of headings in which a user can vote. It should update automatically (using JS) when the heading is updated.

Visual Changes
=======================
![out](https://user-images.githubusercontent.com/31625251/38294239-790981ae-37ea-11e8-9dc5-03e7c36cba3c.gif)

Notes
=====================
I used the commit mentioned in the issue https://github.com/consul/consul/commit/1b63ba39d299a7bdda7465a31d78a733cb1136f3 as a startpoint. Then, I modified the UI and the specs to fill the requirements.

The specs has not change too much, just remove the page refresh so that it checks the change done by AJAX.
