### PR TITLE
Show message on poll results and stats unpublished

### DIFF
--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -10,10 +10,10 @@ module Abilities
       can :results_2018, Poll
       can :stats_2018, Poll
       can :results, Poll do |poll|
-        poll.expired? && poll.results_enabled?
+        poll.expired?
       end
       can :stats, Poll do |poll|
-        poll.expired? && poll.stats_enabled?
+        poll.expired?
       end
       can :read, Poll::Question
       can [:read, :welcome], Budget

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -143,4 +143,12 @@ class Poll < ActiveRecord::Base
     slug.nil?
   end
 
+  def show_results
+    self.expired? && self.results_enabled?
+  end
+
+  def show_stats
+    self.expired? && self.stats_enabled?
+  end
+
 end

--- a/app/views/polls/_poll_subnav.html.erb
+++ b/app/views/polls/_poll_subnav.html.erb
@@ -1,9 +1,8 @@
-<% if current_user && current_user.administrator? ||
-  (@poll.expired? && (@poll.results_enabled? || @poll.stats_enabled?)) %>
+<% if current_user && current_user.administrator? || @poll.expired? %>
   <div class="row margin-top">
     <div class="small-12 column">
       <ul class="menu simple clear">
-        <% if current_user && current_user.administrator? || @poll.results_enabled? %>
+        <% if current_user %>
           <% if controller_name == "polls" && action_name == "results" %>
             <li class="is-active">
               <h2><%= t("polls.show.results_menu") %></h2>
@@ -13,7 +12,7 @@
           <% end %>
         <% end %>
 
-        <% if current_user && current_user.administrator? || @poll.stats_enabled? %>
+        <% if current_user %>
           <% if controller_name == "polls" && action_name == "stats" %>
             <li class="is-active">
               <h2><%= t("polls.show.stats_menu") %></h2>

--- a/app/views/polls/results.html.erb
+++ b/app/views/polls/results.html.erb
@@ -5,46 +5,55 @@
 
   <%= render "poll_subnav" %>
 
-  <div class="row margin" data-equalizer data-equalize-on="medium">
-    <div class="small-12 medium-3 column sidebar" data-equalizer-watch>
-      <p><strong><%= t("polls.show.results.title") %></strong></p>
-      <ul class="menu vertical">
+  <% unless @poll.show_results %>
+    <div class="row margin" data-equalizer data-equalize-on="medium">
+      <div class="small-12 column" data-equalizer-watch>
+        <div class="callout <%= (current_user && current_user.administrator?) ? 'warning' : 'primary' %>"><%= t("polls.show.results.not_published") %></div>
+      </div>
+    </div>
+  <% end %>
+
+  <% if current_user && current_user.administrator? || @poll.show_results %>
+    <div class="row margin" data-equalizer data-equalize-on="medium">
+      <div class="small-12 medium-3 column sidebar" data-equalizer-watch>
+        <p><strong><%= t("polls.show.results.title") %></strong></p>
+        <ul class="menu vertical">
+          <%- @poll.questions.each do |question| %>
+            <li><%=link_to question.title, "##{question.title.parameterize}" %></li>
+          <% end %>
+        </ul>
+      </div>
+
+      <div class="small-12 medium-9 column" data-equalizer-watch>
         <%- @poll.questions.each do |question| %>
-          <li><%=link_to question.title, "##{question.title.parameterize}" %></li>
+          <% most_voted_answer_id = question.most_voted_answer_id %>
+          <h3 id="<%= question.title.parameterize %>"><%= question.title %></h3>
+          <table id="question_<%= question.id %>_results_table">
+            <thead>
+              <tr>
+                <%- question.question_answers.each do |answer| %>
+                  <th scope="col" <%= answer.id == most_voted_answer_id ? "class=win" : "" %>>
+                    <% if answer.id == most_voted_answer_id %>
+                      <span class="show-for-sr"><%= t("polls.show.results.most_voted_answer") %></span>
+                    <% end %>
+                    <%= answer.title %>
+                  </th>
+                <% end %>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <%- question.question_answers.each do |answer| %>
+                  <td id="answer_<%= answer.id %>_result" <%= answer.id == most_voted_answer_id ? "class=win" : "" %>>
+                    <%= answer.total_votes %>
+                    (<%= answer.total_votes_percentage.round(2) %>%)
+                  </td>
+                <% end %>
+              </tr>
+            </tbody>
+          </table>
         <% end %>
-      </ul>
-    </div>
 
-    <div class="small-12 medium-9 column" data-equalizer-watch>
-      <%- @poll.questions.each do |question| %>
-        <% most_voted_answer_id = question.most_voted_answer_id %>
-        <h3 id="<%= question.title.parameterize %>"><%= question.title %></h3>
-        <table id="question_<%= question.id %>_results_table">
-          <thead>
-            <tr>
-              <%- question.question_answers.each do |answer| %>
-                <th scope="col" <%= answer.id == most_voted_answer_id ? "class=win" : "" %>>
-                  <% if answer.id == most_voted_answer_id %>
-                    <span class="show-for-sr"><%= t("polls.show.results.most_voted_answer") %></span>
-                  <% end %>
-                  <%= answer.title %>
-                </th>
-              <% end %>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <%- question.question_answers.each do |answer| %>
-                <td id="answer_<%= answer.id %>_result" <%= answer.id == most_voted_answer_id ? "class=win" : "" %>>
-                  <%= answer.total_votes %>
-                  (<%= answer.total_votes_percentage.round(2) %>%)
-                </td>
-              <% end %>
-            </tr>
-          </tbody>
-        </table>
-      <% end %>
-
-    </div>
-  </div>
+      </div>
+  <% end %>
 </div>

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -5,92 +5,102 @@
 
   <%= render "poll_subnav" %>
 
-  <div class="row margin" data-equalizer data-equalize-on="medium">
-    <div class="small-12 medium-3 column sidebar" data-equalizer-watch>
-      <p><strong><%= t("polls.show.stats.title") %></strong></p>
-
-      <ul class="menu vertical margin-top">
-        <li><a href="#total"><%= t("polls.show.stats.total_participation") %></a></li>
-      </ul>
+  <% unless @poll.show_stats %>
+    <div class="row margin" data-equalizer data-equalize-on="medium">
+      <div class="small-12 column" data-equalizer-watch>
+        <div class="callout <%= (current_user && current_user.administrator?) ? 'warning' : 'primary' %>"><%= t("polls.show.stats.not_published") %></div>
+      </div>
     </div>
+  <% end %>
 
-    <div class="small-12 medium-9 column" data-equalizer-watch>
-      <h3 id="total"><%= t("polls.show.stats.total_participation") %></h3>
+  <% if current_user && current_user.administrator? || @poll.show_stats %>
+    <div class="row margin" data-equalizer data-equalize-on="medium">
+      <div class="small-12 medium-3 column sidebar" data-equalizer-watch>
+        <p><strong><%= t("polls.show.stats.title") %></strong></p>
 
-      <p class="margin-top uppercase">
-        <%= t("polls.show.stats.total_votes") %><br>
-        <span class="number"><%= @stats[:total_participants] %></span>
-      </p>
+        <ul class="menu vertical margin-top">
+          <li><a href="#total"><%= t("polls.show.stats.total_participation") %></a></li>
+        </ul>
+      </div>
 
-      <table>
-        <thead>
-          <tr>
-            <th scope="col"><%= t("polls.show.stats.votes") %></th>
-            <th scope="col"><%= t("polls.show.stats.web") %></th>
-            <th scope="col"><%= t("polls.show.stats.booth") %></th>
-            <th scope="col"><%= t("polls.show.stats.total") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><%= t("polls.show.stats.valid") %></th>
-            <td>
-              <%= @stats[:total_web_valid] %>
-              <small><em>(<%= @stats[:valid_percentage_web].round(2) %>%)</em></small>
-            </td>
-            <td>
-              <%= @stats[:total_booth_valid] %>
-              <small><em>(<%= @stats[:valid_percentage_booth].round(2) %>%)</em></small>
-            </td>
-            <td>
-              <%= @stats[:total_valid_votes] %>
-              <small><em>(<%= @stats[:total_valid_percentage].round(2) %>%)</em></small>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row"><%= t("polls.show.stats.white") %></th>
-            <td>
-              <%= @stats[:total_web_white] %>
-              <small><em>(<%= @stats[:white_percentage_web].round(2) %>%)</em></small>
-            </td>
-            <td>
-              <%= @stats[:total_booth_white] %>
-              <small><em>(<%= @stats[:white_percentage_booth].round(2) %>%)</em></small>
-            </td>
-            <td><%= @stats[:total_white_votes] %>
-              <small><em>(<%= @stats[:total_white_percentage].round(2) %>%)</em></small>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row"><%= t("polls.show.stats.null_votes") %></th>
-            <td>
-              <%= @stats[:total_web_null] %>
-              <small><em>(<%= @stats[:null_percentage_web].round(2) %>%)</em></small>
-            </td>
-            <td>
-              <%= @stats[:total_booth_null] %>
-              <small><em>(<%= @stats[:null_percentage_booth].round(2) %>%)</em></small>
-            </td>
-            <td>
-              <%= @stats[:total_null_votes] %>
-              <small><em>(<%= @stats[:total_null_percentage].round(2) %>%)</em></small>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row"><%= t("polls.show.stats.total") %></th>
-            <td>
-              <%= @stats[:total_participants_web] %>
-              <small><em>(<%= @stats[:total_participants_web_percentage].round(2) %>%)</em></small>
-            </td>
-            <td>
-              <%= @stats[:total_participants_booth] %>
-              <small><em>(<%= @stats[:total_participants_booth_percentage].round(2) %>%)</em></small>
-            </td>
-            <td><%= @stats[:total_participants_web] + @stats[:total_participants_booth] %></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="small-12 medium-9 column" data-equalizer-watch>
+        <h3 id="total"><%= t("polls.show.stats.total_participation") %></h3>
+
+        <p class="margin-top uppercase">
+          <%= t("polls.show.stats.total_votes") %><br>
+          <span class="number"><%= @stats[:total_participants] %></span>
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th scope="col"><%= t("polls.show.stats.votes") %></th>
+              <th scope="col"><%= t("polls.show.stats.web") %></th>
+              <th scope="col"><%= t("polls.show.stats.booth") %></th>
+              <th scope="col"><%= t("polls.show.stats.total") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><%= t("polls.show.stats.valid") %></th>
+              <td>
+                <%= @stats[:total_web_valid] %>
+                <small><em>(<%= @stats[:valid_percentage_web].round(2) %>%)</em></small>
+              </td>
+              <td>
+                <%= @stats[:total_booth_valid] %>
+                <small><em>(<%= @stats[:valid_percentage_booth].round(2) %>%)</em></small>
+              </td>
+              <td>
+                <%= @stats[:total_valid_votes] %>
+                <small><em>(<%= @stats[:total_valid_percentage].round(2) %>%)</em></small>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><%= t("polls.show.stats.white") %></th>
+              <td>
+                <%= @stats[:total_web_white] %>
+                <small><em>(<%= @stats[:white_percentage_web].round(2) %>%)</em></small>
+              </td>
+              <td>
+                <%= @stats[:total_booth_white] %>
+                <small><em>(<%= @stats[:white_percentage_booth].round(2) %>%)</em></small>
+              </td>
+              <td><%= @stats[:total_white_votes] %>
+                <small><em>(<%= @stats[:total_white_percentage].round(2) %>%)</em></small>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><%= t("polls.show.stats.null_votes") %></th>
+              <td>
+                <%= @stats[:total_web_null] %>
+                <small><em>(<%= @stats[:null_percentage_web].round(2) %>%)</em></small>
+              </td>
+              <td>
+                <%= @stats[:total_booth_null] %>
+                <small><em>(<%= @stats[:null_percentage_booth].round(2) %>%)</em></small>
+              </td>
+              <td>
+                <%= @stats[:total_null_votes] %>
+                <small><em>(<%= @stats[:total_null_percentage].round(2) %>%)</em></small>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><%= t("polls.show.stats.total") %></th>
+              <td>
+                <%= @stats[:total_participants_web] %>
+                <small><em>(<%= @stats[:total_participants_web_percentage].round(2) %>%)</em></small>
+              </td>
+              <td>
+                <%= @stats[:total_participants_booth] %>
+                <small><em>(<%= @stats[:total_participants_booth_percentage].round(2) %>%)</em></small>
+              </td>
+              <td><%= @stats[:total_participants_web] + @stats[:total_participants_booth] %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  <% end %>
 
 </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -510,9 +510,11 @@ en:
         valid: "Valid"
         white: "White votes"
         null_votes: "Invalid"
+        not_published: 'The participation statistics of this poll are not published yet.'
       results:
         title: "Questions"
         most_voted_answer: "Most voted answer: "
+        not_published: 'The results of this poll are not published yet.'
   poll_questions:
     create_question: "Create question"
     show:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -507,9 +507,11 @@ es:
         valid: "Válidos"
         white: "En blanco"
         null_votes: "Nulos"
+        not_published: 'Las estadísticas de participación para esta votación no se han publicado aún.'
       results:
         title: "Preguntas"
         most_voted_answer: 'Respuesta más votada: '
+        not_published: 'Los resultados de esta votación no se han publicado aún.'
   poll_questions:
     create_question: "Crear pregunta"
     show:

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -529,84 +529,86 @@ feature 'Polls' do
   end
 
   context "Results and stats" do
-    scenario "Show poll results and stats if enabled and poll expired" do
-      poll = create(:poll, :expired, results_enabled: true, stats_enabled: true)
-      question1 = create(:poll_question, poll: poll)
+
+    before do
+      @poll = create(:poll, :expired, results_enabled: true, stats_enabled: true)
+      question1 = create(:poll_question, poll: @poll)
       create(:poll_question_answer, question: question1, title: 'Han Solo')
       create(:poll_question_answer, question: question1, title: 'Chewbacca')
-      question2 = create(:poll_question, poll: poll)
+      question2 = create(:poll_question, poll: @poll)
       create(:poll_question_answer, question: question2, title: 'Leia')
       create(:poll_question_answer, question: question2, title: 'Luke')
+    end
+
+    scenario "Show poll results and stats if enabled and poll expired" do
       user = create(:user)
 
       login_as user
-      visit poll_path(poll)
+      visit poll_path(@poll)
 
       expect(page).to have_content("Poll results")
       expect(page).to have_content("Participation statistics")
 
-      visit results_poll_path(poll)
+      click_link "Poll results"
       expect(page).to have_content("Questions")
 
-      visit stats_poll_path(poll)
+      click_link "Participation statistics"
       expect(page).to have_content("Participation data")
     end
 
     scenario "Don't show poll results and stats if not enabled" do
-      poll = create(:poll, :expired, results_enabled: false, stats_enabled: false)
       user = create(:user)
 
+      @poll.update(results_enabled: false, stats_enabled: false)
+
       login_as user
-      visit poll_path(poll)
+      visit poll_path(@poll)
 
-      expect(page).not_to have_content("Poll results")
-      expect(page).not_to have_content("Participation statistics")
+      expect(page).to have_link("Poll results")
+      expect(page).to have_link("Participation statistics")
 
-      visit results_poll_path(poll)
-      expect(page).to have_content("You do not have permission to carry out the action 'results' on poll.")
+      click_link "Poll results"
+      expect(page).to have_content("The results of this poll are not published yet.")
 
-      visit stats_poll_path(poll)
-      expect(page).to have_content("You do not have permission to carry out the action 'stats' on poll.")
+      click_link "Participation statistics"
+      expect(page).to have_content("The participation statistics of this poll are not published yet.")
     end
 
     scenario "Don't show poll results and stats if is not expired" do
-      poll = create(:poll, :current, results_enabled: true, stats_enabled: true)
       user = create(:user)
 
+      @poll.update(starts_at: 2.days.ago, ends_at: 2.days.from_now)
+
       login_as user
-      visit poll_path(poll)
+      visit poll_path(@poll)
 
       expect(page).not_to have_content("Poll results")
       expect(page).not_to have_content("Participation statistics")
 
-      visit results_poll_path(poll)
+      visit results_poll_path(@poll)
       expect(page).to have_content("You do not have permission to carry out the action 'results' on poll.")
 
-      visit stats_poll_path(poll)
+      visit stats_poll_path(@poll)
       expect(page).to have_content("You do not have permission to carry out the action 'stats' on poll.")
     end
 
     scenario "Show poll results and stats if user is administrator" do
-      poll = create(:poll, :current, results_enabled: false, stats_enabled: false)
-      question1 = create(:poll_question, poll: poll)
-      create(:poll_question_answer, question: question1, title: 'Han Solo')
-      create(:poll_question_answer, question: question1, title: 'Chewbacca')
-      question2 = create(:poll_question, poll: poll)
-      create(:poll_question_answer, question: question2, title: 'Leia')
-      create(:poll_question_answer, question: question2, title: 'Luke')
+      @poll.update(results_enabled: false, stats_enabled: false, starts_at: 2.days.ago, ends_at: 2.days.from_now)
       user = create(:administrator).user
 
       login_as user
-      visit poll_path(poll)
+      visit poll_path(@poll)
 
       expect(page).to have_content("Poll results")
       expect(page).to have_content("Participation statistics")
 
-      visit results_poll_path(poll)
+      click_link "Poll results"
       expect(page).to have_content("Questions")
+      expect(page).to have_content("The results of this poll are not published yet.")
 
-      visit stats_poll_path(poll)
+      click_link "Participation statistics"
       expect(page).to have_content("Participation data")
+      expect(page).to have_content("The participation statistics of this poll are not published yet.")
     end
   end
 end


### PR DESCRIPTION
References
==========
**Related issue:** #1364 

Objectives
==========
Let users see the results and stats tabs even if the data is not published (admins' checkboxes are unchequed). If there is nothing to see and the user goes to one of that tabs, a message is shown saying that the results or stats have not been published yet.

The admins can see the data always, so, to know if they are published or not, the same message is shown to them if they aren't.

The specs have been updated to check that:

1. The tabs are appearing when the poll is expired. There are not tabs if not.
2. If one of the tabs is accessed and the results/stats are not been published, it checks that the message appears.

Tests also check if the admin sees the message when accessing the results/stats and they are not published.

Visual Changes
=======================
## What user sees
![results02](https://user-images.githubusercontent.com/31625251/38356426-033dedd0-38c0-11e8-8060-2f514419b231.png)

![results03](https://user-images.githubusercontent.com/31625251/38356448-0d0515e6-38c0-11e8-83e6-97728a4b4122.png)

## What admin sees
![results04](https://user-images.githubusercontent.com/31625251/38356452-1174340e-38c0-11e8-8046-1452d06aaff0.png)

![results05](https://user-images.githubusercontent.com/31625251/38356458-162bc4a8-38c0-11e8-87a6-329c5cf5357f.png)


Notes
=====================
Nothing to mention.
