### PR TITLE
Move custom Admin I18n strings to `locales/custom` folder

### DIFF
--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -1,8 +1,128 @@
 en:
   admin:
+    officing_booth:
+      title: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     legislation:
       proposals:
         form:
           custom_categories_placeholder: Enter the tags you would like to use, separated by commas (,) and between quotes ("")
     segment_recipient:
       beta_testers: "Beta testers"
+    budget_investments:
+      show:
+        organization_name: Representing
+        label: Label (public visibility)
+      edit:
+        label: Label (public visibility)
+    hidden_users:
+      show:
+        phone: 'Phone:'
+    recounts:
+      index:
+        all_booths_total: "Cumulative total from all booths:"
+        total_final: Final recounts
+        total_system: Votes (automatic)
+    booths:
+      new:
+        physical: "Physical booth"
+    spending_proposals:
+      index:
+        max_per_geozone: Max per geozone
+        max_for_no_geozone: Max for city-wide
+      show:
+        compatibility_title: Compatibility
+        compatibility:
+          "true": "Compatible"
+          "false": "Incompatible"
+      edit:
+        compatibility: Compatibility
+      results:
+        title: Current final voting ranking
+        spending_proposal: Proposal title
+        ballot_lines_count: Times selected
+        hide_discarded_link: Hide discarded
+        show_all_link: Show all
+        price: Cost
+        amount_available: Available budget
+        incompatible: Incompatibles
+    stats:
+      show:
+        participatory_budget_2016: Participatory Budget 2016
+        participatory_budgets: Participatory Budgets
+        polls: Polls
+        direct_messages: Direct messages
+        proposal_notifications: Proposal notifications
+        redeemable_codes: Redeemable codes
+        user_invites: Invitations
+        external_stats: External stats
+        incomplete_verifications: Incomplete verifications
+        summary:
+          ballot_line_votes: Votes in investment projects
+          ballot_votes: Budgets voted
+          spending_proposal_votes: Investment project votes
+          spending_proposals: Investment projects
+      graph:
+        debate_created: Debates
+        spending_proposals: Investment projects
+        visit: Visits
+        level_2_user: Level 2 users
+        proposal_created: Citizen proposals
+        participatory_budget: Participatory Budget
+        user_voted_budgets: Users that have voted
+        user_supported_budgets: Users that have voted
+        unverified_users: Unverified users
+      spending_proposals:
+        title: Participatory Budgets
+        districts: District
+        users: Users
+        users_city_total: Users who voted for city-wide proposals
+        users_district_total: Users who voted for district-wide proposals
+        users_city_only: Users who voted ONLY for city-wide proposals
+        users_district_only: Users who voted ONLY for district-wide proposals
+        users_both_total:  Users who voted for BOTH
+      budgets:
+        title: "Participatory Budgets - Participation stats"
+        supporting_phase: Supporting phase
+        balloting_phase: Final voting
+      budget_balloting:
+        title: "Final voting stats"
+        vote_count: Votes
+        participant_count: Participants
+        users_city_total: Users who voted for city-wide proposals
+        users_district_total: Users who voted for district-wide proposals
+        users_both_total:  Users who voted for BOTH
+        votes_per_heading: Votes per heading
+        participants_per_district: Participants per district
+      budget_supporting:
+        title: "Supporting phase stats"
+        headings: Headings
+        users: Users
+        users_city_total: Users who voted for city-wide proposals
+        users_district_total: Users who voted for district-wide proposals
+        users_city_only: Users who voted ONLY for city-wide proposals
+        users_district_only: Users who voted ONLY for district-wide proposals
+        users_both_total:  Users who voted for BOTH
+        vote_count: Votes
+        participant_count: Participants
+      polls:
+        title: Poll Stats
+        all: Polls
+        web_participants: Web participants
+        total_participants: Total Participants
+        poll_questions: "Questions from poll: %{poll}"
+        table:
+          poll_name: Poll
+          question_name: Question
+          origin_web: Web participants
+          origin_total: Total participants
+      proposal_notifications:
+        not_available: Proposal not available
+      reedemable_codes:
+        title: Redeemable codes
+        total: Total
+        campaign: After sending 400.000 letters
+      user_invites:
+        title: Invitations from Linea Madrid
+        total: Total
+        clicked_email_link: Clicked email link
+        clicked_signup_button: Clicked signup button

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -1,17 +1,128 @@
 es:
   admin:
+    officing_booth:
+      title: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     legislation:
       proposals:
         form:
           custom_categories_placeholder: Escribe las etiquetas que desees separadas por una coma (,) y entrecomilladas ("")
+    segment_recipient:
+      beta_testers: "Beta testers"
     budget_investments:
       show:
-        info: "%{budget_name} - Grupo: %{group_name} - Proyecto de gasto %{id}"
+        organization_name: En nombre de
+        label: Chapa (visible públicamente)
+      edit:
+        label: Chapa (visible públicamente)
+    hidden_users:
+      show:
+        phone: 'Teléfono:'
+    recounts:
+      index:
+        all_booths_total: "Acumulado en todas las urnas:"
+        total_final: Recuentos finales
+        total_system: Votos (automático)
+    booths:
+      new:
+        physical: "Urna física"
     spending_proposals:
+      index:
+        max_per_geozone: Corte por distrito
+        max_for_no_geozone: Corte por ciudad
       show:
         compatibility_title: Compatibilidad
         compatibility:
           "true": "Compatible"
           "false": "Incompatible"
-    segment_recipient:
-      beta_testers: "Beta testers"
+      edit:
+        compatibility: Compatibilidad
+      results:
+        title: Ranking actual de propuestas - Votaciones finales
+        spending_proposal: Título
+        ballot_lines_count: Votos
+        hide_discarded_link: Ocultar descartadas
+        show_all_link: Mostrar todas
+        price: Coste
+        amount_available: Presupuesto disponible
+        incompatible: Incompatibles
+    stats:
+      show:
+        participatory_budget_2016: Presupuestos Participativos 2016
+        participatory_budgets: Presupuestos Participativos
+        polls: Votaciones
+        direct_messages: Mensajes directos
+        proposal_notifications: Notificaciones de propuestas
+        redeemable_codes: Códigos enviados por carta
+        user_invites: Invitaciones Linea Madrid
+        external_stats: Estadísticas externas
+        incomplete_verifications: Verificaciones incompletas
+        summary:
+          ballot_line_votes: Votos en inversión
+          ballot_votes: Presupuestos votados
+          spending_proposal_votes: Votos Propuesta Inversión
+          spending_proposals: Propuestas de inversión
+      graph:
+        debate_created: Debates
+        spending_proposals: Propuestas de inversión
+        visit: Visitas
+        level_2_user: Usuarios nivel 2
+        proposal_created: Propuestas Ciudadanas
+        participatory_budget: Presupuestos Participativos
+        user_voted_budgets: Usuarios que han votado
+        user_supported_budgets: Usuarios que han votado
+        unverified_users: Usuarios sin verificar
+      spending_proposals:
+        title: Presupuestos participativos
+        districts: Distrito
+        users: Usuarios
+        users_city_total: Usuarios que han votado propuestas de ciudad
+        users_district_total: Usuarios que han votado propuestas de distrito
+        users_city_only: Usuarios que han votado SOLO propuestas de CIUDAD
+        users_district_only: Usuarios que han votado SOLO propuestas de DISTRITO
+        users_both_total: Usuarios que han votado AMBAS
+      budgets:
+        title: "Presupuestos participativos - Estadisticas de participación"
+        supporting_phase: Fase de apoyos
+        balloting_phase: Votación final
+      budget_balloting:
+        title: "Estadísticas votación final"
+        vote_count: Votos
+        participant_count: Participantes
+        users_city_total: Usuarios que han votado propuestas de ciudad
+        users_district_total: Usuarios que han votado propuestas de distrito
+        users_both_total: Usuarios que han votado AMBAS
+        votes_per_heading: Votos por partida
+        participants_per_district: Participantes por distrito
+      budget_supporting:
+        title: "Estadísticas fase de apoyos"
+        headings: Partidas
+        users: Usuarios
+        users_city_total: Usuarios que han apoyado propuestas de ciudad
+        users_district_total: Usuarios que han apoyado propuestas de distrito
+        users_city_only: Usuarios que han apoyado SOLO propuestas de CIUDAD
+        users_district_only: Usuarios que han apoyado SOLO propuestas de DISTRITO
+        users_both_total: Usuarios que han apoyado AMBAS
+        vote_count: Votos
+        participant_count: Participantes
+      polls:
+        title: Estadísticas de votaciones
+        all: Votaciones
+        web_participants: Participantes en Web
+        total_participants: Participantes totales
+        poll_questions: "Preguntas de votación: %{poll}"
+        table:
+          poll_name: Votación
+          question_name: Pregunta
+          origin_web: Participantes Web
+          origin_total: Participantes Totales
+      proposal_notifications:
+        not_available: Esta propuesta ya no está disponible
+      reedemable_codes:
+        title: Códigos enviados por carta
+        total: Total
+        campaign: Después de las 400.000 cartas
+      user_invites:
+        title: Invitaciones Linea Madrid
+        total: Total
+        clicked_email_link: Link del email clickado
+        clicked_signup_button: Botón de registrarse clickado

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -14,8 +14,6 @@ en:
       edit: Edit
       configure: Configure
       delete: Delete
-    officing_booth:
-      title: "You are officing the booth located at %{booth}. If this is not correct, do not continue and call the help phone number. Thank you."
     banners:
       index:
         title: Banners
@@ -217,8 +215,6 @@ en:
         edit: Edit
         edit_classification: Edit classification
         by: By
-        organization_name: Representing
-        label: Label (public visibility)
         sent: Sent
         group: Group
         heading: Heading
@@ -258,7 +254,6 @@ en:
         assigned_valuators: Valuators
         select_heading: Select heading
         submit_button: Update
-        label: Label (public visibility)
         user_tags: User assigned tags
         tags: Tags
         tags_placeholder: "Write the tags you want separated by commas (,)"
@@ -353,7 +348,6 @@ en:
       show:
         email: 'Email:'
         hidden_at: 'Hidden at:'
-        phone: 'Phone:'
         registered_at: 'Registered at:'
         title: Activity of user (%{user})
     legislation:
@@ -910,9 +904,6 @@ en:
       index:
         title: "Recounts"
         no_recounts: "There is nothing to be recounted"
-        all_booths_total: "Cumulative total from all booths:"
-        total_final: Final recounts
-        total_system: Votes (automatic)
         table_booth_name: "Booth"
         table_total_recount: "Total recount (by officer)"
         table_system_count: "Votes (automatic)"
@@ -1081,8 +1072,6 @@ en:
         administrator_filter_all: All administrators
         valuator_filter_all: All valuators
         tags_filter_all: All tags
-        max_per_geozone: Max per geozone
-        max_for_no_geozone: Max for city-wide
         filters:
           valuation_open: Open
           without_admin: Without assigned admin
@@ -1105,10 +1094,6 @@ en:
         assigned_valuators: Assigned valuators
         back: Back
         classification: Classification
-        compatibility_title: Compatibility
-        compatibility:
-          "true": "Compatible"
-          "false": "Incompatible"
         heading: "Investment project %{id}"
         edit: Edit
         edit_classification: Edit classification
@@ -1127,16 +1112,6 @@ en:
         tags: Tags
         tags_placeholder: "Write the tags you want separated by commas (,)"
         undefined: Undefined
-        compatibility: Compatibility
-      results:
-        title: Current final voting ranking
-        spending_proposal: Proposal title
-        ballot_lines_count: Times selected
-        hide_discarded_link: Hide discarded
-        show_all_link: Show all
-        price: Cost
-        amount_available: Available budget
-        incompatible: Incompatibles
       summary:
         title: Summary for investment projects
         geozone_name: Scope
@@ -1205,26 +1180,13 @@ en:
     stats:
       show:
         stats_title: Stats
-        participatory_budget_2016: Participatory Budget 2016
-        participatory_budgets: Participatory Budgets
-        polls: Polls
-        direct_messages: Direct messages
-        proposal_notifications: Proposal notifications
-        redeemable_codes: Redeemable codes
-        user_invites: Invitations
-        external_stats: External stats
-        incomplete_verifications: Incomplete verifications
         summary:
-          ballot_line_votes: Votes in investment projects
-          ballot_votes: Budgets voted
           comment_votes: Comment votes
           comments: Comments
           debate_votes: Debate votes
           debates: Debates
           proposal_votes: Proposal votes
           proposals: Proposals
-          spending_proposal_votes: Investment project votes
-          spending_proposals: Investment projects
           budgets: Open budgets
           budget_investments: Investment projects
           unverified_users: Unverified users
@@ -1241,78 +1203,14 @@ en:
         proposal_notifications: Proposal notifications
         incomplete_verifications: Incomplete verifications
         polls: Polls
-      graph:
-        debate_created: Debates
-        spending_proposals: Investment projects
-        visit: Visits
-        level_2_user: Level 2 users
-        proposal_created: Citizen proposals
-        participatory_budget: Participatory Budget
-        user_voted_budgets: Users that have voted
-        user_supported_budgets: Users that have voted
-        unverified_users: Unverified users
-      spending_proposals:
-        title: Participatory Budgets
-        districts: District
-        users: Users
-        users_city_total: Users who voted for city-wide proposals
-        users_district_total: Users who voted for district-wide proposals
-        users_city_only: Users who voted ONLY for city-wide proposals
-        users_district_only: Users who voted ONLY for district-wide proposals
-        users_both_total:  Users who voted for BOTH
-      budgets:
-        title: "Participatory Budgets - Participation stats"
-        supporting_phase: Supporting phase
-        balloting_phase: Final voting
-      budget_balloting:
-        title: "Final voting stats"
-        vote_count: Votes
-        participant_count: Participants
-        users_city_total: Users who voted for city-wide proposals
-        users_district_total: Users who voted for district-wide proposals
-        users_both_total:  Users who voted for BOTH
-        votes_per_heading: Votes per heading
-        participants_per_district: Participants per district
-      budget_supporting:
-        title: "Supporting phase stats"
-        headings: Headings
-        users: Users
-        users_city_total: Users who voted for city-wide proposals
-        users_district_total: Users who voted for district-wide proposals
-        users_city_only: Users who voted ONLY for city-wide proposals
-        users_district_only: Users who voted ONLY for district-wide proposals
-        users_both_total:  Users who voted for BOTH
-        vote_count: Votes
-        participant_count: Participants
       direct_messages:
         title: Direct messages
         total: Total
         users_who_have_sent_message: Users that have sent a private message
-      polls:
-        title: Poll Stats
-        all: Polls
-        web_participants: Web participants
-        total_participants: Total Participants
-        poll_questions: "Questions from poll: %{poll}"
-        table:
-          poll_name: Poll
-          question_name: Question
-          origin_web: Web participants
-          origin_total: Total participants
       proposal_notifications:
         title: Proposal notifications
         total: Total
         proposals_with_notifications: Proposals with notifications
-        not_available: Proposal not available
-      reedemable_codes:
-        title: Redeemable codes
-        total: Total
-        campaign: After sending 400.000 letters
-      user_invites:
-        title: Invitations from Linea Madrid
-        total: Total
-        clicked_email_link: Clicked email link
-        clicked_signup_button: Clicked signup button
       polls:
         title: Poll Stats
         all: Polls

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -14,8 +14,6 @@ es:
       edit: Editar
       configure: Configurar
       delete: Borrar
-    officing_booth:
-      title: "Estás ahora mismo en la mesa ubicada en %{booth}. Si esto no es correcto no sigas adelante y llama al teléfono de incidencias. Gracias."
     banners:
       index:
         title: Banners
@@ -217,8 +215,6 @@ es:
         edit: Editar
         edit_classification: Editar clasificación
         by: Autor
-        organization_name: En nombre de
-        label: Chapa (visible públicamente)
         sent: Fecha
         group: Grupo
         heading: Partida
@@ -258,7 +254,6 @@ es:
         assigned_valuators: Evaluadores
         select_heading: Seleccionar partida
         submit_button: Actualizar
-        label: Chapa (visible públicamente)
         user_tags: Etiquetas asignadas por el usuario
         tags: Etiquetas
         tags_placeholder: "Escribe las etiquetas que desees separadas por comas (,)"
@@ -353,7 +348,6 @@ es:
       show:
         email: 'Email:'
         hidden_at: 'Bloqueado:'
-        phone: 'Teléfono:'
         registered_at: 'Fecha de alta:'
         title: Actividad del usuario (%{user})
     legislation:
@@ -910,9 +904,6 @@ es:
       index:
         title: "Recuentos"
         no_recounts: "No hay nada de lo que hacer recuento"
-        all_booths_total: "Acumulado en todas las urnas:"
-        total_final: Recuentos finales
-        total_system: Votos (automático)
         table_booth_name: "Urna"
         table_total_recount: "Recuento total (presidente de mesa)"
         table_system_count: "Votos (automático)"
@@ -1081,8 +1072,6 @@ es:
         administrator_filter_all: Todos los administradores
         valuator_filter_all: Todos los evaluadores
         tags_filter_all: Todas las etiquetas
-        max_per_geozone: Corte por distrito
-        max_for_no_geozone: Corte por ciudad
         filters:
           valuation_open: Abiertas
           without_admin: Sin administrador
@@ -1123,16 +1112,6 @@ es:
         tags: Etiquetas
         tags_placeholder: "Escribe las etiquetas que desees separadas por comas (,)"
         undefined: Sin definir
-        compatibility: Compatibilidad
-      results:
-        title: Ranking actual de propuestas - Votaciones finales
-        spending_proposal: Título
-        ballot_lines_count: Votos
-        hide_discarded_link: Ocultar descartadas
-        show_all_link: Mostrar todas
-        price: Coste
-        amount_available: Presupuesto disponible
-        incompatible: Incompatibles
       summary:
         title: Resumen de propuestas de inversión
         geozone_name: Ámbito de ciudad
@@ -1201,26 +1180,13 @@ es:
     stats:
       show:
         stats_title: Estadísticas
-        participatory_budget_2016: Presupuestos Participativos 2016
-        participatory_budgets: Presupuestos Participativos
-        polls: Votaciones
-        direct_messages: Mensajes directos
-        proposal_notifications: Notificaciones de propuestas
-        redeemable_codes: Códigos enviados por carta
-        user_invites: Invitaciones Linea Madrid
-        external_stats: Estadísticas externas
-        incomplete_verifications: Verificaciones incompletas
         summary:
-          ballot_line_votes: Votos en inversión
-          ballot_votes: Presupuestos votados
           comment_votes: Votos en comentarios
           comments: Comentarios
           debate_votes: Votos en debates
           debates: Debates
           proposal_votes: Votos en propuestas
           proposals: Propuestas
-          spending_proposal_votes: Votos Propuesta Inversión
-          spending_proposals: Propuestas de inversión
           budgets: Presupuestos abiertos
           budget_investments: Proyectos de gasto
           spending_proposals: Propuestas de inversión
@@ -1238,78 +1204,14 @@ es:
         proposal_notifications: Notificaciones de propuestas
         incomplete_verifications: Verificaciones incompletas
         polls: Votaciones
-      graph:
-        debate_created: Debates
-        spending_proposals: Propuestas de inversión
-        visit: Visitas
-        level_2_user: Usuarios nivel 2
-        proposal_created: Propuestas Ciudadanas
-        participatory_budget: Presupuestos Participativos
-        user_voted_budgets: Usuarios que han votado
-        user_supported_budgets: Usuarios que han votado
-        unverified_users: Usuarios sin verificar
-      spending_proposals:
-        title: Presupuestos participativos
-        districts: Distrito
-        users: Usuarios
-        users_city_total: Usuarios que han votado propuestas de ciudad
-        users_district_total: Usuarios que han votado propuestas de distrito
-        users_city_only: Usuarios que han votado SOLO propuestas de CIUDAD
-        users_district_only: Usuarios que han votado SOLO propuestas de DISTRITO
-        users_both_total: Usuarios que han votado AMBAS
-      budgets:
-        title: "Presupuestos participativos - Estadisticas de participación"
-        supporting_phase: Fase de apoyos
-        balloting_phase: Votación final
-      budget_balloting:
-        title: "Estadísticas votación final"
-        vote_count: Votos
-        participant_count: Participantes
-        users_city_total: Usuarios que han votado propuestas de ciudad
-        users_district_total: Usuarios que han votado propuestas de distrito
-        users_both_total: Usuarios que han votado AMBAS
-        votes_per_heading: Votos por partida
-        participants_per_district: Participantes por distrito
-      budget_supporting:
-        title: "Estadísticas fase de apoyos"
-        headings: Partidas
-        users: Usuarios
-        users_city_total: Usuarios que han apoyado propuestas de ciudad
-        users_district_total: Usuarios que han apoyado propuestas de distrito
-        users_city_only: Usuarios que han apoyado SOLO propuestas de CIUDAD
-        users_district_only: Usuarios que han apoyado SOLO propuestas de DISTRITO
-        users_both_total: Usuarios que han apoyado AMBAS
-        vote_count: Votos
-        participant_count: Participantes
       direct_messages:
         title: Mensajes directos
         total: Total
         users_who_have_sent_message: Usuarios que han enviado un mensaje privado
-      polls:
-        title: Estadísticas de votaciones
-        all: Votaciones
-        web_participants: Participantes en Web
-        total_participants: Participantes totales
-        poll_questions: "Preguntas de votación: %{poll}"
-        table:
-          poll_name: Votación
-          question_name: Pregunta
-          origin_web: Participantes Web
-          origin_total: Participantes Totales
       proposal_notifications:
         title: Notificaciones de propuestas
         total: Total
         proposals_with_notifications: Propuestas con notificaciones
-        not_available: Esta propuesta ya no está disponible
-      reedemable_codes:
-        title: Códigos enviados por carta
-        total: Total
-        campaign: Después de las 400.000 cartas
-      user_invites:
-        title: Invitaciones Linea Madrid
-        total: Total
-        clicked_email_link: Link del email clickado
-        clicked_signup_button: Botón de registrarse clickado
       polls:
         title: Estadísticas de votaciones
         all: Votaciones


### PR DESCRIPTION
References
==========
* Related issue: #1129
* Related PR: #1273

Objectives
==========
* Moves custom :gb: / :es: I18n strings located in `config/locales` folder structure to `config/loclales/custom`

Visual Changes (if any)
=======================
None

Notes
=====================
This is an ongoing effort to move all custom I18n strings located in `config/locales` to their proper folders/files, so several PRs are needed in order to achieve this. Small PRs are being done from time to time to make the review process easier and to avoid possible conflicts