### PR TITLE
Always calculate correct letter for DNI

### DIFF
--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -135,13 +135,13 @@ class CensusApi
           stubbed_invalid_response
         end
       when "2"
-        if document_number == "12345678A"
+        if document_number == "AA12345B"
           stubbed_valid_passport_response
         else
           stubbed_invalid_response
         end
       when "3"
-        if document_number == "12345678B"
+        if document_number == "X54321H"
           stubbed_valid_foreign_resident_response
         else
           stubbed_invalid_response
@@ -156,11 +156,11 @@ class CensusApi
     end
 
     def stubbed_valid_passport_response
-      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: { item: {fecha_nacimiento_string: "31-12-1980", identificador_documento: "12345678", letra_documento_string: "A", descripcion_sexo: "Varón", nombre: "José", apellido1: "García" }}, datos_vivienda: {item: {codigo_postal: "28013", codigo_distrito: "01"}}}}}
+      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: { item: {fecha_nacimiento_string: "31-12-1980", identificador_documento: "AA12345", letra_documento_string: "B", descripcion_sexo: "Varón", nombre: "José", apellido1: "García" }}, datos_vivienda: {item: {codigo_postal: "28013", codigo_distrito: "01"}}}}}
     end
 
     def stubbed_valid_foreign_resident_response
-      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: { item: {fecha_nacimiento_string: "31-12-1980", identificador_documento: "12345678", letra_documento_string: "B", descripcion_sexo: "Varón", nombre: "José", apellido1: "García" }}, datos_vivienda: {item: {codigo_postal: "28013", codigo_distrito: "01"}}}}}
+      {get_habita_datos_response: {get_habita_datos_return: {datos_habitante: { item: {fecha_nacimiento_string: "31-12-1980", identificador_documento: "X54321", letra_documento_string: "H", descripcion_sexo: "Varón", nombre: "José", apellido1: "García" }}, datos_vivienda: {item: {codigo_postal: "28013", codigo_distrito: "01"}}}}}
     end
 
     def stubbed_invalid_response

--- a/lib/document_parser.rb
+++ b/lib/document_parser.rb
@@ -54,17 +54,11 @@ module DocumentParser
   # ['1234a', '1234A', '01234a', '01234A']
   def get_letter_variants(number_variants, letter)
     variants = []
-    if letter.present?
-      number_variants.each do |number|
-        variants << number + letter.downcase << number + letter.upcase
-      end
-    else
-      spanish_id_eight_digits = format_spanish_id_digits(number_variants.first)
-      letter = generate_letter(spanish_id_eight_digits)
+    spanish_id_eight_digits = format_spanish_id_digits(number_variants.first)
+    letter = generate_letter(spanish_id_eight_digits)
 
-      number_variants.each do |number|
-        variants << number + letter.downcase << number + letter.upcase
-      end
+    number_variants.each do |number|
+      variants << number + letter.downcase << number + letter.upcase
     end
     variants
   end

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -39,13 +39,13 @@ feature 'Signature sheets' do
 
       select "Citizen proposal", from: "signature_sheet_signable_type"
       fill_in "signature_sheet_signable_id", with: proposal.id
-      fill_in "signature_sheet_document_numbers", with: "12345678Z, 99999999Z"
+      fill_in "signature_sheet_document_numbers", with: "12345678Z, 1234567L, 99999999Z"
       click_button "Create signature sheet"
 
       expect(page).to have_content "Signature sheet created successfully"
       expect(page).to have_content "There is 1 valid signature"
       expect(page).to have_content "There is 1 vote created from the verified signatures"
-      expect(page).to have_content "There is 1 invalid signature"
+      expect(page).to have_content "There are 2 invalid signatures"
 
       visit proposal_path(proposal)
 
@@ -61,17 +61,17 @@ feature 'Signature sheets' do
 
       select "Investment", from: "signature_sheet_signable_type"
       fill_in "signature_sheet_signable_id", with: investment.id
-      fill_in "signature_sheet_document_numbers", with: "12345678Z, 12345678A, 99999999Z"
+      fill_in "signature_sheet_document_numbers", with: "12345678Z, 1234567L, 99999999Z"
       click_button "Create signature sheet"
 
       expect(page).to have_content "Signature sheet created successfully"
-      expect(page).to have_content "There are 2 valid signatures"
-      expect(page).to have_content "There is 2 votes created from verified signatures"
-      expect(page).to have_content "There is 1 invalid signature"
+      expect(page).to have_content "There is 1 valid signature"
+      expect(page).to have_content "There is 1 vote created from the verified signatures"
+      expect(page).to have_content "There are 2 invalid signatures"
 
       visit budget_investment_path(budget, investment)
 
-      expect(page).to have_content "2 supports"
+      expect(page).to have_content "1 support"
     end
 
   end

--- a/spec/features/officing/letters_spec.rb
+++ b/spec/features/officing/letters_spec.rb
@@ -220,49 +220,49 @@ feature 'Letters' do
   context "Checks all document types" do
 
     scenario "Passport" do
-      fill_in 'residence_document_number', with: "12345678A"
+      fill_in 'residence_document_number', with: "AA12345B"
       fill_in 'residence_postal_code', with: '28013'
 
       click_button 'Validate document'
 
       expect(page).to have_content 'Voto VÁLIDO'
-      expect(page).to have_content '12345678A'
+      expect(page).to have_content 'AA12345B'
       expect(page).to have_content '28013'
 
       voters = Poll::Voter.all
       expect(voters.count).to eq(1)
       expect(voters.first.origin).to eq("letter")
-      expect(voters.first.document_number).to eq("12345678A")
+      expect(voters.first.document_number).to eq("AA12345B")
       expect(voters.first.document_type).to eq("2")
       expect(voters.first.poll).to eq(poll)
 
       logs = Poll::LetterOfficerLog.all
       expect(logs.count).to eq(2)
       expect(logs.first.user_id).to eq(officer.user_id)
-      expect(logs.first.document_number).to eq("12345678A")
+      expect(logs.first.document_number).to eq("AA12345B")
       expect(logs.first.postal_code).to eq("28013")
       expect(logs.first.message).to eq("Voto NO VÁLIDO")
 
       expect(logs.last.user_id).to eq(officer.user_id)
-      expect(logs.last.document_number).to eq("12345678A")
+      expect(logs.last.document_number).to eq("AA12345B")
       expect(logs.last.postal_code).to eq("28013")
       expect(logs.last.message).to eq("Voto VÁLIDO")
     end
 
     scenario "Foreign resident" do
-      fill_in 'residence_document_number', with: "12345678B"
+      fill_in 'residence_document_number', with: "X54321H"
       fill_in 'residence_postal_code', with: '28013'
 
       click_button 'Validate document'
 
       expect(page).to have_content 'Voto VÁLIDO'
-      expect(page).to have_content '12345678B'
+      expect(page).to have_content 'X54321H'
       expect(page).to have_content '28013'
 
       voters = Poll::Voter.all
       expect(voters.count).to eq(1)
       expect(voters.first.origin).to eq("letter")
-      expect(voters.first.document_number).to eq("12345678B")
+      expect(voters.first.document_number).to eq("X54321H")
       expect(voters.first.document_type).to eq("3")
       expect(voters.first.poll).to eq(poll)
 

--- a/spec/lib/census_api_spec.rb
+++ b/spec/lib/census_api_spec.rb
@@ -23,11 +23,15 @@ describe CensusApi do
     end
 
     it 'adds upper and lowercase letter when the letter is present' do
-      expect(api.get_document_number_variants(1, '1234567A')).to eq(%w(1234567 01234567 1234567a 1234567A 01234567a 01234567A))
+      expect(api.get_document_number_variants(1, '1234567L')).to eq(%w(1234567 01234567 1234567l 1234567L 01234567l 01234567L))
     end
 
     it 'adds letter if not present' do
       expect(api.get_document_number_variants(1, '1234567')).to eq(%w(1234567 01234567 1234567l 1234567L 01234567l 01234567L))
+    end
+
+    it 'uses the correct letter for a spanish document number' do
+      expect(api.get_document_number_variants(1, '1234567B')).to eq(%w(1234567 01234567 1234567l 1234567L 01234567l 01234567L))
     end
   end
 

--- a/spec/lib/local_census_spec.rb
+++ b/spec/lib/local_census_spec.rb
@@ -23,11 +23,15 @@ describe LocalCensus do
     end
 
     it 'adds upper and lowercase letter when the letter is present' do
-      expect(api.get_document_number_variants(1, '1234567A')).to eq(%w(1234567 01234567 1234567a 1234567A 01234567a 01234567A))
+      expect(api.get_document_number_variants(1, '1234567L')).to eq(%w(1234567 01234567 1234567l 1234567L 01234567l 01234567L))
     end
 
     it 'adds letter if not present' do
       expect(api.get_document_number_variants(1, '1234567')).to eq(%w(1234567 01234567 1234567l 1234567L 01234567l 01234567L))
+    end
+
+    it 'uses the correct letter for a spanish document number' do
+      expect(api.get_document_number_variants(1, '1234567B')).to eq(%w(1234567 01234567 1234567l 1234567L 01234567l 01234567L))
     end
   end
 


### PR DESCRIPTION
Objectives
==========
Always calculate letter for a spanish document number

Notes
=====================
Sometimes when transcribing signature sheets the letters are mistyped. For example: using 'P' instead of 'F'. This commit generates the letter every time to make sure we avoid this typos
