### PR TITLE
Move custom Budgets I18n strings to `locales/custom` folder

### DIFF
--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -12,6 +12,9 @@ en:
       index:
         unfeasible_text: "The investments must meet a number of criteria (legality, concreteness, be the responsibility of the city, not exceed the limit of the budget; %{definitions}) to be declared viable and reach the stage of final vote. All investments don't meet these criteria are marked as unfeasible and published in the following list, along with its report of infeasibility."
         unfeasible_text_definitions: see definitions here
+      form:
+        faq: "What can you propose?"
+        faq_link: "See all information of participatory budgets"
     stats:
       title: Participation stats
       link: Stats
@@ -46,6 +49,6 @@ en:
       heading_disclaimer: "*** Data about headings refer to the heading where each user voted, not necessarily the one that person is registered on."
   votes:
     budget_investments:
-      different_heading_assigned: 
+      different_heading_assigned:
         one: "You can only support investment projects in %{count} district"
         other: "You can only support investment projects in %{count} districts"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -14,6 +14,8 @@ es:
       form:
         tags_instructions: "Etiqueta este proyecto. Puedes elegir entre las categorías propuestas o introducir las que desees"
         tags_label: Temas
+        faq: "¿Qué puedes proponer?"
+        faq_link: "Mira toda la información sobre los presupuestos participativos"
       index:
         unfeasible: Proyectos de gasto no viables
         unfeasible_text: Los proyectos presentados deben cumplir una serie de criterios (legalidad, concreción, ser competencia del Ayuntamiento, no superar el tope del presupuesto; %{definitions}) para ser declarados viables y llegar hasta la fase de votación final. Todos los proyectos que no cumplen estos criterios son marcados como inviables y publicados en la siguiente lista, junto con su informe de inviabilidad.
@@ -61,6 +63,6 @@ es:
       heading_disclaimer: "*** Los datos de distrito se refieren al distrito en el que el usuario ha votado, no necesariamente en el que está empadronado."
   votes:
     budget_investments:
-      different_heading_assigned: 
+      different_heading_assigned:
         one: "Sólo puedes apoyar proyectos de gasto de %{count} distrito"
         other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos"

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -66,8 +66,6 @@ en:
         tags_instructions: "Tag this investment. You can choose from proposed categories or add your own"
         tags_label: Tags
         tags_placeholder: "Enter the tags you would like to use, separated by commas (',')"
-        faq: "What can you propose?"
-        faq_link: "See all information of participatory budgets"
         map_location: "Map location"
         map_location_instructions: "Navigate the map to the location and place the marker."
         map_remove_marker: "Remove map marker"
@@ -133,7 +131,7 @@ en:
         already_added: You have already added this investment project
         already_supported: You have already supported this investment project. Share it!
         support_title: Support this project
-        confirm_group: 
+        confirm_group:
           one: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
           other: "You can only support investments in %{count} district. If you continue you cannot change the election of your district. Are you sure?"
         supports:

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -66,8 +66,6 @@ es:
         tags_instructions: "Etiqueta esta propuesta. Puedes elegir entre las categorías propuestas o introducir las que desees"
         tags_label: Etiquetas
         tags_placeholder: "Escribe las etiquetas que desees separadas por una coma (',')"
-        faq: "¿Qué puedes proponer?"
-        faq_link: "Mira toda la información sobre los presupuestos participativos"
         map_location: "Ubicación en el mapa"
         map_location_instructions: "Navega por el mapa hasta la ubicación y coloca el marcador."
         map_remove_marker: "Eliminar el marcador"
@@ -133,7 +131,7 @@ es:
         already_added: Ya has añadido este proyecto de gasto
         already_supported: Ya has apoyado este proyecto de gasto. ¡Compártelo!
         support_title: Apoyar este proyecto
-        confirm_group: 
+        confirm_group:
           one: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar la elección de este distrito. ¿Estás seguro?"
           other: "Sólo puedes apoyar proyectos en %{count} distritos. Si sigues adelante no podrás cambiar la elección de este distrito. ¿Estás seguro?"
         supports:


### PR DESCRIPTION
References
==========
* **Related issue**: #1129

Objectives
==========
Move custom :gb: / :es: Budgets I18n strings to their proper files under `config/locales/custom` folder structure

Visual Changes (if any)
=======================
None

Notes
=====================
This is an ongoing effort to move all custom I18n strings located in `config/locales` to their proper folders/files, so several PRs are needed in order to achieve this. Small PRs are being done from time to time to make the review process easier and to avoid possible conflicts
