### PR TITLE
Move custom Devise I18n strings to `locales/custom/` folder

### DIFF
--- a/config/locales/custom/en/devise.yml
+++ b/config/locales/custom/en/devise.yml
@@ -1,0 +1,8 @@
+en:
+  devise:
+    registrations:
+      destroyed:
+        "Goodbye! Your account has been cancelled. We hope to see you again soon. In accordance with your request, personal data registered as
+        a user of the site decide.madrid.es and form part of the file 'Gestión de procesos participativos' under the responsibility of the
+        Dirección General de Participación Ciudadana, they have been canceled under the terms of the provisions of Article 16 of the
+        Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal and Article 31 of its Reglamento de desarrollo (RD 1720/2007)."

--- a/config/locales/custom/en/devise_views.yml
+++ b/config/locales/custom/en/devise_views.yml
@@ -1,0 +1,5 @@
+en:
+  devise_views:
+    mailer:
+      confirmation_instructions:
+        title: Welcome to the Open Government Portal of the Madrid City Council

--- a/config/locales/custom/es/devise_views.yml
+++ b/config/locales/custom/es/devise_views.yml
@@ -1,0 +1,5 @@
+en:
+  devise_views:
+    mailer:
+      confirmation_instructions:
+        title: Te damos la bienvenida al Portal de Gobierno Abierto del Ayuntamiento de Madrid

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -40,8 +40,8 @@ en:
     registrations:
       destroyed:
         "Goodbye! Your account has been cancelled. We hope to see you again soon. In accordance with your request, personal data registered as
-        a user of the site decide.madrid.es and form part of the file 'Gestión de procesos participativos' under the responsibility of the
-        Dirección General de Participación Ciudadana, they have been canceled under the terms of the provisions of Article 16 of the
+        a user of the site and form part of the file 'File' under the responsibility of the
+        'Responsible', they have been canceled under the terms of the provisions of Article 16 of the
         Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal and Article 31 of its Reglamento de desarrollo (RD 1720/2007)."
       signed_up: "Welcome! You have been authenticated."
       signed_up_but_inactive: "Your registration was successful, but you could not be signed in because your account has not been activated."

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -16,7 +16,7 @@ en:
       confirmation_instructions:
         confirm_link: Confirm my account
         text: 'You can confirm your email account at the following link:'
-        title: Welcome to the Open Government Portal of the Madrid City Council
+        title: Welcome to the Open Government Portal
         welcome: Welcome
       reset_password_instructions:
         change_link: Change my password

--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -16,7 +16,7 @@ es:
       confirmation_instructions:
         confirm_link: Confirmar mi cuenta
         text: 'Puedes confirmar tu cuenta de correo electrónico en el siguiente enlace:'
-        title: Te damos la bienvenida al Portal de Gobierno Abierto del Ayuntamiento de Madrid
+        title: Te damos la bienvenida al Portal de Gobierno Abierto
         welcome: Bienvenido/a
       reset_password_instructions:
         change_link: Cambiar mi contraseña


### PR DESCRIPTION
References
==========
* Related issue: #1129 

Objectives
==========
Move all custom :gb: / :es: Devise-related I18n strings to their proper files under `config/locales/custom` folder structure

Visual Changes (if any)
=======================
None

Notes
=====================
This is an ongoing effort to move all custom I18n strings located in `config/locales` to their proper folders/files, so several PRs are needed in order to achieve this. Small PRs are being done from time to time to make the review process easier and to avoid possible conflicts
