### PR TITLE
Moderate pending proposal system emails

### DIFF
--- a/app/controllers/admin/activity_controller.rb
+++ b/app/controllers/admin/activity_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ActivityController < Admin::BaseController
-  has_filters %w{all on_users on_proposals on_debates on_comments}
+  has_filters %w{all on_users on_proposals on_debates on_comments on_system_emails}
 
   def show
     @activity = Activity.for_render.send(@current_filter)

--- a/app/controllers/admin/system_emails_controller.rb
+++ b/app/controllers/admin/system_emails_controller.rb
@@ -1,6 +1,6 @@
 class Admin::SystemEmailsController < Admin::BaseController
 
-  before_action :load_system_email, only: [:view, :preview_pending]
+  before_action :load_system_email, only: [:view, :preview_pending, :moderate_pending]
 
   def index
     @system_emails = {
@@ -22,6 +22,12 @@ class Admin::SystemEmailsController < Admin::BaseController
       @previews = ProposalNotification.where(id: unsent_proposal_notifications_ids)
                                       .page(params[:page])
     end
+  end
+
+  def moderate_pending
+    ProposalNotification.find(params[:id]).moderate_system_email(current_user)
+
+    redirect_to admin_system_email_preview_pending_path("proposal_notification_digest")
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -11,6 +11,7 @@ class Activity < ActiveRecord::Base
   scope :on_users, -> { where(actionable_type: 'User') }
   scope :on_comments, -> { where(actionable_type: 'Comment') }
   scope :on_budget_investments, -> { where(actionable_type: 'Budget::Investment') }
+  scope :on_system_emails, -> { where(actionable_type: 'ProposalNotification') }
   scope :for_render, -> { includes(user: [:moderator, :administrator]).includes(:actionable) }
 
   def self.log(user, action, actionable)

--- a/app/models/proposal_notification.rb
+++ b/app/models/proposal_notification.rb
@@ -10,6 +10,7 @@ class ProposalNotification < ActiveRecord::Base
   validates :proposal, presence: true
   validate :minimum_interval
 
+  scope :with_hidden, -> { all }
   scope :public_for_api, -> { where(proposal_id: Proposal.public_for_api.pluck(:id)) }
 
   def minimum_interval

--- a/app/models/proposal_notification.rb
+++ b/app/models/proposal_notification.rb
@@ -39,4 +39,9 @@ class ProposalNotification < ActiveRecord::Base
     proposal
   end
 
+  def moderate_system_email(moderator)
+    Notification.where(notifiable_type: 'ProposalNotification', notifiable: self).destroy_all
+    Activity.log(moderator, :hide, self)
+  end
+
 end

--- a/app/views/admin/activity/show.html.erb
+++ b/app/views/admin/activity/show.html.erb
@@ -37,7 +37,11 @@
               <strong><%= activity.actionable.title %></strong>
               <br>
               <div class="proposal-description">
-                <%= activity.actionable.description %>
+                <% if activity.actionable.respond_to?(:description) %>
+                  <%= activity.actionable.description %>
+                <% elsif activity.actionable.respond_to?(:body) %>
+                  <%= activity.actionable.body %>
+                <% end %>
               </div>
             <% end %>
           <td class="align-top">

--- a/app/views/admin/system_emails/preview_pending/_proposal_notification_digest.html.erb
+++ b/app/views/admin/system_emails/preview_pending/_proposal_notification_digest.html.erb
@@ -1,33 +1,40 @@
 <% if preview.proposal.present? %>
-  <div class="callout highlight">
-    <div class="row">
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.shared.proposal") %></strong><br>
-        <%= link_to preview.proposal.title, proposal_url(preview.proposal) %>
-      </div>
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.shared.title") %></strong><br>
-        <%= link_to preview.title, proposal_url(preview.proposal, anchor: "tab-notifications") %>
+  <div id="<%= dom_id(preview) %>">
+    <div class="callout highlight">
+      <div class="row expanded">
+        <div class="small-12 medium-6 column">
+          <strong><%= t("admin.shared.proposal") %></strong><br>
+          <%= link_to preview.proposal.title, proposal_url(preview.proposal) %>
+        </div>
+        <div class="small-12 medium-6 column">
+          <strong><%= t("admin.shared.title") %></strong><br>
+          <%= link_to preview.title, proposal_url(preview.proposal, anchor: "tab-notifications") %>
+        </div>
+        <div class="small-12 medium-6 column">
+          <strong><%= t("admin.shared.author") %></strong><br>
+          <%= preview.proposal.author&.username || '-' %>
+        </div>
+        <div class="small-12 medium-6 column">
+          <strong><%= t("admin.shared.created_at") %></strong><br>
+          <%= l(preview.created_at, format: :datetime) %>
+        </div>
       </div>
     </div>
-    <div class="row">
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.shared.author") %></strong><br>
-        <%= preview.proposal.author&.username || '-' %>
-      </div>
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.shared.created_at") %></strong><br>
-        <%= l(preview.created_at, format: :datetime) %>
-      </div>
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="column">
-      <strong><%= t("admin.shared.content") %></strong>
-      <p class="help-text" id="phase-description-help-text">
-        <%= preview.body %>
-      </p>
+    <div class="row">
+      <div class="column">
+        <strong><%= t("admin.shared.content") %></strong>
+        <p id="phase-description-help-text">
+          <%= preview.body %>
+        </p>
+      </div>
     </div>
+
+    <%= link_to t("admin.system_emails.preview_pending.moderate_pending"),
+          admin_system_email_moderate_pending_path(system_email_id: 'proposal_notification_digest',
+          id: preview.id),
+          method: :put,
+          class: "button hollow float-right" %>
   </div>
+  <hr>
 <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -660,6 +660,7 @@ en:
         action: Preview Pending
         preview_of: Preview of %{name}
         pending_to_be_sent: This is the content pending to be sent
+        moderate_pending: Moderate notification send
       proposal_notification_digest:
         title: Proposal Notification Digest
         description: Gathers all proposal notifications for an user in a single message, to avoid too much emails.

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -62,6 +62,7 @@ en:
           on_debates: Debates
           on_proposals: Proposals
           on_users: Users
+          on_system_emails: System emails
         title: Moderator activity
         type: Type
         no_activity: There ares no moderators activity.

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -62,6 +62,7 @@ es:
           on_debates: Debates
           on_proposals: Propuestas
           on_users: Usuarios
+          on_system_emails: Emails del sistema
         title: Actividad de los Moderadores
         type: Tipo
         no_activity: No hay actividad de moderadores.

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -660,6 +660,7 @@ es:
         action: Previsualizar Pendientes
         preview_of: Vista previa de %{name}
         pending_to_be_sent: Este es todo el contenido pendiente de enviar
+        moderate_pending: Moderar envío de notificación
       proposal_notification_digest:
         title: Resumen de Notificationes de Propuestas
         description: Reune todas las notificaciones de propuestas en un único mensaje, para evitar demasiados emails.

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -167,6 +167,7 @@ namespace :admin do
   resources :system_emails, only: [:index] do
     get :view
     get :preview_pending
+    put :moderate_pending
   end
 
   resources :emails_download, only: :index do

--- a/spec/features/admin/activity_spec.rb
+++ b/spec/features/admin/activity_spec.rb
@@ -331,4 +331,22 @@ feature 'Admin activity' do
     end
   end
 
+  context "System emails" do
+    scenario "Shows moderation activity on system emails" do
+      proposal = create(:proposal, title: 'Proposal A')
+      proposal_notification = create(:proposal_notification, proposal: proposal,
+                                                               title: 'Proposal A Title',
+                                                               body: 'Proposal A Notification Body')
+      proposal_notification.moderate_system_email(@admin.user)
+
+      visit admin_activity_path
+
+      within("#activity_#{Activity.last.id}") do
+        expect(page).to have_content(proposal_notification.title)
+        expect(page).to have_content("Hidden")
+        expect(page).to have_content(@admin.user.username)
+      end
+    end
+  end
+
 end

--- a/spec/features/admin/system_emails_spec.rb
+++ b/spec/features/admin/system_emails_spec.rb
@@ -65,6 +65,29 @@ feature "System Emails" do
       expect(page).to have_link('Proposal B Title', href: proposal_url(proposal_b,
                                                     anchor: 'tab-notifications'))
     end
+
+    scenario "#moderate_pending" do
+      proposal1 = create(:proposal, title: 'Proposal A')
+      proposal2 = create(:proposal, title: 'Proposal B')
+      proposal_notification1 = create(:proposal_notification, proposal: proposal1,
+                                                               title: 'Proposal A Title',
+                                                               body: 'Proposal A Notification Body')
+      proposal_notification2 = create(:proposal_notification, proposal: proposal2)
+      create(:notification, notifiable: proposal_notification1, emailed_at: nil)
+      create(:notification, notifiable: proposal_notification2, emailed_at: nil)
+
+      visit admin_system_email_preview_pending_path('proposal_notification_digest')
+
+      within("#proposal_notification_#{proposal_notification1.id}") do
+        click_on "Moderate notification send"
+      end
+
+      visit admin_system_email_preview_pending_path('proposal_notification_digest')
+
+      expect(Notification.count).to equal(1)
+      expect(Activity.last.actionable_type).to eq('ProposalNotification')
+      expect(page).not_to have_content("Proposal A Title")
+    end
   end
 
 end

--- a/spec/features/emails_spec.rb
+++ b/spec/features/emails_spec.rb
@@ -336,6 +336,23 @@ feature 'Emails' do
       expect(notification2.emailed_at).to be
     end
 
+    scenario "notifications moderated are not sent" do
+      user = create(:user, email_digest: true)
+      proposal = create(:proposal)
+      proposal_notification = create(:proposal_notification, proposal: proposal)
+      notification = create(:notification, notifiable: proposal_notification)
+
+      reset_mailer
+
+      proposal_notification.moderate_system_email(create(:administrator).user)
+
+      email_digest = EmailDigest.new(user)
+      email_digest.deliver
+      email_digest.mark_as_emailed
+
+      expect { open_last_email }.to raise_error "No email has been sent!"
+    end
+
     xscenario "Delete all Notifications included in the digest after email sent" do
     end
 

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -152,5 +152,21 @@ describe ProposalNotification do
 
     end
 
+    describe "#moderate_system_email" do
+      let(:admin) { create(:administrator) }
+      let(:proposal) { create(:proposal) }
+      let(:proposal_notification) { build(:proposal_notification, proposal: proposal) }
+      let(:notification) { create(:notification, notifiable: proposal_notification) }
+
+      it "removes all notifications related to the proposal notification" do
+        proposal_notification.moderate_system_email(admin.user)
+        expect(Notification.all.count).to be(0)
+      end
+
+      it "records the moderation action in the Activity table" do
+        proposal_notification.moderate_system_email(admin.user)
+        expect(Activity.last.actionable_type).to eq('ProposalNotification')
+      end
+    end
   end
 end


### PR DESCRIPTION
References
==========
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1468

Objectives
==========
- Add moderation abilities for Proposal Notifications.
- Add new tab "System emails" in the Moderation section `/admin/activity`.

Screen shots
==========
<img width="1027" alt="screen shot 2018-05-16 at 10 13 33" src="https://user-images.githubusercontent.com/2141690/40104939-de12f8b4-58f1-11e8-9371-b78d2dd818d7.png">
<img width="1054" alt="screen shot 2018-05-16 at 10 14 20" src="https://user-images.githubusercontent.com/2141690/40104960-ef07b7ea-58f1-11e8-917d-c745742a4051.png">

