### PR TITLE
Content translatable UI

### DIFF
--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -14,12 +14,12 @@ App.Globalize =
         $(this).show()
       else
         $(this).hide()
-      $('.delete-language').hide()
+      $('.js-delete-language').hide()
       $('#delete-' + locale).show()
 
   highlight_locale: (element) ->
-    $('.js-globalize-locale-link').removeClass('highlight');
-    element.addClass('highlight');
+    $('.js-globalize-locale-link').removeClass('is-active');
+    element.addClass('is-active');
 
   remove_language: (locale) ->
     $(".js-globalize-attribute[data-locale=" + locale + "]").val('').hide()
@@ -39,7 +39,7 @@ App.Globalize =
       App.Globalize.display_translations(locale)
       App.Globalize.highlight_locale($(this))
 
-    $('.delete-language').on 'click', ->
+    $('.js-delete-language').on 'click', ->
       locale = $(this).data("locale")
       $(this).hide()
       App.Globalize.remove_language(locale)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -19,7 +19,7 @@ module GlobalizeHelper
   end
 
   def highlight_current?(locale)
-    same_locale?(I18n.locale, locale) ? 'highlight' : ''
+    same_locale?(I18n.locale, locale) ? 'is-active' : ''
   end
 
   def show_delete?(locale)

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -1,21 +1,18 @@
-<div>
-  <%= render "globalize_locales" %>
-</div>
+<%= render "globalize_locales" %>
 
 <%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
 
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime),
                              maxlength: Budget::Investment::Milestone.title_max_length %>
 
-  <div class="row">
-    <div class="small-12 medium-6 margin-bottom">
-      <%= f.select :status_id,
-            @statuses.collect { |s| [s.name, s.id] },
-            { include_blank: @statuses.any? ? '' : t('admin.milestones.form.no_statuses_defined') },
-            { disabled: @statuses.blank? } %>
-      <%= link_to t('admin.milestones.form.admin_statuses'),
-                  admin_budget_investment_statuses_path %>
-    </div>
+
+  <div class="small-12 medium-6 margin-bottom">
+    <%= f.select :status_id,
+          @statuses.collect { |s| [s.name, s.id] },
+          { include_blank: @statuses.any? ? '' : t('admin.milestones.form.no_statuses_defined') },
+          { disabled: @statuses.blank? } %>
+    <%= link_to t('admin.milestones.form.admin_statuses'),
+                admin_budget_investment_statuses_path %>
   </div>
 
   <%= f.label :description, t("admin.milestones.new.description") %>

--- a/app/views/admin/budget_investment_milestones/_globalize_locales.html.erb
+++ b/app/views/admin/budget_investment_milestones/_globalize_locales.html.erb
@@ -1,19 +1,27 @@
 <% I18n.available_locales.each do |locale| %>
-  <span>
-    <%= link_to name_for_locale(locale), "#",
-                style: css_to_display_translation?(@milestone, locale),
-                class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                data: { locale: neutral_locale(locale) },
-                remote: true %>
-    <%= link_to t("admin.milestones.form.remove_language"), "#",
-                id: "delete-#{neutral_locale(locale)}",
-                style: show_delete?(locale),
-                class: 'float-right delete-language',
-                data: { locale: neutral_locale(locale) } %>
-  </span>
+  <%= link_to t("admin.milestones.form.remove_language"), "#",
+              id: "delete-#{neutral_locale(locale)}",
+              style: show_delete?(locale),
+              class: 'float-right delete js-delete-language',
+              data: { locale: neutral_locale(locale) } %>
+
 <% end %>
 
-<%= select_tag :translation_locale,
-               options_for_locale_select,
-               prompt: t("admin.milestones.form.add_language"),
-               class: "js-globalize-locale" %>
+<ul class="tabs" data-tabs id="globalize_locale">
+  <% I18n.available_locales.each do |locale| %>
+    <li class="tabs-title">
+      <%= link_to name_for_locale(locale), "#",
+                  style: css_to_display_translation?(@milestone, locale),
+                  class: "js-globalize-locale-link #{highlight_current?(locale)}",
+                  data: { locale: neutral_locale(locale) },
+                  remote: true %>
+    </li>
+  <% end %>
+</ul>
+
+<div class="small-12 medium-6">
+  <%= select_tag :translation_locale,
+                 options_for_locale_select,
+                 prompt: t("admin.milestones.form.add_language"),
+                 class: "js-globalize-locale" %>
+</div>

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -76,21 +76,21 @@ feature "Translations" do
       scenario "Highlight current locale", :js do
         visit @edit_milestone_url
 
-        expect(find("span .js-globalize-locale-link.highlight")).to have_content "English"
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "English"
 
         select('Español', from: 'locale-switcher')
 
-        expect(find("span .js-globalize-locale-link.highlight")).to have_content "Español"
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "Español"
       end
 
       scenario "Highlight selected locale", :js do
         visit @edit_milestone_url
 
-        expect(find("span .js-globalize-locale-link.highlight")).to have_content "English"
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "English"
 
         click_link "Español"
 
-        expect(find("span .js-globalize-locale-link.highlight")).to have_content "Español"
+        expect(find("a.js-globalize-locale-link.is-active")).to have_content "Español"
       end
 
       scenario "Show selected locale form", :js do


### PR DESCRIPTION
Objectives
==========

Improves admin content translatable UI with some minor changes to maintain consistency with the Admin Panel styles.

Visual Changes
=======================
**BEFORE**
![before](https://user-images.githubusercontent.com/631897/39822200-4a9ff84e-53aa-11e8-867d-b39f5bc7d22b.png)

**AFTER**
![after](https://user-images.githubusercontent.com/631897/39822206-4c581202-53aa-11e8-801b-37cbfde40319.png)

Notes
=====================
Backport this to CONSUL repo.
