### PR TITLE
Add year to Signature Sheets's dates in the admin section and order by date

### DIFF
--- a/app/controllers/admin/signature_sheets_controller.rb
+++ b/app/controllers/admin/signature_sheets_controller.rb
@@ -1,7 +1,7 @@
 class Admin::SignatureSheetsController < Admin::BaseController
 
   def index
-    @signature_sheets = SignatureSheet.all
+    @signature_sheets = SignatureSheet.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/admin/signature_sheets/index.html.erb
+++ b/app/views/admin/signature_sheets/index.html.erb
@@ -19,7 +19,7 @@
           <%= signature_sheet.author.name %>
         </td>
         <td>
-          <%= l(signature_sheet.created_at, format: :short) %>
+          <%= l(signature_sheet.created_at, format: :long) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/signature_sheets/show.html.erb
+++ b/app/views/admin/signature_sheets/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="callout secondary float-right">
   <%= t("admin.signature_sheets.show.created_at") %>
-  <strong><%= l(@signature_sheet.created_at, format: :short) %></strong>
+  <strong><%= l(@signature_sheet.created_at, format: :long) %></strong>
   <span class="bullet">&nbsp;&bull;&nbsp;</span>
   <%= t("admin.signature_sheets.show.author") %>
   <strong><%= @signature_sheet.author.name %></strong>

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -7,15 +7,28 @@ feature 'Signature sheets' do
     login_as(admin.user)
   end
 
-  scenario "Index" do
-    3.times { create(:signature_sheet) }
+  context "Index" do
+    scenario 'Lists all signature_sheets' do
+      3.times { create(:signature_sheet) }
 
-    visit admin_signature_sheets_path
+      visit admin_signature_sheets_path
 
-    expect(page).to have_css(".signature_sheet", count: 3)
+      expect(page).to have_css(".signature_sheet", count: 3)
 
-    SignatureSheet.all.each do |signature_sheet|
-      expect(page).to have_content signature_sheet.name
+      SignatureSheet.all.each do |signature_sheet|
+        expect(page).to have_content signature_sheet.name
+      end
+    end
+
+    scenario 'Orders signature_sheets by created_at DESC' do
+      signature_sheet1 = create(:signature_sheet)
+      signature_sheet2 = create(:signature_sheet)
+      signature_sheet3 = create(:signature_sheet)
+
+      visit admin_signature_sheets_path
+
+      expect(signature_sheet3.name).to appear_before(signature_sheet2.name)
+      expect(signature_sheet2.name).to appear_before(signature_sheet1.name)
     end
   end
 
@@ -78,7 +91,7 @@ feature 'Signature sheets' do
 
     expect(page).to have_content "Citizen proposal #{proposal.id}"
     expect(page).to have_content "12345678Z, 123A, 123B"
-    expect(page).to have_content signature_sheet.created_at.strftime("%d %b %H:%M")
+    expect(page).to have_content signature_sheet.created_at.strftime("%B %d, %Y %H:%M")
     expect(page).to have_content user.name
 
     within("#document_count") do


### PR DESCRIPTION
References
==========
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1427

Visual Changes (if any)
=======================
<img width="778" alt="screen shot 2018-04-16 at 18 06 56" src="https://user-images.githubusercontent.com/2141690/38821554-1e11cf48-41a1-11e8-880f-bcebd395fbdd.png">
<img width="1042" alt="screen shot 2018-04-16 at 18 07 12" src="https://user-images.githubusercontent.com/2141690/38821555-1e2d42dc-41a1-11e8-8f74-5b4ac590fcc9.png">

