### PR TITLE
Show investment's map at Budget's heading page

### DIFF
--- a/app/assets/javascripts/fixed_bar.js.coffee
+++ b/app/assets/javascripts/fixed_bar.js.coffee
@@ -8,6 +8,8 @@ App.FixedBar =
         if $(window).scrollTop() > fixedBarTopPosition
           $this.addClass('is-fixed')
           $("#check-ballot").css({ 'display': "inline-block" })
+          $(".header-map").hide()
         else
           $this.removeClass('is-fixed')
           $("#check-ballot").hide()
+          $(".header-map").show()

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1061,6 +1061,10 @@ $sidebar-active: #f4fcd0;
   height: 0;
 }
 
+.header-map {
+  max-height: $line-height * 10;
+}
+
 // 10. Budgets
 // -----------------
 

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -3,10 +3,12 @@ module Budgets
     include FeatureFlags
     include CommentableActions
     include FlagActions
+    include BudgetHeadingsHelper
 
     before_action :authenticate_user!, except: [:index, :show, :redirect_to_new_url, :json_data]
     before_action :load_budget, except: [:redirect_to_new_url, :json_data]
     before_action :load_investment, only: [:show]
+    before_action :load_geozones, only: [:index]
 
     load_and_authorize_resource :budget, except: [:redirect_to_new_url, :json_data]
     load_and_authorize_resource :investment, through: :budget, class: "Budget::Investment", except: [:redirect_to_new_url, :json_data]
@@ -37,6 +39,7 @@ module Budgets
       @investments = investments.page(params[:page]).per(10).for_render
       @investment_ids = @investments.pluck(:id)
       load_investment_votes(@investments)
+      @investments_map_coordinates = current_heading_map_locations(investments)
     end
 
     def new

--- a/app/helpers/budget_headings_helper.rb
+++ b/app/helpers/budget_headings_helper.rb
@@ -12,4 +12,17 @@ module BudgetHeadingsHelper
     link_to(assigned_heading.name, heading_path)
   end
 
+  def current_heading_map_locations(investments)
+    investments.map do |investment|
+      next unless investment.map_location.present?
+      {
+        lat: investment.map_location.latitude,
+        long: investment.map_location.longitude,
+        investment_title: investment.title,
+        investment_id: investment.id,
+        budget_id: investment.budget.id
+      }
+    end.flatten.compact
+  end
+
 end

--- a/app/helpers/map_locations_helper.rb
+++ b/app/helpers/map_locations_helper.rb
@@ -24,11 +24,11 @@ module MapLocationsHelper
     "remove-marker-link-#{dom_id(map_location)}"
   end
 
-  def render_map(map_location, parent_class, editable, remove_marker_label, investments_coordinates=nil)
+  def render_map(map_location, parent_class, editable, remove_marker_label, investments_coordinates=nil, custom_css_class=nil)
     map_location = MapLocation.new if map_location.nil?
     map = content_tag_for :div,
                           map_location,
-                          class: "map",
+                          class: "map #{custom_css_class}",
                           data: prepare_map_settings(map_location, editable, parent_class, investments_coordinates)
     map += map_location_remove_marker(map_location, remove_marker_label) if editable
     map

--- a/app/views/budgets/investments/_header.html.erb
+++ b/app/views/budgets/investments/_header.html.erb
@@ -2,7 +2,7 @@
   <section class="no-margin-top margin-bottom">
     <div class="expanded jumbo-budget budget-heading padding">
 
-      <div class="row">
+      <div id="check-ballot-div" class="row">
         <div class="small-12 column">
           <%= back_link_to budgets_path %>
 
@@ -15,7 +15,7 @@
       </div>
 
       <div class="row progress-votes">
-        <div class="small-12 column">
+        <div class="small-12 medium-6 column">
           <% if can? :show, @ballot %>
             <div id="check-ballot" style="display: none;">
               <%= link_to t("budgets.investments.header.check_ballot"),
@@ -57,8 +57,14 @@
             </h3>
           <% end %>
         </div>
+
+        <div class="small-12 medium-6 column">
+          <%= render_map(nil, "budgets", false, nil, @investments_map_coordinates, 'header-map') %>
+        </div>
+
       </div>
     </div>
+
   </section>
 <% else %>
   <div class="expanded jumbo-budget padding no-margin-top margin-bottom">

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -59,7 +59,6 @@
       </div>
 
       <% unless investment.unfeasible? %>
-
         <% if investment.should_show_votes? %>
           <div id="<%= dom_id(investment) %>_votes"
                class="small-12 medium-3 column text-center"

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -271,14 +271,20 @@ feature 'Ballots' do
       ballot = create(:budget_ballot, user: user, budget: budget)
       ballot.investments << investment1
 
-      visit budget_investments_path(budget, heading_id: california.id)
+      visit budget_path(budget)
+
+      click_link "States"
+
+      expect(page).not_to have_css("#budget_heading_#{new_york.id}.is-active")
+      expect(page).to have_css("#budget_heading_#{california.id}.is-active")
+
+      click_link "California"
 
       within("#budget_investment_#{investment1.id}") do
         find('.remove a').click
       end
 
       visit budget_investments_path(budget, heading_id: new_york.id)
-
       add_to_ballot(investment2)
 
       visit budget_path(budget)
@@ -427,7 +433,9 @@ feature 'Ballots' do
     visit budget_investments_path(budget, heading_id: new_york.id)
     add_to_ballot(investment)
 
-    click_link "Check my ballot"
+    within("#check-ballot-div") do
+      click_link "Check my ballot"
+    end
 
     expect(page).to have_content("You have voted one investment")
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -72,6 +72,29 @@ feature 'Budget Investments' do
     end
   end
 
+  context 'Header map' do
+
+    scenario 'Shows map markers', :js do
+      investment1 = create(:budget_investment, :feasible, heading: heading)
+      investment2 = create(:budget_investment, :undecided, heading: heading)
+      investment3 = create(:budget_investment, :unfeasible, heading: heading)
+
+      investment1.create_map_location(longitude: 40.1234, latitude: 3.1234, zoom: 10)
+      investment2.create_map_location(longitude: 40.1235, latitude: 3.1235, zoom: 10)
+      investment3.create_map_location(longitude: 40.1236, latitude: 3.1236, zoom: 10)
+
+      visit budget_investments_path(budget_id: investment1.budget.id, heading_id: investment1.heading.id)
+
+      expect(find(".map_location")['data-marker-investments-coordinates']).to have_content '40.1234'
+      expect(find(".map_location")['data-marker-investments-coordinates']).to have_content '40.1235'
+      expect(find(".map_location")['data-marker-investments-coordinates']).to have_content '3.1234'
+      expect(find(".map_location")['data-marker-investments-coordinates']).to have_content '3.1235'
+      expect(find(".map_location")['data-marker-investments-coordinates']).to have_content investment1.title
+      expect(find(".map_location")['data-marker-investments-coordinates']).to have_content investment2.title
+      expect(find(".map_location")['data-marker-investments-coordinates']).not_to have_content investment3.title
+    end
+  end
+
   scenario 'Index should show investment descriptive image only when is defined' do
     Setting['feature.allow_images'] = true
 


### PR DESCRIPTION
References
==========
**Related issue**: https://github.com/consul/consul/issues/2430

Objectives
==========
Add a map to the heading of the budget investments (when accessing to all the investments of a heading). Only the geolocated and not unfeasible (the ones listed) investments will appear in the map.

Visual Changes
=======================
![mapa01](https://user-images.githubusercontent.com/31625251/39196988-c19247b8-47e3-11e8-9cee-2c2514ae6d42.png)
---
When scrolling

![map03](https://user-images.githubusercontent.com/31625251/39196999-c5a45ff8-47e3-11e8-9308-7893589f7218.gif)

Notes
=====================
- The map is smaller that the one which appeared in the mockups because, after rebasing with master, the header changed a bit. Now, the text that appears is longer, so I made the map a little shorter to fit the space in a good way.
- When the budget is in balloting phase and the user scrolls down the screen, the map hides so that the header occupies the whole wide of screen.
