### PR TITLE
Fix title positioning for Legislation Processes in admin panel

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -702,12 +702,9 @@ table {
   }
 }
 
-.legislation-process-index {
-
-  .legislation-process-new {
-    @include breakpoint(medium) {
-      text-align: right;
-    }
+.legislation-process-new {
+  @include breakpoint(medium) {
+    text-align: right;
   }
 }
 

--- a/app/views/admin/legislation/processes/index.html.erb
+++ b/app/views/admin/legislation/processes/index.html.erb
@@ -2,32 +2,27 @@
   Admin - <%= t("admin.menu.legislation") %> - <%= t("admin.legislation.processes.index.filters.#{@current_filter}") %>
 <% end %>
 
-<div class="legislation-admin legislation-process-index">
-  <div class="row">
-    <div class="small-12 medium-9 column">
-      <h2 class="inline-block"><%= t("admin.legislation.processes.index.title") %></h2>
-    </div>
-    <div class="small-12 medium-3 column legislation-process-new">
-      <%= link_to t("admin.legislation.processes.index.create"), new_admin_legislation_process_path, class: "button" %>
-    </div>
-  </div>
+<h2 class="inline-block"><%= t("admin.legislation.processes.index.title") %></h2>
 
-  <%= render 'shared/filter_subnav', i18n_namespace: "admin.legislation.processes.index" %>
+<%= link_to t("admin.legislation.processes.index.create"), new_admin_legislation_process_path,
+            class: "button success float-right" %>
 
-  <% if @processes.any? %>
-    <h3><%= page_entries_info @processes %></h3>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.legislation.processes.index" %>
 
-    <table class="stack">
-      <thead>
-        <tr>
-          <th><%= t("admin.legislation.processes.process.title") %></th>
-          <th><%= t("admin.legislation.processes.process.status") %></th>
-          <th><%= t("admin.legislation.processes.process.creation_date") %></th>
-          <th><%= t("admin.legislation.processes.process.comments") %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
+<% if @processes.any? %>
+  <h3><%= page_entries_info @processes %></h3>
+
+  <table class="stack">
+    <thead>
+      <tr>
+        <th><%= t("admin.legislation.processes.process.title") %></th>
+        <th><%= t("admin.legislation.processes.process.status") %></th>
+        <th><%= t("admin.legislation.processes.process.creation_date") %></th>
+        <th><%= t("admin.legislation.processes.process.comments") %></th>
+      </tr>
+    </thead>
+
+    <tbody>
       <% @processes.each do |process| %>
         <tr id="<%= dom_id(process) %>">
           <td class="small-12 medium-8">
@@ -43,14 +38,12 @@
           </td>
         </tr>
       <% end %>
-      </tbody>
-    </table>
+    </tbody>
+  </table>
 
-    <%= paginate @processes %>
-  <% else %>
-    <div class="callout primary">
-      <%= page_entries_info @processes %>
-    </div>
-  <% end %>
-
-</div>
+  <%= paginate @processes %>
+<% else %>
+  <div class="callout primary">
+    <%= page_entries_info @processes %>
+  </div>
+<% end %>


### PR DESCRIPTION
References
==========
None

Objectives
==========
Fixes incorrect title positioning for Legislation Processes index view in Admin panel. This was done removing unnecessary markup in the related view as well as removing an unused CSS class.

Visual Changes (if any)
=======================
**Before**:
![screenshot_2018-04-09_12-30-44](https://user-images.githubusercontent.com/9470839/38512189-96e05eca-3bf8-11e8-80e9-fc93026eccaa.png)

**After**:
![screenshot_2018-04-09_12-31-13](https://user-images.githubusercontent.com/9470839/38512204-a2642ec0-3bf8-11e8-9cae-b96937ded103.png)

Notes
=====================
Backport pending to [CONSUL](http://github.com/consul/consul/) once merged into `master`