### PR TITLE
Fix redirect after milestone creation

### DIFF
--- a/app/controllers/admin/budget_investment_milestones_controller.rb
+++ b/app/controllers/admin/budget_investment_milestones_controller.rb
@@ -16,7 +16,8 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
     @milestone = Budget::Investment::Milestone.new(milestone_params)
     @milestone.investment = @investment
     if @milestone.save
-      redirect_to admin_budget_budget_investment_path(@investment.budget, @investment),
+      investment_id = @investment.original_spending_proposal_id || @investment.id
+      redirect_to admin_budget_budget_investment_path(budget_id: @investment.budget, id: investment_id),
                   notice: t('admin.milestones.create.notice')
     else
       render :new


### PR DESCRIPTION
Objectives
==========
Redirect to correct investment after creating a milestone

Notes
=====================
This is a hotfix to solve an incorrect redirect that stems from a bigger problem related to the migration of spending proposals to budget investments

We should review this PR and other related ones to make a solid and elegant solution to maintain the existing spending proposal urls and make them work harmoniously with the new budget investment urls, both in admin sections and user facing sections
