### PR TITLE
Store budget heading supports

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -196,6 +196,5 @@ module Budgets
                       .send("sort_by_#{@current_order}")
         end
       end
-
   end
 end

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -24,6 +24,11 @@ class Budget
       headings.count == 1
     end
 
+    def reached_max_supportable_headings?(user)
+      supported = user.budget_heading_supports.pluck(:budget_heading_id) & headings.pluck(:id)
+      supported.count >= max_supportable_headings
+    end
+
     private
 
     def generate_slug?

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -5,6 +5,7 @@ class Budget
     belongs_to :group
 
     has_many :investments
+    has_many :supports, foreign_key: :budget_heading_id, class_name: "Budget::Heading::Support"
 
     validates :group_id, presence: true
     validates :name, presence: true, uniqueness: { if: :name_exists_in_budget_headings }
@@ -32,6 +33,10 @@ class Budget
 
     def can_be_deleted?
       investments.empty?
+    end
+
+    def already_supported_by_user?(user)
+      supports.where(user: user).any?
     end
 
     private

--- a/app/models/budget/heading/support.rb
+++ b/app/models/budget/heading/support.rb
@@ -1,0 +1,7 @@
+class Budget::Heading::Support < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :budget_heading, class_name: "Budget::Heading"
+
+  validates :user_id, presence: true
+  validates :budget_heading_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ActiveRecord::Base
   has_many :direct_messages_received, class_name: 'DirectMessage', foreign_key: :receiver_id
   has_many :legislation_answers, class_name: 'Legislation::Answer', dependent: :destroy, inverse_of: :user
   has_many :follows
+  has_many :budget_heading_supports, class_name: "Budget::Heading::Support"
   belongs_to :geozone
   belongs_to :representative, class_name: "Forum"
 

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -19,7 +19,7 @@
           title: t('budgets.investments.investment.support_title'),
           method: "post",
           remote: (display_support_alert?(investment) ? false: true ),
-          data:   (display_support_alert?(investment) ? { confirm: t('budgets.investments.investment.confirm_group', count: investment.group.max_votable_headings)} : nil),
+          data:   (display_support_alert?(investment) ? { confirm: t('budgets.investments.investment.confirm_group', count: investment.group.max_supportable_headings)} : nil),
           "aria-hidden" => css_for_aria_hidden(reason) do %>
         <%= t("budgets.investments.investment.give_support") %>
       <% end %>
@@ -30,8 +30,8 @@
     <div class="js-participation-not-allowed participation-not-allowed" style='display:none' aria-hidden="false">
       <p>
         <small>
-          <%= t("votes.budget_investments.#{reason}", 
-                count: investment.group.max_votable_headings,
+          <%= t("votes.budget_investments.#{reason}",
+                count: investment.group.max_supportable_headings,
                 verify_account: link_to(t("votes.verify_account"), verification_path),
                 signin: link_to(t("votes.signin"), new_user_session_path),
                 signup: link_to(t("votes.signup"), new_user_registration_path)

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -49,6 +49,4 @@ en:
       heading_disclaimer: "*** Data about headings refer to the heading where each user voted, not necessarily the one that person is registered on."
   votes:
     budget_investments:
-      different_heading_assigned:
-        one: "You can only support investment projects in %{count} district"
-        other: "You can only support investment projects in %{count} districts"
+      max_supportable_headings_reached: "You have reached the maximum supportable investments in this group (%{count})"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -63,6 +63,4 @@ es:
       heading_disclaimer: "*** Los datos de distrito se refieren al distrito en el que el usuario ha votado, no necesariamente en el que está empadronado."
   votes:
     budget_investments:
-      different_heading_assigned:
-        one: "Sólo puedes apoyar proyectos de gasto de %{count} distrito"
-        other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos"
+      max_supportable_headings_reached: "Has alcanzado el máximo de partidas que puedes apoyar en este grupo (%{count})"

--- a/db/migrate/20180418135704_create_budget_heading_supports.rb
+++ b/db/migrate/20180418135704_create_budget_heading_supports.rb
@@ -1,0 +1,10 @@
+class CreateBudgetHeadingSupports < ActiveRecord::Migration
+  def change
+    create_table :budget_heading_supports do |t|
+      t.references :user
+      t.references :budget_heading
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,6 +151,13 @@ ActiveRecord::Schema.define(version: 20180418164308) do
 
   add_index "budget_groups", ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree
 
+  create_table "budget_heading_supports", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "budget_heading_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
+
   create_table "budget_headings", force: :cascade do |t|
     t.integer "group_id"
     t.string  "name",       limit: 50

--- a/lib/tasks/heading_supports.rake
+++ b/lib/tasks/heading_supports.rake
@@ -1,0 +1,14 @@
+namespace :budget_heading_supports do
+  desc "Save in budget_heading_supports table the headings users have supported investments in"
+  task create: :environment do
+    Budget::Heading.pluck(:id).each do |heading_id|
+      voters = Vote.joins("JOIN budget_investments ON budget_investments.id = votes.votable_id")
+                   .where(votable_type: "Budget::Investment")
+                   .where("budget_investments.heading_id = ?", heading_id)
+                   .pluck(:voter_id)
+      voters.uniq.each do |voter_id|
+        Budget::Heading::Support.create(user_id: voter_id, budget_heading_id: heading_id)
+      end
+    end
+  end
+end

--- a/lib/tasks/max_supportable_headings.rake
+++ b/lib/tasks/max_supportable_headings.rake
@@ -1,0 +1,8 @@
+namespace :max_supportable_headings do
+  desc "Set max_votable_headings value in max_supportable_headings in existing Budget:Group"
+  task set_value: :environment do
+    Budget::Group.all.each do |group|
+      group.update(max_supportable_headings: group.max_votable_headings)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -326,6 +326,11 @@ FactoryBot.define do
     end
   end
 
+  factory :budget_heading_support, class: "Budget::Heading::Support" do
+    association :user, factory: :user
+    association :budget_heading, factory: :budget_heading
+  end
+
   factory :budget_investment, class: 'Budget::Investment' do
     sequence(:title) { |n| "Budget Investment #{n} title" }
     association :heading, factory: :budget_heading

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -172,5 +172,31 @@ feature 'Votes' do
       end
 
     end
+
+    context "User supports in a group heading" do
+      scenario "should record the heading support the first time" do
+        login_as(@manuela)
+        budget.update(phase: "selecting")
+        investment = create(:budget_investment, budget: budget, heading: heading)
+
+        visit budget_investment_path(budget, investment)
+        find('.in-favor a').click
+
+        expect(Budget::Heading::Support.all.count).to be(1)
+      end
+
+      scenario "should not record the heading support again if it was supported before" do
+        login_as(@manuela)
+        budget.update(phase: "selecting")
+        investment1 = create(:budget_investment, budget: budget, heading: heading)
+        investment2 = create(:budget_investment, budget: budget, heading: heading)
+        create(:vote, votable: investment2)
+
+        visit budget_investment_path(budget, investment1)
+        find('.in-favor a').click
+
+        expect(Budget::Heading::Support.all.count).to be(1)
+      end
+    end
   end
 end

--- a/spec/models/budget/group_spec.rb
+++ b/spec/models/budget/group_spec.rb
@@ -36,4 +36,34 @@ describe Budget::Group do
       end
     end
   end
+
+  describe "#reached_max_supportable_headings?" do
+    let(:user) { create(:user) }
+    let(:budget) { create(:budget) }
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading1) { create(:budget_heading, group: group) }
+    let(:heading2) { create(:budget_heading, group: group) }
+    let(:investment1) { create(:budget_investment, budget: budget, heading: heading1) }
+    let(:investment2) { create(:budget_investment, budget: budget, heading: heading2) }
+
+    before do
+      group.update(max_supportable_headings: 2)
+    end
+
+    it "returns true if user has supported the max headings in this group" do
+      create(:vote, votable: investment1, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading1)
+      create(:vote, votable: investment2, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading2)
+
+      expect(group.reached_max_supportable_headings?(user)).to be(true)
+    end
+
+    it "returns false if user hasn't supported the max headings in this group" do
+      create(:vote, votable: investment1, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading1)
+
+      expect(group.reached_max_supportable_headings?(user)).to be(false)
+    end
+  end
 end

--- a/spec/models/budget/heading/support_spec.rb
+++ b/spec/models/budget/heading/support_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Budget::Heading::Support do
+
+  describe "Validations" do
+    let(:budget_heading_support) { build(:budget_heading_support) }
+
+    it "is valid" do
+      expect(budget_heading_support).to be_valid
+    end
+
+    it "is not valid without user_id" do
+      budget_heading_support.user_id = nil
+      expect(budget_heading_support).not_to be_valid
+    end
+
+    it "is not valid without budget_heading_id" do
+      budget_heading_support.budget_heading_id = nil
+      expect(budget_heading_support).not_to be_valid
+    end
+  end
+
+end

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -56,4 +56,28 @@ describe Budget::Heading do
     end
   end
 
+  describe "already_supported_by_user?" do
+    let(:user) { create(:user) }
+    let(:budget) { create(:budget) }
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading1) { create(:budget_heading, group: group) }
+    let(:heading2) { create(:budget_heading, group: group) }
+    let(:investment1) { create(:budget_investment, budget: budget, heading: heading1) }
+    let(:investment2) { create(:budget_investment, budget: budget, heading: heading2) }
+
+    it "returns true if user has already supported investments in this heading" do
+      create(:vote, votable: investment1, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading1)
+
+      expect(heading1.already_supported_by_user?(user)).to be(true)
+    end
+
+    it "returns false if user hasn't supported investments in this heading" do
+      create(:vote, votable: investment2, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading2)
+
+      expect(heading1.already_supported_by_user?(user)).to be(false)
+    end
+  end
+
 end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -708,10 +708,12 @@ describe Budget::Investment do
   describe 'Permissions' do
     let(:budget)      { create(:budget) }
     let(:group)       { create(:budget_group, budget: budget) }
-    let(:heading)     { create(:budget_heading, group: group) }
+    let(:heading1)     { create(:budget_heading, group: group) }
+    let(:heading2)     { create(:budget_heading, group: group) }
+    let(:heading3)     { create(:budget_heading, group: group) }
     let(:user)        { create(:user, :level_two) }
     let(:luser)       { create(:user) }
-    let(:district_sp) { create(:budget_investment, budget: budget, group: group, heading: heading) }
+    let(:district_sp) { create(:budget_investment, budget: budget, group: group, heading: heading1) }
 
     describe '#reason_for_not_being_selectable_by' do
       it "rejects not logged in users" do
@@ -737,207 +739,63 @@ describe Budget::Investment do
         expect(district_sp.reason_for_not_being_selectable_by(user)).to be_nil
       end
 
-      it "rejects votes in two headings of the same group" do
-        carabanchel = create(:budget_heading, group: group)
-        salamanca   = create(:budget_heading, group: group)
+      it "rejects if heading investments can't be supported" do
+        budget.phase = "selecting"
+        group.update(max_supportable_headings: 2)
 
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
+        create(:vote, votable: create(:budget_investment, heading: heading2), voter: user)
+        create(:budget_heading_support, user: user, budget_heading: heading2)
+        create(:vote, votable: create(:budget_investment, heading: heading3), voter: user)
+        create(:budget_heading_support, user: user, budget_heading: heading3)
 
-        create(:vote, votable: carabanchel_investment, voter: user)
-
-        expect(salamanca_investment.valid_heading?(user)).to eq(false)
-      end
-
-      it "accepts votes in multiple headings of the same group" do
-        group.update(max_votable_headings: 2)
-
-        carabanchel = create(:budget_heading, group: group)
-        salamanca   = create(:budget_heading, group: group)
-
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
-
-        create(:vote, votable: carabanchel_investment, voter: user)
-
-        expect(salamanca_investment.valid_heading?(user)).to eq(true)
-      end
-
-      it "accepts votes in any heading previously voted in" do
-        group.update(max_votable_headings: 2)
-
-        carabanchel = create(:budget_heading, group: group)
-        salamanca   = create(:budget_heading, group: group)
-
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
-
-        create(:vote, votable: carabanchel_investment, voter: user)
-        create(:vote, votable: salamanca_investment, voter: user)
-
-        expect(carabanchel_investment.valid_heading?(user)).to eq(true)
-        expect(salamanca_investment.valid_heading?(user)).to eq(true)
-      end
-
-      it "allows votes in a group with a single heading" do
-        all_city_investment = create(:budget_investment, heading: heading)
-        expect(all_city_investment.valid_heading?(user)).to eq(true)
-      end
-
-      it "allows votes in a group with a single heading after voting in that heading" do
-        all_city_investment1 = create(:budget_investment, heading: heading)
-        all_city_investment2 = create(:budget_investment, heading: heading)
-
-        create(:vote, votable: all_city_investment1, voter: user)
-
-        expect(all_city_investment2.valid_heading?(user)).to eq(true)
-      end
-
-      it "allows votes in a group with a single heading after voting in another group" do
-        districts = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
-
-        all_city_investment    = create(:budget_investment, heading: heading)
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-
-        create(:vote, votable: carabanchel_investment, voter: user)
-
-        expect(all_city_investment.valid_heading?(user)).to eq(true)
-      end
-
-      it "allows votes in a group with multiple headings after voting in group with a single heading" do
-        districts = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
-        salamanca   = create(:budget_heading, group: districts)
-
-        all_city_investment    = create(:budget_investment, heading: heading)
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-
-        create(:vote, votable: all_city_investment, voter: user)
-
-        expect(carabanchel_investment.valid_heading?(user)).to eq(true)
-      end
-
-      it "allows voting in investments of headings where I have already voted due to a reclassification" do
-        districts   = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
-        salamanca   = create(:budget_heading, group: districts)
-        latina      = create(:budget_heading, group: districts)
-
-        all_city_investment    = create(:budget_investment, heading: heading)
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
-        latina_investment      = create(:budget_investment, heading: latina)
-
-        create(:vote, votable: all_city_investment, voter: user)
-        create(:vote, votable: carabanchel_investment, voter: user)
-
-        all_city_investment.group_id = districts.id
-        all_city_investment.heading_id = salamanca.id
-        all_city_investment.save
-
-        expect(all_city_investment.valid_heading?(user)).to eq(true)
-        expect(carabanchel_investment.valid_heading?(user)).to eq(true)
-        expect(salamanca_investment.valid_heading?(user)).to eq(true)
-        expect(latina_investment.valid_heading?(user)).to eq(false)
-      end
-
-      describe "#can_vote_in_another_heading?" do
-
-        let(:districts)   { create(:budget_group, budget: budget) }
-        let(:carabanchel) { create(:budget_heading, group: districts) }
-        let(:salamanca)   { create(:budget_heading, group: districts) }
-        let(:latina)      { create(:budget_heading, group: districts) }
-
-        let(:carabanchel_investment) { create(:budget_investment, heading: carabanchel) }
-        let(:salamanca_investment)   { create(:budget_investment, heading: salamanca) }
-        let(:latina_investment)      { create(:budget_investment, heading: latina) }
-
-        it "returns true if the user has voted in less headings than the maximum" do
-          districts.update(max_votable_headings: 2)
-
-          create(:vote, votable: carabanchel_investment, voter: user)
-
-          expect(salamanca_investment.can_vote_in_another_heading?(user)).to eq(true)
-        end
-
-        it "returns false if the user has already voted in the maximum number of headings" do
-          districts.update(max_votable_headings: 2)
-
-          create(:vote, votable: carabanchel_investment, voter: user)
-          create(:vote, votable: salamanca_investment, voter: user)
-
-          expect(latina_investment.can_vote_in_another_heading?(user)).to eq(false)
-        end
+        expect(
+          district_sp.reason_for_not_being_selectable_by(user)
+        ).to eq(:max_supportable_headings_reached)
       end
     end
+  end
 
-    describe "reclassification" do
+  describe "#not_supportable_heading?" do
+    let(:user) { create(:user) }
+    let(:budget) { create(:budget) }
+    let(:group) { create(:budget_group, budget: budget) }
+    let(:heading1) { create(:budget_heading, group: group) }
+    let(:heading2) { create(:budget_heading, group: group) }
+    let(:heading3) { create(:budget_heading, group: group) }
+    let(:investment1) { create(:budget_investment, budget: budget, heading: heading1) }
+    let(:investment2) { create(:budget_investment, budget: budget, heading: heading2) }
+    let(:investment3) { create(:budget_investment, budget: budget, heading: heading3) }
 
-      it "returns false if I have not voted" do
-        districts   = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
+    it "returns true if user has reached the max supportable headings and didn't support in it" do
+      group.update(max_supportable_headings: 2)
 
-        investment = create(:budget_investment, heading: carabanchel)
+      create(:vote, votable: investment1, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading1)
+      create(:vote, votable: investment2, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading2)
 
-        expect(investment.reclassification?(user)).to eq(false)
-      end
+      expect(investment3.not_supportable_heading?(user)).to be(true)
+    end
 
-      it "returns false if I have voted once in a single heading of a group" do
-        districts   = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
+    it "returns false if user reached max supportable headings but already supported in it" do
+      group.update(max_supportable_headings: 2)
+      investment3.update(heading: heading2)
 
-        investment = create(:budget_investment, heading: carabanchel)
+      create(:vote, votable: investment1, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading1)
+      create(:vote, votable: investment2, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading2)
 
-        create(:vote, votable: investment, voter: user)
+      expect(investment3.not_supportable_heading?(user)).to be(false)
+    end
 
-        expect(investment.reclassification?(user)).to eq(false)
-      end
+    it "returns false if user didn't reach the max supportable headings" do
+      group.update(max_supportable_headings: 2)
 
-      it "returns false if I have voted twice in a single heading of a group" do
-        districts   = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
+      create(:vote, votable: investment1, voter: user)
+      create(:budget_heading_support, user: user, budget_heading: heading1)
 
-        investment1 = create(:budget_investment, heading: carabanchel)
-        investment2 = create(:budget_investment, heading: carabanchel)
-
-        create(:vote, votable: investment1, voter: user)
-        create(:vote, votable: investment2, voter: user)
-
-        expect(investment1.reclassification?(user)).to eq(false)
-      end
-
-      it "returns false if I have voted in two headings of the same group but I am voting in a different heading" do
-        districts   = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
-        salamanca = create(:budget_heading, group: districts)
-        latina      = create(:budget_heading, group: districts)
-
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
-        latina_investment   = create(:budget_investment, heading: latina)
-
-        create(:vote, votable: carabanchel_investment, voter: user)
-        create(:vote, votable: salamanca_investment, voter: user)
-
-        expect(latina_investment.reclassification?(user)).to eq(false)
-      end
-
-      it "returns true if I have voted in two headings of the same group and I am voting in one of those headings" do
-        districts   = create(:budget_group, budget: budget)
-        carabanchel = create(:budget_heading, group: districts)
-        salamanca = create(:budget_heading, group: districts)
-
-        carabanchel_investment = create(:budget_investment, heading: carabanchel)
-        salamanca_investment   = create(:budget_investment, heading: salamanca)
-        salamanca_investment2  = create(:budget_investment, heading: salamanca)
-
-        create(:vote, votable: carabanchel_investment, voter: user)
-        create(:vote, votable: salamanca_investment, voter: user)
-
-        expect(salamanca_investment2.reclassification?(user)).to eq(true)
-      end
-
+      expect(investment2.not_supportable_heading?(user)).to be(false)
     end
   end
 
@@ -968,23 +826,6 @@ describe Budget::Investment do
       expect(another_investment.headings_voted_by_user(user2)).to_not include(san_franciso.id)
       expect(another_investment.headings_voted_by_user(user2)).to_not include(another_heading.id)
     end
-  end
-
-  describe "#voted_in?" do
-
-    let(:user) { create(:user) }
-    let(:investment) { create(:budget_investment) }
-
-    it "returns true if the user has voted in this heading" do
-      create(:vote, votable: investment, voter: user)
-
-      expect(investment.voted_in?(investment.heading, user)).to eq(true)
-    end
-
-    it "returns false if the user has not voted in this heading" do
-      expect(investment.voted_in?(investment.heading, user)).to eq(false)
-    end
-
   end
 
   describe "Order" do


### PR DESCRIPTION
References
==========
Related issue: https://github.com/consul/consul/issues/2498

Objectives
==========
- Created new model called Budget::Heading::Support to store the headings a user has supported investments in.
- Added maximum supportable headings limit for users.

Screenshots
=========
<img width="882" alt="screen shot 2018-04-20 at 15 36 44" src="https://user-images.githubusercontent.com/2141690/39062075-aa763a32-44c6-11e8-922e-48b33465cdf4.png">


Notes
==========
⚠️ **Right after deploying to production run the rake task `rake budget_heading_supports:create RAILS_ENV=[environment_name]`**