### PR TITLE
[WIP] Signature validations

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -70,6 +70,7 @@ module Budgets
 
     def vote
       @investment.register_selection(current_user)
+      @investment.record_heading_support(current_user)
       load_investment_votes(@investment)
       respond_to do |format|
         format.html { redirect_to budget_investments_path(heading_id: @investment.heading.id) }
@@ -196,6 +197,5 @@ module Budgets
                       .send("sort_by_#{@current_order}")
         end
       end
-
   end
 end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -70,7 +70,6 @@ module Budgets
 
     def vote
       @investment.register_selection(current_user)
-      @investment.record_heading_support(current_user)
       load_investment_votes(@investment)
       respond_to do |format|
         format.html { redirect_to budget_investments_path(heading_id: @investment.heading.id) }

--- a/app/models/budget/group.rb
+++ b/app/models/budget/group.rb
@@ -24,6 +24,11 @@ class Budget
       headings.count == 1
     end
 
+    def reached_max_supportable_headings?(user)
+      supported = user.budget_heading_supports.pluck(:budget_heading_id) & headings.pluck(:id)
+      supported.count >= max_supportable_headings
+    end
+
     private
 
     def generate_slug?

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -5,6 +5,7 @@ class Budget
     belongs_to :group
 
     has_many :investments
+    has_many :supports, foreign_key: :budget_heading_id, class_name: "Budget::Heading::Support"
 
     validates :group_id, presence: true
     validates :name, presence: true, uniqueness: { if: :name_exists_in_budget_headings }
@@ -32,6 +33,10 @@ class Budget
 
     def can_be_deleted?
       investments.empty?
+    end
+
+    def already_supported_by_user?(user)
+      supports.where(user: user).any?
     end
 
     private

--- a/app/models/budget/heading/support.rb
+++ b/app/models/budget/heading/support.rb
@@ -1,0 +1,7 @@
+class Budget::Heading::Support < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :budget_heading, class_name: "Budget::Heading"
+
+  validates :user_id, presence: true
+  validates :budget_heading_id, presence: true
+end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -286,6 +286,12 @@ class Budget
       vote_by(voter: user, vote: 'yes') if selectable_by?(user)
     end
 
+    def record_heading_support(user)
+      unless heading.already_supported_by_user?(user.id)
+        Budget::Heading::Support.create(user: user, budget_heading: heading)
+      end
+    end
+
     def calculate_confidence_score
       self.confidence_score = ScoreCalculator.confidence_score(total_votes, total_votes)
     end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -218,7 +218,7 @@ class Budget
 
     def reason_for_not_being_selectable_by(user)
       return permission_problem(user) if permission_problem?(user)
-      return :different_heading_assigned unless valid_heading?(user)
+      return :max_supportable_headings_reached if not_supportable_heading?(user)
 
       return :no_selecting_allowed unless budget.selecting?
     end
@@ -242,35 +242,16 @@ class Budget
       permission_problem(user).present?
     end
 
+    def not_supportable_heading?(user)
+      group.reached_max_supportable_headings?(user) && !heading.already_supported_by_user?(user)
+    end
+
     def selectable_by?(user)
       reason_for_not_being_selectable_by(user).blank?
     end
 
-    def valid_heading?(user)
-      reclassification?(user) ||
-      voted_in?(heading, user) ||
-      can_vote_in_another_heading?(user)
-    end
-
-    def can_vote_in_another_heading?(user)
-      headings_voted_by_user(user).count < group.max_votable_headings
-    end
-
-    def reclassification?(user)
-      headings_voted_by_user(user).count > 1 &&
-      headings_voted_by_user(user).include?(heading_id)
-    end
-
-    def can_vote_in_another_heading?(user)
-      headings_voted_by_user(user).count < group.max_votable_headings
-    end
-
     def headings_voted_by_user(user)
       user.votes.for_budget_investments(budget.investments.where(group: group)).votables.map(&:heading_id).uniq
-    end
-
-    def voted_in?(heading, user)
-      headings_voted_by_user(user).include?(heading.id)
     end
 
     def ballotable_by?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ActiveRecord::Base
   has_many :direct_messages_received, class_name: 'DirectMessage', foreign_key: :receiver_id
   has_many :legislation_answers, class_name: 'Legislation::Answer', dependent: :destroy, inverse_of: :user
   has_many :follows
+  has_many :budget_heading_supports, class_name: "Budget::Heading::Support"
   belongs_to :geozone
   belongs_to :representative, class_name: "Forum"
 

--- a/app/views/budgets/investments/_votes.html.erb
+++ b/app/views/budgets/investments/_votes.html.erb
@@ -19,7 +19,7 @@
           title: t('budgets.investments.investment.support_title'),
           method: "post",
           remote: (display_support_alert?(investment) ? false: true ),
-          data:   (display_support_alert?(investment) ? { confirm: t('budgets.investments.investment.confirm_group', count: investment.group.max_votable_headings)} : nil),
+          data:   (display_support_alert?(investment) ? { confirm: t('budgets.investments.investment.confirm_group', count: investment.group.max_supportable_headings)} : nil),
           "aria-hidden" => css_for_aria_hidden(reason) do %>
         <%= t("budgets.investments.investment.give_support") %>
       <% end %>
@@ -30,8 +30,8 @@
     <div class="js-participation-not-allowed participation-not-allowed" style='display:none' aria-hidden="false">
       <p>
         <small>
-          <%= t("votes.budget_investments.#{reason}", 
-                count: investment.group.max_votable_headings,
+          <%= t("votes.budget_investments.#{reason}",
+                count: investment.group.max_supportable_headings,
                 verify_account: link_to(t("votes.verify_account"), verification_path),
                 signin: link_to(t("votes.signin"), new_user_session_path),
                 signup: link_to(t("votes.signup"), new_user_registration_path)

--- a/config/initializers/vote_extensions.rb
+++ b/config/initializers/vote_extensions.rb
@@ -4,6 +4,8 @@ ActsAsVotable::Vote.class_eval do
   belongs_to :signature
   belongs_to :budget_investment, foreign_key: 'votable_id', class_name: 'Budget::Investment'
 
+  after_create :record_heading_support
+
   scope :public_for_api, -> do
     where(%{(votes.votable_type = 'Debate' and votes.votable_id in (?)) or
             (votes.votable_type = 'Proposal' and votes.votable_id in (?)) or
@@ -63,6 +65,11 @@ ActsAsVotable::Vote.class_eval do
 
   def value
     vote_flag
+  end
+
+  def record_heading_support
+    return unless votable.class == Budget::Investment
+    votable.record_heading_support(voter)
   end
 
 end

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -49,6 +49,4 @@ en:
       heading_disclaimer: "*** Data about headings refer to the heading where each user voted, not necessarily the one that person is registered on."
   votes:
     budget_investments:
-      different_heading_assigned:
-        one: "You can only support investment projects in %{count} district"
-        other: "You can only support investment projects in %{count} districts"
+      max_supportable_headings_reached: "You have reached the maximum supportable investments in this group (%{count})"

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -63,6 +63,4 @@ es:
       heading_disclaimer: "*** Los datos de distrito se refieren al distrito en el que el usuario ha votado, no necesariamente en el que está empadronado."
   votes:
     budget_investments:
-      different_heading_assigned:
-        one: "Sólo puedes apoyar proyectos de gasto de %{count} distrito"
-        other: "Sólo puedes apoyar proyectos de gasto de %{count} distritos"
+      max_supportable_headings_reached: "Has alcanzado el máximo de partidas que puedes apoyar en este grupo (%{count})"

--- a/db/migrate/20180418135704_create_budget_heading_supports.rb
+++ b/db/migrate/20180418135704_create_budget_heading_supports.rb
@@ -1,0 +1,10 @@
+class CreateBudgetHeadingSupports < ActiveRecord::Migration
+  def change
+    create_table :budget_heading_supports do |t|
+      t.references :user
+      t.references :budget_heading
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,6 +151,13 @@ ActiveRecord::Schema.define(version: 20180418164308) do
 
   add_index "budget_groups", ["budget_id"], name: "index_budget_groups_on_budget_id", using: :btree
 
+  create_table "budget_heading_supports", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "budget_heading_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
+
   create_table "budget_headings", force: :cascade do |t|
     t.integer "group_id"
     t.string  "name",       limit: 50

--- a/lib/tasks/heading_supports.rake
+++ b/lib/tasks/heading_supports.rake
@@ -1,0 +1,14 @@
+namespace :budget_heading_supports do
+  desc "Save in budget_heading_supports table the headings users have supported investments in"
+  task create: :environment do
+    Vote.where(votable_type: "Budget::Investment").each do |vote|
+      heading = Budget::Investment.with_hidden.find(vote.votable_id).heading
+      already_saved = Budget::Heading::Support.where(user: vote.voter,
+                                                     budget_heading: heading).any?
+
+      unless already_saved
+        Budget::Heading::Support.create(user: vote.voter, budget_heading: heading)
+      end
+    end
+  end
+end

--- a/lib/tasks/max_supportable_headings.rake
+++ b/lib/tasks/max_supportable_headings.rake
@@ -1,0 +1,8 @@
+namespace :max_supportable_headings do
+  desc "Set max_votable_headings value in max_supportable_headings in existing Budget:Group"
+  task set_value: :environment do
+    Budget::Group.all.each do |group|
+      group.update(max_supportable_headings: group.max_votable_headings)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -326,6 +326,11 @@ FactoryBot.define do
     end
   end
 
+  factory :budget_heading_support, class: "Budget::Heading::Support" do
+    association :user, factory: :user
+    association :budget_heading, factory: :budget_heading
+  end
+
   factory :budget_investment, class: 'Budget::Investment' do
     sequence(:title) { |n| "Budget Investment #{n} title" }
     association :heading, factory: :budget_heading

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -276,7 +276,7 @@ feature 'Votes' do
         budget.update(phase: "selecting")
         investment1 = create(:budget_investment, budget: budget, heading: heading)
         investment2 = create(:budget_investment, budget: budget, heading: heading)
-        create(:vote, votable: investment2)
+        create(:vote, votable: investment2, voter: @manuela)
 
         visit budget_investment_path(budget, investment1)
         find('.in-favor a').click

--- a/spec/features/budgets/votes_spec.rb
+++ b/spec/features/budgets/votes_spec.rb
@@ -172,5 +172,31 @@ feature 'Votes' do
       end
 
     end
+
+    context "User supports in a group heading" do
+      scenario "should record the heading support the first time" do
+        login_as(@manuela)
+        budget.update(phase: "selecting")
+        investment = create(:budget_investment, budget: budget, heading: heading)
+
+        visit budget_investment_path(budget, investment)
+        find('.in-favor a').click
+
+        expect(Budget::Heading::Support.all.count).to be(1)
+      end
+
+      scenario "should not record the heading support again if it was supported before" do
+        login_as(@manuela)
+        budget.update(phase: "selecting")
+        investment1 = create(:budget_investment, budget: budget, heading: heading)
+        investment2 = create(:budget_investment, budget: budget, heading: heading)
+        create(:vote, votable: investment2)
+
+        visit budget_investment_path(budget, investment1)
+        find('.in-favor a').click
+
+        expect(Budget::Heading::Support.all.count).to be(1)
+      end
+    end
   end
 end

--- a/spec/models/budget/heading/support_spec.rb
+++ b/spec/models/budget/heading/support_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Budget::Heading::Support do
+
+  describe "Validations" do
+    let(:budget_heading_support) { build(:budget_heading_support) }
+
+    it "is valid" do
+      expect(budget_heading_support).to be_valid
+    end
+
+    it "is not valid without user_id" do
+      budget_heading_support.user_id = nil
+      expect(budget_heading_support).not_to be_valid
+    end
+
+    it "is not valid without budget_heading_id" do
+      budget_heading_support.budget_heading_id = nil
+      expect(budget_heading_support).not_to be_valid
+    end
+  end
+
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -132,6 +132,28 @@ describe Signature do
         expect(Vote.count).to eq(1)
       end
 
+      it "does not assign vote to user if user cannot vote in that heading" do
+        budget = create(:budget, phase: "selecting")
+        group = create(:budget_group, budget: budget, max_supportable_headings: 1)
+        heading1 = create(:budget_heading, group: group)
+        heading2 = create(:budget_heading, group: group)
+
+        investment1 = create(:budget_investment, heading: heading1)
+        investment2 = create(:budget_investment, heading: heading2)
+
+        user = create(:user, :level_two, document_number: "123A")
+        vote = create(:vote, votable: investment1, voter: user)
+
+        signature_sheet = create(:signature_sheet, signable: investment2)
+        signature = create(:signature, document_number: user.document_number, signature_sheet: signature_sheet)
+
+        expect(Vote.count).to eq(1)
+
+        signature.verify
+
+        expect(Vote.count).to eq(1)
+      end
+
       it "marks the vote as coming from a signature" do
         signature = create(:signature, document_number: "12345678Z")
 


### PR DESCRIPTION
References
==========
**Pull Request**: [Store budget heading supports](https://github.com/AyuntamientoMadrid/consul/pull/1439)

Objectives
==========
Add a spec to make sure _signature sheets_ take into account that the user can indeed support an investment before recording the _signature vote_

Notes
=====================
This PR is based from a yet unmerged [PR](https://github.com/AyuntamientoMadrid/consul/pull/1439)

The _signature sheets_ will still work properly before merging the related [PR](https://github.com/AyuntamientoMadrid/consul/pull/1439). However once that PR is merged, this one should be merged too for signature sheets to continue to work properly, as the logic to validate votes will change.

