### PR TITLE
Budgets admin add heading

### DIFF
--- a/app/views/admin/budgets/_heading_form.html.erb
+++ b/app/views/admin/budgets/_heading_form.html.erb
@@ -27,12 +27,11 @@
                         label: false,
                         maxlength: 8,
                         placeholder: t("admin.budgets.form.population"),
-                        data: {toggle_focus: "population_info_#{group.name.parameterize('_')}"},
                         aria: {describedby: "budgets-population-help-text"} %>
     </div>
 
     <div class="small-12 medium-6 column">
-      <div id="population_info_<%= group.name.parameterize('_') %>" class="callout is-hidden" data-toggler="is-hidden">
+      <div class="callout">
         <%= t("admin.budgets.form.population_info") %>
       </div>
     </div>


### PR DESCRIPTION
References
==========
This PR fixes **Admin budgets Manage groups and headings Create heading** spec:

`rspec ./spec/features/admin/budgets_spec.rb:253`

It was failing with:

```
Admin budgets
  Manage groups and headings
    Create heading (FAILED - 1)

Failures:

  1) Admin budgets Manage groups and headings Create heading
     Failure/Error: expect(page).not_to have_content 'This group has no assigned heading.'
       expected not to find text "This group has no assigned heading." in "Districts improvments Edit group Add heading This group has no assigned heading."
     # ./spec/features/admin/budgets_spec.rb:276:in `block (4 levels) in <top (required)>'
```

How
==========

Removes data `toggle focus` on _population info_ field. I think (after a little research) It does not work as expected because the value of the element is already updated to `''` when the focus is triggered and the heading it wasn't created on spec.

Now the callout with info appears always (not only when focus population field) _(see screenshot)_

Visual Changes 
=======================
![admin_heading](https://user-images.githubusercontent.com/631897/39640143-5d64f058-4fca-11e8-82fd-2b4f46545157.png)
