### PR TITLE
[WIP] Document upload setting

### DIFF
--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -23,9 +23,11 @@
       </div>
     <% end %>
 
-    <div class="documents small-12 column">
-      <%= render 'documents/nested_documents', documentable: @investment, f: f %>
-    </div>
+    <% if feature?(:allow_attached_documents) %>
+      <div class="documents small-12 column">
+        <%= render 'documents/nested_documents', documentable: @investment, f: f %>
+      </div>
+    <% end %>
 
     <% if feature?(:map) %>
       <div class="small-12 column">

--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -55,9 +55,11 @@
         </p>
       <% end %>
 
-      <%= render 'documents/documents',
-                  documents: investment.documents,
-                  max_documents_allowed: Budget::Investment.max_documents_allowed %>
+      <% if feature?(:allow_attached_documents) %>
+        <%= render 'documents/documents',
+                    documents: investment.documents,
+                    max_documents_allowed: Budget::Investment.max_documents_allowed %>
+      <% end %>
 
       <%= render 'shared/tags', taggable: investment %>
 

--- a/app/views/custom/legislation/proposals/show.html.erb
+++ b/app/views/custom/legislation/proposals/show.html.erb
@@ -83,9 +83,11 @@
         <h4><%= @proposal.question %></h4>
 
         <% if @proposal.is_proposal? %>
-          <%= render 'documents/documents',
-                      documents: @proposal.documents,
-                      max_documents_allowed: Proposal.max_documents_allowed %>
+          <% if feature?(:allow_attached_documents) %>
+            <%= render 'documents/documents',
+                        documents: @proposal.documents,
+                        max_documents_allowed: Proposal.max_documents_allowed %>
+          <% end %>
 
           <%= render 'shared/tags', taggable: @proposal %>
 

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -119,9 +119,11 @@
           </div>
         <% end %>
 
-        <%= render 'documents/documents',
-                    documents: @proposal.documents,
-                    max_documents_allowed: Proposal.max_documents_allowed %>
+        <% if feature?(:allow_attached_documents) %>
+          <%= render 'documents/documents',
+                      documents: @proposal.documents,
+                      max_documents_allowed: Proposal.max_documents_allowed %>
+        <% end %>
 
         <%= render 'shared/tags', taggable: @proposal %>
 

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -47,9 +47,11 @@
                                    aria: {describedby: "video-url-help-text"} %>
     </div>
 
-    <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>" id="js-legislation-proposal-documents">
-      <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
-    </div>
+    <% if feature?(:allow_attached_documents) %>
+      <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>" id="js-legislation-proposal-documents">
+        <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
+      </div>
+    <% end %>
 
     <div class="small-12 medium-6 column" id="js-legislation-proposal-geozone">
       <%= f.label :geozone_id,  t("proposals.form.geozone") %>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -80,9 +80,11 @@
 
         <h4><%= @proposal.question %></h4>
 
-        <%= render 'documents/documents',
-                    documents: @proposal.documents,
-                    max_documents_allowed: Proposal.max_documents_allowed %>
+        <% if feature?(:allow_attached_documents) %>
+          <%= render 'documents/documents',
+                      documents: @proposal.documents,
+                      max_documents_allowed: Proposal.max_documents_allowed %>
+        <% end %>
 
         <%= render 'shared/tags', taggable: @proposal %>
 

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -65,9 +65,11 @@
       </div>
     <% end %>
 
-    <div class="documents small-12 column">
-      <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
-    </div>
+    <% if feature?(:allow_attached_documents) %>
+      <div class="documents small-12 column">
+        <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
+      </div>
+    <% end %>
 
     <div class="small-12 medium-6 column">
       <%= f.label :geozone_id,  t("proposals.form.geozone") %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -114,9 +114,11 @@
           </div>
         <% end %>
 
-        <%= render 'documents/documents',
-                    documents: @proposal.documents,
-                    max_documents_allowed: Proposal.max_documents_allowed %>
+        <% if feature?(:allow_attached_documents) %>
+          <%= render 'documents/documents',
+                      documents: @proposal.documents,
+                      max_documents_allowed: Proposal.max_documents_allowed %>
+        <% end %>
 
         <%= render 'shared/tags', taggable: @proposal %>
 

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -55,6 +55,7 @@ en:
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images
+      allow_attached_documents: Allow upload and show of attached documents
     map_latitude: Latitude
     map_longitude: Longitude
     map_zoom: Zoom

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -55,6 +55,7 @@ es:
       community: Comunidad en propuestas y proyectos de gasto
       map: Geolocalización de propuestas y proyectos de gasto
       allow_images: Permitir subir y mostrar imágenes
+      allow_attached_documents: Permitir creación de documentos adjuntos
     map_latitude: Latitud
     map_longitude: Longitud
     map_zoom: Zoom

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -50,6 +50,7 @@ section "Creating Settings" do
   Setting.create(key: 'feature.community', value: "true")
   Setting.create(key: 'feature.map', value: "true")
   Setting.create(key: 'feature.allow_images', value: "true")
+  Setting.create(key: 'feature.allow_attached_documents', value: "true")
   Setting.create(key: 'feature.public_stats', value: "true")
   Setting.create(key: 'feature.guides', value: true)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,6 +85,7 @@ Setting['feature.user.recommendations'] = true
 Setting['feature.community'] = true
 Setting['feature.map'] = nil
 Setting['feature.allow_images'] = true
+Setting['feature.allow_attached_documents'] = true
 Setting['feature.guides'] = nil
 
 # Spending proposals feature flags

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -8,4 +8,9 @@ namespace :settings do
     per_page_code_setting.destroy if per_page_code_setting.present?
   end
 
+  desc "Create new Attached Documents feature setting"
+  task create_attached_documents_setting: :environment do
+    Setting['feature.allow_attached_documents'] = true
+  end
+
 end

--- a/spec/shared/features/documentable.rb
+++ b/spec/shared/features/documentable.rb
@@ -68,6 +68,23 @@ shared_examples "documentable" do |documentable_factory_name,
 
     end
 
+    describe "When allow attached documents setting is disabled" do
+      before do
+        Setting['feature.allow_attached_documents'] = false
+      end
+
+      after do
+        Setting['feature.allow_attached_documents'] = true
+      end
+
+      scenario "Documents list should not be available" do
+        login_as(create(:user))
+        visit send(documentable_path, arguments)
+
+        expect(page).not_to have_css("#documents")
+      end
+    end
+
   end
 
   context "Destroy" do

--- a/spec/shared/features/nested_documentable.rb
+++ b/spec/shared/features/nested_documentable.rb
@@ -285,6 +285,23 @@ shared_examples "nested documentable" do |login_as_name, documentable_factory_na
 
     end
 
+    describe "When allow attached documents setting is disabled" do
+      before do
+        Setting['feature.allow_attached_documents'] = false
+      end
+
+      after do
+        Setting['feature.allow_attached_documents'] = true
+      end
+
+      scenario "Add new document button should not be available" do
+        login_as user_to_login
+        visit send(path, arguments)
+
+        expect(page).not_to have_content("Add new document")
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
References
==========
https://github.com/consul/consul/issues/2579

Objectives
==========
Allow admins to disable attached document uploads and document list show in the settings panel.

Visual Changes (if any)
=======================
Incoming screenshots... for now just checking solution is right for tests

Notes
=====================
After deploying this it will be neccessary to create the setting:
`Setting['feature.allow_attached_documents'] = true` either by manually typing it in the rails console on the server... or by running the rake task:
`bin/rake settings:create_attached_documents_setting RAILS_ENV=production`

## ⚠️ If this setting is not created, the Documents feature will be disabled by default!
