### PR TITLE
Fix incorrect highlight for selected option in admin menu

### DIFF
--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -96,7 +96,7 @@
 
     <% if feature?(:budgets) %>
       <li class="section-title <%= "active" if controller_name == "budgets" ||
-                                                                  "budget_investment_statuses" %>">
+                                               controller_name == "budget_investment_statuses" %>">
         <%= link_to admin_budgets_path do %>
           <span class="icon-budget"></span>
           <strong><%= t("admin.menu.budgets") %></strong>


### PR DESCRIPTION
References
==========
Closes #1408 once merged into `master`

Objectives
==========
`Participatory budgets` option in Admin menu is highlighted by default and stays highlighted even when the user clicks in other options. This PR solves this issue.

Visual Changes (if any)
=======================
**Before**:
![screenshot_2018-04-09_12-07-42](https://user-images.githubusercontent.com/9470839/38508999-a3e34fd8-3bee-11e8-935e-c8a1a914f6a7.png)

**After**:
![highlighted menu](https://user-images.githubusercontent.com/9470839/38508821-341f6d26-3bee-11e8-9405-18f868f6c455.gif)

Notes
=====================
None
