### PR TITLE
Fix Investments bugs from migrated Spending Proposals

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -6,7 +6,6 @@ module Budgets
 
     before_action :authenticate_user!, except: [:index, :show, :redirect_to_new_url, :json_data]
     before_action :load_budget, except: [:redirect_to_new_url, :json_data]
-    before_action :load_investment, only: [:show]
 
     load_and_authorize_resource :budget, except: [:redirect_to_new_url, :json_data]
     load_and_authorize_resource :investment, through: :budget, class: "Budget::Investment", except: [:redirect_to_new_url, :json_data]
@@ -85,7 +84,7 @@ module Budgets
 
     def redirect_to_new_url
       investment = Budget::Investment.where(original_spending_proposal_id: params['id']).first
-      redirect_to budget_investment_path(investment.budget.slug, params['id']) if investment.present?
+      redirect_to budget_investment_path(investment.budget.slug, investment.id) if investment.present?
     end
 
     def json_data
@@ -138,11 +137,6 @@ module Budgets
                       image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                       documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                       map_location_attributes: [:latitude, :longitude, :zoom])
-      end
-
-      def load_investment
-        @investment = @budget.investments.where(original_spending_proposal_id: params['id']).first
-        @investment ||= @budget.investments.find(params['id'])
       end
 
       def load_ballot

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -102,10 +102,6 @@ class Budget
     before_validation :set_responsible_name
     before_validation :set_denormalized_ids
 
-    def to_param
-      original_spending_proposal_id || id
-    end
-
     def comments_count
       comments.count
     end


### PR DESCRIPTION
References
==========
There where some problems around investments migrated from spending proposals:
- Milestones created on 2017 Investments that had the same ID as a migrated Spending Proposal... lead to milestone creation on the associated investment to the migrated spending proposal.

- Investments map links where incorrect, leading to 2016 proposals when another "same ID as" scenario happened https://twitter.com/sergio_gfp/status/982164154021593089

Objectives
==========
Revert the changes done to wrongly solve https://github.com/AyuntamientoMadrid/consul/issues/1163 and another scenario that was described internally: When visiting and old spending proposal url, it should redirect to the new investment url but maintaining the old spending proposal ID.... that leads to "same ID as" problems and finally not really something that we have to achieve in order to keep the page working properly.

Both parameterizing investments by its possible present `old_spending_proposal_id` and looking for investments firstly by its possible present `old_spending_proposal_id` was the main reason behind all this bugs.

Also the specs created to check this url redirects behaviour where not very clear.

Visual Changes (if any)
=======================
None, only url's behaviour

Notes
=====================
Still this can't be backported to consul, as we're far from completing the SpendingProposal migration task. 