### PR TITLE
Added `max_supportable_headings` to Budget::Group

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -646,16 +646,6 @@ $sidebar-active: #f4fcd0;
   font-weight: bold;
 }
 
-table {
-
-  .callout {
-    height: $line-height * 2;
-    line-height: $line-height * 2;
-    margin: 0;
-    padding: 0 $line-height / 2;
-  }
-}
-
 // 07. Legislation
 // --------------
 
@@ -1128,12 +1118,6 @@ table {
       content: '\76';
     }
   }
-}
-
-.max-headings-label {
-  color: $text-medium;
-  font-size: $small-font-size;
-  margin-left: $line-height / 2;
 }
 
 .current-of-max-headings {

--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -16,7 +16,7 @@ class Admin::BudgetGroupsController < Admin::BaseController
   private
 
     def budget_group_params
-      params.require(:budget_group).permit(:name, :max_votable_headings)
+      params.require(:budget_group).permit(:name, :max_votable_headings, :max_supportable_headings)
     end
 
     def load_budget

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -9,6 +9,8 @@ class Budget
     validates :budget_id, presence: true
     validates :name, presence: true, uniqueness: { scope: :budget }
     validates :slug, presence: true, format: /\A[a-z0-9\-_]+\z/
+    validates :max_votable_headings, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+    validates :max_supportable_headings, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
     scope :by_slug, ->(slug) { where(slug: slug) }
 

--- a/app/views/admin/budget_groups/update.js.erb
+++ b/app/views/admin/budget_groups/update.js.erb
@@ -2,6 +2,7 @@
   $("#group-form-<%= @group.id %>").html('<%= j render("admin/budgets/group_form", group: @group, budget: @group.budget, button_title: t("admin.budgets.form.submit"), id: "group-form-#{@group.id}", css_class: "group-toggle-#{@group.id}" ) %>');
 <% else %>
   $("#group-name-<%= @group.id %>").html('<%= @group.name %>')
-  $("#max-heading-label-<%=@group.id%>").html('<%= j render("admin/budgets/max_headings_label", current: @group.max_votable_headings, max: @group.headings.count, group: @group) %>')
+  $("#max-supportable-heading-label-<%=@group.id%>").html('<%= j render("admin/budgets/max_supportable_headings_label", current: @group.max_supportable_headings, max: @group.headings.count, group: @group) %>')
+  $("#max-votable-heading-label-<%=@group.id%>").html('<%= j render("admin/budgets/max_votable_headings_label", current: @group.max_votable_headings, max: @group.headings.count, group: @group) %>')
   $(".group-toggle-<%= @group.id %>").toggle()
 <% end %>

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -4,34 +4,39 @@
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
 
-        <%= content_tag(:span, (render 'admin/budgets/max_supportable_headings_label',
-                        current: group.max_supportable_headings,
-                        max: group.headings.count, group: group if group.max_supportable_headings),
-                        class:"max-headings-label group-toggle-#{group.id}",
-                        id:"max-supportable-heading-label-#{group.id}") %>
-
-        <%= content_tag(:span, (render 'admin/budgets/max_votable_headings_label',
-                        current: group.max_votable_headings,
-                        max: group.headings.count,
-                        group: group if group.max_votable_headings),
-                        class:"max-headings-label group-toggle-#{group.id}",
-                        id:"max-votable-heading-label-#{group.id}") %>
-
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>
         <%= link_to t("admin.budgets.form.add_heading"), "#", class: "button float-right js-toggle-link", data: { "toggle-selector" => "#group-#{group.id}-new-heading-form" } %>
       </th>
     </tr>
+    <% if headings.present? %>
+      <tr>
+        <th colspan="4">
+          <%= content_tag(:span, (render 'admin/budgets/max_supportable_headings_label',
+                          current: group.max_supportable_headings,
+                          max: group.headings.count, group: group if group.max_supportable_headings),
+                          class:"small group-toggle-#{group.id}",
+                          id:"max-supportable-heading-label-#{group.id}") %>
 
-  <% if headings.present? %>
-    <tr>
-      <th><%= t("admin.budgets.form.table_heading") %></th>
-      <th class="text-right"><%= t("admin.budgets.form.table_amount") %></th>
-      <th class="text-right"><%= t("admin.budgets.form.table_population") %></th>
-      <th><%= t("admin.actions.actions") %></th>
-    </tr>
-  <% end %>
-
+        </th>
+      </tr>
+      <tr>
+        <th colspan="4">
+          <%= content_tag(:span, (render 'admin/budgets/max_votable_headings_label',
+                          current: group.max_votable_headings,
+                          max: group.headings.count,
+                          group: group if group.max_votable_headings),
+                          class:"small group-toggle-#{group.id}",
+                          id:"max-votable-heading-label-#{group.id}") %>
+        </th>
+      </tr>
+      <tr>
+        <th><%= t("admin.budgets.form.table_heading") %></th>
+        <th class="text-right"><%= t("admin.budgets.form.table_amount") %></th>
+        <th class="text-right"><%= t("admin.budgets.form.table_population") %></th>
+        <th><%= t("admin.actions.actions") %></th>
+      </tr>
+    <% end %>
   </thead>
   <tbody>
 

--- a/app/views/admin/budgets/_group.html.erb
+++ b/app/views/admin/budgets/_group.html.erb
@@ -4,7 +4,18 @@
       <th colspan="4" class="with-button">
         <%= content_tag(:span, group.name, class:"group-toggle-#{group.id}", id:"group-name-#{group.id}") %>
 
-        <%= content_tag(:span, (render 'admin/budgets/max_headings_label', current: group.max_votable_headings, max: group.headings.count, group: group if group.max_votable_headings), class:"max-headings-label group-toggle-#{group.id}", id:"max-heading-label-#{group.id}") %>
+        <%= content_tag(:span, (render 'admin/budgets/max_supportable_headings_label',
+                        current: group.max_supportable_headings,
+                        max: group.headings.count, group: group if group.max_supportable_headings),
+                        class:"max-headings-label group-toggle-#{group.id}",
+                        id:"max-supportable-heading-label-#{group.id}") %>
+
+        <%= content_tag(:span, (render 'admin/budgets/max_votable_headings_label',
+                        current: group.max_votable_headings,
+                        max: group.headings.count,
+                        group: group if group.max_votable_headings),
+                        class:"max-headings-label group-toggle-#{group.id}",
+                        id:"max-votable-heading-label-#{group.id}") %>
 
         <%= render 'admin/budgets/group_form', budget: @budget, group: group, id: "group-form-#{group.id}", button_title: t("admin.budgets.form.submit"), css_class: "group-toggle-#{group.id}" %>
         <%= link_to t("admin.budgets.form.edit_group"), "#", class: "button float-right js-toggle-link hollow", data: { "toggle-selector" => ".group-toggle-#{group.id}" } %>

--- a/app/views/admin/budgets/_group_form.html.erb
+++ b/app/views/admin/budgets/_group_form.html.erb
@@ -1,6 +1,5 @@
 <%= form_for [:admin, budget, group], html: {id: id, style: display_budget_goup_form(group), class: css_class}, remote: true do |f| %>
-
-  <div class="row">
+  <div class="row expanded">
     <div class="small-12 column">
       <%= f.label :name, t("admin.budgets.form.group") %>
 
@@ -11,8 +10,8 @@
                         class: "input-group-field" %>
     </div>
   </div>
-  <div class="row">
-    <% if group.persisted? %>
+  <% if group.persisted? %>
+    <div class="row expanded">
       <div class="small-12 medium-6 column">
         <%= f.label :name, t("admin.budgets.form.max_supportable_headings") %>
 
@@ -31,10 +30,10 @@
                      label: false,
                      placeholder: t("admin.budgets.form.max_votable_headings") %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
-  <div class="row">
+  <div class="row expanded">
     <div class="small-12 column">
       <%= f.submit button_title, class: "button success" %>
     </div>

--- a/app/views/admin/budgets/_group_form.html.erb
+++ b/app/views/admin/budgets/_group_form.html.erb
@@ -1,27 +1,41 @@
 <%= form_for [:admin, budget, group], html: {id: id, style: display_budget_goup_form(group), class: css_class}, remote: true do |f| %>
 
-  <%= f.label :name, t("admin.budgets.form.group") %>
+  <div class="row">
+    <div class="small-12 column">
+      <%= f.label :name, t("admin.budgets.form.group") %>
 
-  <div class="input-group">
-    <%= f.text_field :name,
-                      label: false,
-                      maxlength: 50,
-                      placeholder: t("admin.budgets.form.group"),
-                      class: "input-group-field" %>
-
+      <%= f.text_field :name,
+                        label: false,
+                        maxlength: 50,
+                        placeholder: t("admin.budgets.form.group"),
+                        class: "input-group-field" %>
+    </div>
+  </div>
+  <div class="row">
     <% if group.persisted? %>
-      <div class="small-12 medium-6 large-4">
+      <div class="small-12 medium-6 column">
+        <%= f.label :name, t("admin.budgets.form.max_supportable_headings") %>
+
+        <%= f.select :max_supportable_headings,
+                     (1..group.headings.count),
+                     label: false,
+                     placeholder: t("admin.budgets.form.max_supportable_headings"),
+                     class: "input-group-field" %>
+      </div>
+
+      <div class="small-12 medium-6 column">
         <%= f.label :name, t("admin.budgets.form.max_votable_headings") %>
 
         <%= f.select :max_votable_headings,
                      (1..group.headings.count),
                      label: false,
-                     placeholder: t("admin.budgets.form.max_votable_headings"),
-                     class: "input-group-field" %>
+                     placeholder: t("admin.budgets.form.max_votable_headings") %>
       </div>
     <% end %>
+  </div>
 
-    <div class="input-group-button">
+  <div class="row">
+    <div class="small-12 column">
       <%= f.submit button_title, class: "button success" %>
     </div>
   </div>

--- a/app/views/admin/budgets/_heading_form.html.erb
+++ b/app/views/admin/budgets/_heading_form.html.erb
@@ -1,13 +1,15 @@
 <%= form_for [:admin, budget, group, heading], remote: true do |f| %>
   <%= render 'shared/errors', resource: heading %>
-  <label><%= t("admin.budgets.form.heading") %></label>
-  <%= f.text_field :name,
-                    label: false,
-                    maxlength: 50,
-                    placeholder: t("admin.budgets.form.heading") %>
+  <div class="row expanded">
+    <div class="small-12 column">
+      <label><%= t("admin.budgets.form.heading") %></label>
+      <%= f.text_field :name,
+                        label: false,
+                        maxlength: 50,
+                        placeholder: t("admin.budgets.form.heading") %>
+    </div>
 
-  <div class="row">
-    <div class="small-12 medium-6 column">
+    <div class="small-12 medium-6 column end">
       <label><%= t("admin.budgets.form.amount") %></label>
       <%= f.text_field :price,
                         label: false,
@@ -15,7 +17,7 @@
                         placeholder: t("admin.budgets.form.amount") %>
     </div>
   </div>
-  <div class="row">
+  <div class="row expanded">
     <div class="small-12 medium-6 column">
       <label><%= t("admin.budgets.form.population") %></label>
       <p class="help-text" id="budgets-population-help-text">
@@ -25,15 +27,20 @@
                         label: false,
                         maxlength: 8,
                         placeholder: t("admin.budgets.form.population"),
-                        data: {toggle_focus: "population-info"},
+                        data: {toggle_focus: "population_info_#{group.name.parameterize('_')}"},
                         aria: {describedby: "budgets-population-help-text"} %>
     </div>
-    <div class="small-12 medium-6 column " >
-      <div id="population-info" class="is-hidden" data-toggler="is-hidden">
+
+    <div class="small-12 medium-6 column">
+      <div id="population_info_<%= group.name.parameterize('_') %>" class="callout is-hidden" data-toggler="is-hidden">
         <%= t("admin.budgets.form.population_info") %>
       </div>
     </div>
   </div>
 
-  <%= f.submit t("admin.budgets.form.save_heading"), class: "button success" %>
+  <div class="row expanded">
+    <div class="small-12 column">
+      <%= f.submit t("admin.budgets.form.save_heading"), class: "button success" %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/admin/budgets/_max_supportable_headings_label.html.erb
+++ b/app/views/admin/budgets/_max_supportable_headings_label.html.erb
@@ -1,5 +1,4 @@
-<%= t("admin.budgets.form.max_votable_headings")%>
+<%= t("admin.budgets.form.max_supportable_headings")%>
 <%= content_tag(:strong,
                 t('admin.budgets.form.current_of_max_headings', current: current, max: max ),
                 class:"current-of-max-headings") %>
-

--- a/app/views/admin/budgets/_max_votable_headings_label.html.erb
+++ b/app/views/admin/budgets/_max_votable_headings_label.html.erb
@@ -1,0 +1,4 @@
+<%= t("admin.budgets.form.max_votable_headings")%>
+<%= content_tag(:strong,
+                t('admin.budgets.form.current_of_max_headings', current: current, max: max ),
+                class:"current-of-max-headings") %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -122,6 +122,7 @@ en:
         table_amount: Amount
         table_population: Population
         population_info: "Budget Heading population field is used for Statistic purposes at the end of the Budget to show for each Heading that represents an area with population what percentage voted. The field is optional so you can leave it empty if it doesn't apply."
+        max_supportable_headings: "Maximum number of headings in which a user can support"
         max_votable_headings: "Maximum number of headings in which a user can vote"
         current_of_max_headings: "%{current} of %{max}"
       winners:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -122,6 +122,7 @@ es:
         table_amount: Cantidad
         table_population: Población
         population_info: "El campo población de las partidas presupuestarias se usa con fines estadísticos únicamente, con el objetivo de mostrar el porcentaje de votos habidos en cada partida que represente un área con población. Es un campo opcional, así que puedes dejarlo en blanco si no aplica."
+        max_supportable_headings: "Máximo número de partidas en que un usuario puede apoyar"
         max_votable_headings: "Máximo número de partidas en que un usuario puede votar"
         current_of_max_headings: "%{current} de %{max}"
       winners:

--- a/db/migrate/20180418164308_add_max_supportable_headings_to_budget_groups.rb
+++ b/db/migrate/20180418164308_add_max_supportable_headings_to_budget_groups.rb
@@ -1,0 +1,5 @@
+class AddMaxSupportableHeadingsToBudgetGroups < ActiveRecord::Migration
+  def change
+    add_column :budget_groups, :max_supportable_headings, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180321180149) do
+ActiveRecord::Schema.define(version: 20180418164308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,9 +143,10 @@ ActiveRecord::Schema.define(version: 20180321180149) do
 
   create_table "budget_groups", force: :cascade do |t|
     t.integer "budget_id"
-    t.string  "name",                 limit: 50
+    t.string  "name",                     limit: 50
     t.string  "slug"
-    t.integer "max_votable_headings",            default: 1
+    t.integer "max_votable_headings",                default: 1
+    t.integer "max_supportable_headings",            default: 1
   end
 
   add_index "budget_groups", ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -85,6 +85,52 @@ feature 'Admin can change the groups name' do
       expect(page).to have_field('budget_group_name')
       expect(page).not_to have_field('budget_group_max_votable_headings')
     end
+  end
 
+  context "Maximum supportable headings" do
+
+    background do
+      3.times { create(:budget_heading, group: group) }
+    end
+
+    scenario "Defaults to 1 heading per group", :js do
+      visit admin_budget_path(group.budget)
+
+      expect(page).to have_content('Maximum number of headings in which a user can support 1 of 3')
+
+      within("#budget_group_#{group.id}") do
+        click_link 'Edit group'
+
+        expect(page).to have_select('budget_group_max_supportable_headings', selected: '1')
+      end
+    end
+
+    scenario "Update", :js do
+      visit admin_budget_path(group.budget)
+
+      within("#budget_group_#{group.id}") do
+        click_link 'Edit group'
+
+        select '2', from: 'budget_group_max_supportable_headings'
+        click_button 'Save group'
+      end
+
+      expect(page).to have_content('Maximum number of headings in which a user can support 2 of 3')
+
+      within("#budget_group_#{group.id}") do
+        click_link 'Edit group'
+
+        expect(page).to have_select('budget_group_max_supportable_headings', selected: '2')
+      end
+    end
+
+    scenario "Do not display maximum supportable headings' select in new form", :js do
+      visit admin_budget_path(group.budget)
+
+      click_link 'Add new group'
+
+      expect(page).to have_field('budget_group_name')
+      expect(page).not_to have_field('budget_group_max_supportable_headings')
+    end
   end
 end

--- a/spec/models/budget/group_spec.rb
+++ b/spec/models/budget/group_spec.rb
@@ -1,23 +1,39 @@
 require 'rails_helper'
 
 describe Budget::Group do
-
-  let(:budget) { create(:budget) }
-
   it_behaves_like "sluggable", updatable_slug_trait: :drafting_budget
 
-  describe "name" do
-    before do
-      create(:budget_group, budget: budget, name: 'object name')
+  describe "Validations" do
+
+    let(:budget) { create(:budget) }
+    let(:group) { create(:budget_group, budget: budget) }
+
+    describe "name" do
+      before do
+        create(:budget_group, budget: budget, name: 'object name')
+      end
+
+      it "can be repeatead in other budget's groups" do
+        expect(build(:budget_group, budget: create(:budget), name: 'object name')).to be_valid
+      end
+
+      it "must be unique among all budget's groups" do
+        expect(build(:budget_group, budget: budget, name: 'object name')).not_to be_valid
+      end
     end
 
-    it "can be repeatead in other budget's groups" do
-      expect(build(:budget_group, budget: create(:budget), name: 'object name')).to be_valid
+    describe "max_supportable_headings" do
+      it "is invalid if its not greater than 1" do
+        group.max_supportable_headings = 0
+        expect(group).not_to be_valid
+      end
     end
 
-    it "must be unique among all budget's groups" do
-      expect(build(:budget_group, budget: budget, name: 'object name')).not_to be_valid
+    describe "max_votable_headings" do
+      it "is invalid if its not greater than 1" do
+        group.max_votable_headings = 0
+        expect(group).not_to be_valid
+      end
     end
   end
-
 end


### PR DESCRIPTION
References
==========
Related issue: https://github.com/consul/consul/issues/2498

Objectives
==========
In order to achieve the issue https://github.com/consul/consul/issues/2498, we need to set a maximum supportable headings in budget groups, as it has been implemented with the votes.

In this PR, I've added a new attribute to save the `max_supportable_headings` in Budget::Group and a select in the admin section to manage groups and headings (`admin/budgets/[:budget_id]`) to set the value.

The logic to allow/prevent users to support the amount of headings defined is not implemented, that will come in a separated PR after this one's merged.

Visual Changes 
=======================
![screen shot 2018-04-19 at 17 14 47](https://user-images.githubusercontent.com/631897/39000981-8d285702-43f5-11e8-9aee-51703570ff70.png)

Now the info about `max_supportable_headings` and `max_votable_headings` appears only if headings is present. Also fixed the info callout when population input is focused. 

![screen shot 2018-04-19 at 17 14 31](https://user-images.githubusercontent.com/631897/39001099-c65693f4-43f5-11e8-93af-bea6047b1e22.png)
