### PR TITLE
Budgets see results

### DIFF
--- a/app/views/admin/budget_investments/index.html.erb
+++ b/app/views/admin/budget_investments/index.html.erb
@@ -1,3 +1,9 @@
+<div class="float-right">
+  <%= link_to t("admin.budget_investments.index.see_results"),
+              budget_results_path(current_budget, heading_id: current_budget.headings.first),
+              class: "button hollow medium", target: "_blank" %>
+</div>
+
 <h2 class="inline-block"><%= @budget.name %> - <%= t("admin.budget_investments.index.title") %></h2>
 
 <%= render "search_form" %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -49,7 +49,7 @@
           <% end %>
 
 
-        <% if current_budget.finished? || (current_budget.balloting? && can?(:read_results, current_budget)) %>
+        <% if current_budget.finished? %>
           <%= link_to t("budgets.show.see_results"),
                       budget_results_path(current_budget, heading_id: current_budget.headings.first),
                       class: "button margin-top expanded" %>
@@ -138,7 +138,7 @@
                       </div>
                     </div>
                   </div>
-                  
+
                   <div class="small-12 medium-3 column table" data-equalizer-watch>
                     <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
                       <% if budget.name == "Presupuestos Participativos 2016" %>

--- a/app/views/custom/admin/budget_investments/index.html.erb
+++ b/app/views/custom/admin/budget_investments/index.html.erb
@@ -1,0 +1,14 @@
+<div class="float-right">
+  <%= link_to t("admin.budget_investments.index.see_results"),
+              custom_budget_results_path(current_budget),
+              class: "button hollow medium", target: "_blank" %>
+</div>
+
+<h2 class="inline-block"><%= @budget.name %> - <%= t("admin.budget_investments.index.title") %></h2>
+
+<%= render "search_form" %>
+<%= render "/shared/filter_subnav", i18n_namespace: "admin.budget_investments.index" %>
+
+<div id="investments">
+  <%= render "investments" %>
+</div>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 
   <% provide :tracking_page_number, "33" %>
-  
+
   <div id="budget_heading" class="expanded budget budget-header no-margin-top">
     <div class="row" data-equalizer data-equalizer-on="medium">
       <div class="small-12 medium-9 column padding" data-equalizer-watch>
@@ -62,9 +62,9 @@
           <% end %>
 
 
-        <% if current_budget.finished? || (current_budget.balloting? && can?(:read_results, current_budget)) %>
+        <% if current_budget.finished? %>
           <%= link_to t("budgets.show.see_results"),
-                      budget_results_path(current_budget, heading_id: current_budget.headings.first),
+                      custom_budget_results_path(current_budget),
                       class: "button margin-top expanded" %>
         <% end %>
       </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -207,6 +207,7 @@ en:
         table_selection: "Selected"
         table_evaluation: "Show to valuators"
         table_incompatible: "Incompatible"
+        see_results: "See results"
       show:
         assigned_admin: Assigned administrator
         assigned_valuators: Assigned valuators

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -207,6 +207,7 @@ es:
         table_selection: "Seleccionado"
         table_evaluation: "Mostrar a evaluadores"
         table_incompatible: "Incompatible"
+        see_results: "Ver resultados"
       show:
         assigned_admin: Administrador asignado
         assigned_valuators: Evaluadores asignados


### PR DESCRIPTION
Objectives
==========
Shows **See results** button _[Screenshot_1]_ only if current budget is finished. 

Also included this button on admin panel `/admin/budgets/N/budget_investments`. _[Screenshot_2]_

Visual Changes
=======================
**[Screenshot_1]**
![screen shot 2018-05-09 at 16 06 15](https://user-images.githubusercontent.com/631897/39819140-f9e7cc9e-53a2-11e8-800c-43d8320d93ec.png)


**[Screenshot_2]**
![screen shot 2018-05-09 at 16 05 44](https://user-images.githubusercontent.com/631897/39819147-fb59561a-53a2-11e8-9016-914fadba868b.png)

Notes
=====================
Backport this to CONSUL repo (don't include commits of `custom` views)

