### PR TITLE
Add default order for admin budget investments list

### DIFF
--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -77,7 +77,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def load_investments
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-      @investments = @investments.order_filter(params[:sort_by]) if params[:sort_by].present?
+                                       .order_filter(params[:sort_by])
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -149,6 +149,8 @@ class Budget
     def self.order_filter(sorting_param)
       if sorting_param.present? && SORTING_OPTIONS.include?(sorting_param)
         send("sort_by_#{sorting_param}")
+      else
+        order(cached_votes_up: :desc).order(id: :desc)
       end
     end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -640,6 +640,16 @@ feature 'Admin budget investments' do
       create(:budget_investment, title: 'C Third Investment', cached_votes_up: 10, budget: budget)
     end
 
+    scenario "Default sorting" do
+      create(:budget_investment, title: 'D Fourth Investment', cached_votes_up: 50, budget: budget)
+
+      visit admin_budget_budget_investments_path(budget)
+
+      expect('D Fourth Investment').to appear_before('B First Investment')
+      expect('D Fourth Investment').to appear_before('A Second Investment')
+      expect('A Second Investment').to appear_before('C Third Investment')
+    end
+
     scenario 'Sort by ID' do
       visit admin_budget_budget_investments_path(budget, sort_by: 'id')
 


### PR DESCRIPTION
When there's no sorting option selected, by default it orders the investment list by supports and, for those with the same number of supports, by ID.
