### PR TITLE
Allow select between map or links on sidebar

### DIFF
--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -76,6 +76,7 @@ module CommentableActions
 
   def map
     @resource = resource_model.new
+    @resource_name = resource_model.name.downcase
     @tag_cloud = tag_cloud
   end
 

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -7,6 +7,7 @@ class DebatesController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :map]
   before_action :set_view, only: :index
   before_action :debates_recommendations, only: :index, if: :current_user
+  before_action :load_geozones, only: [:map, :index]
 
   feature_flag :debates
 

--- a/app/controllers/human_rights_controller.rb
+++ b/app/controllers/human_rights_controller.rb
@@ -7,6 +7,7 @@ class HumanRightsController < ApplicationController
   before_action :parse_search_terms,          only: :index
   before_action :parse_advanced_search_terms, only: :index
   before_action :set_search_order,            only: :index
+  before_action :load_geozones,               only: :index
 
   has_orders %w{random confidence_score},     only: :index
   has_orders %w{most_voted newest oldest},    only: :show

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -5,7 +5,7 @@ class ProposalsController < ApplicationController
 
   before_action :parse_tag_filter, only: :index
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
-  before_action :load_geozones, only: [:edit, :map, :summary]
+  before_action :load_geozones, only: [:edit, :map, :summary, :index]
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
   before_action :destroy_map_location_association, only: :update
   before_action :set_view, only: :index

--- a/app/helpers/geozones_helper.rb
+++ b/app/helpers/geozones_helper.rb
@@ -39,4 +39,12 @@ module GeozonesHelper
     end
   end
 
+  def show_map(geozonable)
+    feature?("geozones.#{geozonable.pluralize}.maps")
+  end
+
+  def show_links(geozonable)
+    feature?("geozones.#{geozonable.pluralize}.links")
+  end
+
 end

--- a/app/helpers/geozones_helper.rb
+++ b/app/helpers/geozones_helper.rb
@@ -17,4 +17,26 @@ module GeozonesHelper
     @all_geozones[g_id] || t("geozones.none")
   end
 
+  def geozonables_path(geozonable_type, geozonable_name)
+    case geozonable_type
+    when 'debate'
+      debates_path(search: geozonable_name)
+    when 'proposal'
+      proposals_path(search: geozonable_name)
+    else
+      '#'
+    end
+  end
+
+  def map_geozonable_path(geozonable)
+    case geozonable
+    when 'debate'
+      map_debates_path
+    when 'proposal'
+      map_proposals_path
+    else
+      '#'
+    end
+  end
+
 end

--- a/app/views/custom/debates/index.html.erb
+++ b/app/views/custom/debates/index.html.erb
@@ -115,6 +115,7 @@
       <aside class="margin-bottom">
         <%= link_to t("debates.index.start_debate"), new_debate_path, class: "button expanded" %>
         <%= render "shared/tag_cloud", taggable: "debate" %>
+        <%= render 'shared/geozones', geozonable: 'debate' %>
         <%= render "popular" %>
       </aside>
     </div>

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -146,7 +146,7 @@
           <% if request.path != human_rights_proposals_path %>
             <%= render "shared/tag_cloud", taggable: 'proposal' %>
           <% end %>
-          <%= render 'geozones' %>
+          <%= render 'shared/geozones', geozonable: 'proposal' %>
           <%= render 'popular' %>
         <% end %>
         <%= render 'retired' %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -105,6 +105,7 @@
       <aside class="margin-bottom">
         <%= link_to t("debates.index.start_debate"), new_debate_path, class: "button expanded" %>
         <%= render "shared/tag_cloud", taggable: "debate" %>
+        <%= render 'shared/geozones', geozonable: 'debate' %>
       </aside>
     </div>
 

--- a/app/views/proposals/_geozones.html.erb
+++ b/app/views/proposals/_geozones.html.erb
@@ -1,6 +1,0 @@
-<div class="sidebar-divider"></div>
-<h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
-<br>
-<%= link_to map_proposals_path, id: 'map', title: t("shared.tags_cloud.districts_list") do %>
-  <%= image_tag("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
-<% end %>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -116,7 +116,7 @@
         <% if params[:retired].blank? %>
           <%= render 'categories' %>
           <%= render "shared/tag_cloud", taggable: 'proposal' %>
-          <%= render 'geozones' %>
+          <%= render 'shared/geozones', geozonable: 'proposal' %>
           <%= render 'popular' %>
         <% end %>
         <%= render 'retired' %>

--- a/app/views/proposals/summary.html.erb
+++ b/app/views/proposals/summary.html.erb
@@ -46,7 +46,7 @@
         <%= link_to t("proposals.index.start_proposal"), new_proposal_path, class: 'button expanded' %>
         <%= render "shared/tag_cloud", taggable: 'proposal' %>
         <%= render 'categories' %>
-        <%= render 'geozones' %>
+        <%= render 'shared/geozones', geozonable: 'proposal' %>
       </aside>
     </div>
   </div>

--- a/app/views/shared/_geozones.html.erb
+++ b/app/views/shared/_geozones.html.erb
@@ -1,0 +1,12 @@
+<div class="sidebar-divider"></div>
+<h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
+<br>
+<%= link_to map_geozonable_path(geozonable), id: 'map', title: t("shared.tags_cloud.districts_list") do %>
+  <%= image_tag("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
+<% end %>
+
+<ul id="geozones" class="no-bullet">
+  <% @geozones.each do |geozone| %>
+    <li><%= link_to geozone.name, geozonables_path(geozonable, geozone.name) %></li>
+  <% end %>
+</ul>

--- a/app/views/shared/_geozones.html.erb
+++ b/app/views/shared/_geozones.html.erb
@@ -1,12 +1,18 @@
-<div class="sidebar-divider"></div>
-<h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
-<br>
-<%= link_to map_geozonable_path(geozonable), id: 'map', title: t("shared.tags_cloud.districts_list") do %>
-  <%= image_tag("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
-<% end %>
-
-<ul id="geozones" class="no-bullet">
-  <% @geozones.each do |geozone| %>
-    <li><%= link_to geozone.name, geozonables_path(geozonable, geozone.name) %></li>
+<% if show_map(geozonable.pluralize) || show_links(geozonable.pluralize) %>
+  <div class="sidebar-divider"></div>
+  <h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
+  <br>
+  <% if show_map(geozonable.pluralize) %>
+    <%= link_to map_geozonable_path(geozonable), id: 'map', title: t("shared.tags_cloud.districts_list") do %>
+      <%= image_tag("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
+    <% end %>
   <% end %>
-</ul>
+
+  <% if show_links(geozonable.pluralize) %>
+    <ul id="geozones" class="no-bullet">
+      <% @geozones.each do |geozone| %>
+        <li><%= link_to geozone.name, geozonables_path(geozonable, geozone.name) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -7,7 +7,7 @@
       <div class="small-12 medium-3 column">
         <ul id="geozones" class="no-bullet">
           <% @geozones.each do |geozone| %>
-            <li><%= link_to geozone.name, proposals_path(search: geozone.name) %></li>
+            <li><%= link_to geozone.name, polymorphic_url(@resource, search: geozone.name) %></li>
           <% end %>
         </ul>
       </div>
@@ -37,16 +37,16 @@
       </div>
 
       <div class="actions small-12">
-        <%= f.submit(class: "button", value: t("map.start_proposal")) %>
+        <%= f.submit(class: "button", value: t("map.start.#{@resource_name}")) %>
       </div>
     <% end %>
   </div>
 
   <div class="small-12 medium-3 column">
     <aside class="sidebar">
-      <%= link_to t("map.start_proposal"),
-                  new_proposal_path, class: 'button expanded' %>
-      <%= render "shared/tag_cloud", taggable: 'proposal' %>
+      <%= link_to t("map.start.#{@resource_name}"),
+                  polymorphic_url(@resource, action: :new), class: 'button expanded' %>
+      <%= render "shared/tag_cloud", taggable: @resource_name %>
     </aside>
   </div>
 </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -274,7 +274,9 @@ en:
     title: "Districts"
     proposal_for_district: "Start a proposal for your district"
     select_district: Scope of operation
-    start_proposal: Create a proposal
+    start:
+      proposal: Create a proposal
+      debate: Create a debate
   omniauth:
     facebook:
       sign_in: Sign in with Facebook

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -131,4 +131,11 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       probe:
         plaza: "Plaza España Probe"
-        voting_allowed: Voting on investment projects
+        voting_allowed: "Voting on investment projects"
+      geozones:
+        proposals:
+          maps: "Show map of geozones on proposals index sidebar"
+          links: "Show links of geozones on proposals index sidebar"
+        debates:
+          maps: "Show map of geozones on debates index sidebar"
+          links: "Show links of geozones on debates index sidebar"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -271,7 +271,9 @@ es:
     title: "Distritos"
     proposal_for_district: "Crea una propuesta para tu distrito"
     select_district: Ámbito de actuación
-    start_proposal: Crea una propuesta
+    start:
+      proposal: Crea una propuesta
+      debate: Crea un debate
   omniauth:
     facebook:
       sign_in: Entra con Facebook

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -131,4 +131,11 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       probe:
         plaza: "Sondeo Plaza España"
-        voting_allowed: Votaciones sobre propuestas de inversión
+        voting_allowed: "Votaciones sobre propuestas de inversión"
+      geozones:
+        proposals:
+          maps: "Ver mapa de geozonas en la barra lateral de las propuestas"
+          links: "Ver links de geozonas en la barra lateral de las propuestas"
+        debates:
+          maps: "Ver mapa de geozonas en la barra lateral de los debates"
+          links: "Ver links de geozonas en la barra lateral de los debates"

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -57,6 +57,11 @@ section "Creating Settings" do
   Setting.create(key: 'feature.guides', value: true)
   Setting.create(key: 'feature.user.skip_verification', value: "true")
 
+  Setting.create(key: 'feature.geozones.proposals.maps', value: true)
+  Setting.create(key: 'feature.geozones.proposals.links', value: true)
+  Setting.create(key: 'feature.geozones.debates.maps', value: true)
+  Setting.create(key: 'feature.geozones.debates.links', value: true)
+
   Setting.create(key: 'per_page_code_head', value: "")
   Setting.create(key: 'per_page_code_body', value: "")
   Setting.create(key: 'comments_body_max_length', value: '1000')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -99,6 +99,12 @@ Setting['feature.spending_proposal_features.final_voting_allowed'] = true
 Setting['feature.spending_proposal_features.open_results_page'] = nil
 Setting['feature.spending_proposal_features.valuation_allowed'] = nil
 
+# Geozones links and maps on debates and proposals
+Setting['feature.geozones.proposals.maps'] = true
+Setting['feature.geozones.proposals.links'] = true
+Setting['feature.geozones.debates.maps'] = true
+Setting['feature.geozones.debates.links'] = true
+
 # Banner styles
 Setting['banner-style.banner-style-one']   = "Banner style 1"
 Setting['banner-style.banner-style-two']   = "Banner style 2"

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -20,4 +20,12 @@ namespace :settings do
     Setting['feature.user.recommendations_on_proposals'] = true
   end
 
+  desc "Create new settings for geozones maps and links in proposals and debates sidebar"
+  task create_geozones_maps_links: :environment do
+    Setting['feature.geozones.proposals.maps'] = true
+    Setting['feature.geozones.proposals.links'] = true
+    Setting['feature.geozones.debates.maps'] = true
+    Setting['feature.geozones.debates.links'] = true
+  end
+
 end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -29,6 +29,47 @@ feature 'Debates' do
     end
   end
 
+  context "Map and links of geozones" do
+
+    after do
+      Setting['feature.geozones.debates.maps'] = true
+      Setting['feature.geozones.debates.links'] = true
+    end
+
+    scenario "Both are shown" do
+      visit debates_path
+
+      expect(page).to have_selector('a#map')
+      expect(page).to have_selector('ul#geozones')
+    end
+
+    scenario "Map is shown" do
+      Setting['feature.geozones.debates.links'] = nil
+      visit debates_path
+
+      expect(page).to have_selector('a#map')
+      expect(page).not_to have_selector('ul#geozones')
+    end
+
+    scenario "Links are shown" do
+      Setting['feature.geozones.debates.maps'] = nil
+      visit debates_path
+
+      expect(page).not_to have_selector('a#map')
+      expect(page).to have_selector('ul#geozones')
+    end
+
+    scenario "Neither map nor links are shown" do
+      Setting['feature.geozones.debates.maps'] = nil
+      Setting['feature.geozones.debates.links'] = nil
+      visit debates_path
+
+      expect(page).not_to have_selector('a#map')
+      expect(page).not_to have_selector('ul#geozones')
+    end
+
+  end
+
   scenario 'Paginated Index' do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:debate) }
@@ -59,7 +100,7 @@ feature 'Debates' do
     debates.each do |debate|
       within('#debates') do
         expect(page).to     have_link debate.title
-        expect(page).to_not have_content debate.description
+        expect(page).not_to have_content debate.description
       end
     end
 
@@ -1072,7 +1113,7 @@ feature 'Debates' do
         @debate3 = create(:debate, geozone: @new_york)
       end
 
-      pending "From map" do
+      scenario "From map" do
         visit debates_path
 
         click_link "map"
@@ -1089,7 +1130,7 @@ feature 'Debates' do
         end
       end
 
-      pending "From geozone list" do
+      scenario "From geozone list" do
         visit debates_path
 
         click_link "map"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -112,6 +112,47 @@ feature 'Proposals' do
       end
       Setting['feature.allow_images'] = nil
     end
+
+    context "Map and links of geozones" do
+
+      after do
+        Setting['feature.geozones.proposals.maps'] = true
+        Setting['feature.geozones.proposals.links'] = true
+      end
+
+      scenario "Both are shown" do
+        visit proposals_path
+
+        expect(page).to have_selector('a#map')
+        expect(page).to have_selector('ul#geozones')
+      end
+
+      scenario "Map is shown" do
+        Setting['feature.geozones.proposals.links'] = nil
+        visit proposals_path
+
+        expect(page).to have_selector('a#map')
+        expect(page).not_to have_selector('ul#geozones')
+      end
+
+      scenario "Links are shown" do
+        Setting['feature.geozones.proposals.maps'] = nil
+        visit proposals_path
+
+        expect(page).not_to have_selector('a#map')
+        expect(page).to have_selector('ul#geozones')
+      end
+
+      scenario "Neither map nor links are shown" do
+        Setting['feature.geozones.proposals.maps'] = nil
+        Setting['feature.geozones.proposals.links'] = nil
+        visit proposals_path
+
+        expect(page).not_to have_selector('a#map')
+        expect(page).not_to have_selector('ul#geozones')
+      end
+
+    end
   end
 
   scenario 'Show' do


### PR DESCRIPTION
References
==========
**Related issue:** #2602

Objectives
==========
Add settings to admins so that they can select what can be seen in the geozones section of the debates and proposals sidebars. For both models, admins can choose between maps, links, both or none, activating or deactivating the corresponding features.

I created the `shared/_geozones.html.erb` partial to be able to share the same view between proposals and debates (and with others, in case this is added to another index). I also added some functions to `GeozonesHelper` to use in that partial.

I also change the `shared/_map.html.erb` partial so that it can be used with both proposals and debates (and others, if it is added to other indexes).

Visual Changes (if any)
=======================
### Admin settings view
![admin](https://user-images.githubusercontent.com/31625251/39811408-dcc7cc00-5388-11e8-9613-704471803fb9.png)

### Map and links in debates
![debates](https://user-images.githubusercontent.com/31625251/39811438-ff0c2504-5388-11e8-951e-9732870778c8.png)

### Maps and links together
![map_links](https://user-images.githubusercontent.com/31625251/39811450-083ee530-5389-11e8-84a1-c73773f5241f.png)

### Only map (the same as now)
![only_map](https://user-images.githubusercontent.com/31625251/39811465-14806b20-5389-11e8-8079-7b558850e21d.png)

### Only links
![only_links](https://user-images.githubusercontent.com/31625251/39811473-1b8688dc-5389-11e8-8f0f-23146c7d60f4.png)

### Neither map nor links
![nothing](https://user-images.githubusercontent.com/31625251/39812285-4d9d70b2-538c-11e8-922c-f42fa8443100.png)

Notes
=====================
:warning: Run rake task `rake settings:create_geozones_maps_links` to create the settings to enable/disable the features.