### PR TITLE
Removes permissions for admins to access unfinished budget results

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -59,7 +59,7 @@ module Abilities
       end
 
       can [:read, :valuate, :summary], SpendingProposal
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners, :read_results], Budget
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :update, :toggle_selection], Budget::Investment

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -41,7 +41,7 @@
         <% end %>
       <% end %>
 
-      <% if @budget.finished? || (@budget.balloting? && can?(:read_results, @budget)) %>
+      <% if @budget.finished? %>
         <%= link_to t("budgets.show.see_results"),
                   custom_budget_results_path(@budget),
                   class: "button margin-top expanded" %>

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -306,6 +306,38 @@ feature 'Budgets' do
       expect(page).to_not have_css("#budget_heading_#{heading4.id}")
     end
 
+    scenario "See results button is showed if the budget has finished for all users" do
+      user = create(:user)
+      admin = create(:administrator)
+      budget = create(:budget, :finished)
+
+      login_as(user)
+      visit budget_path(budget)
+      expect(page).to have_link "See results"
+
+      logout
+
+      login_as(admin.user)
+      visit budget_path(budget)
+      expect(page).to have_link "See results"
+    end
+
+    scenario "See results button isn't showed if the budget hasn't finished for all users" do
+      user = create(:user)
+      admin = create(:administrator)
+      budget = create(:budget, :balloting)
+
+      login_as(user)
+      visit budget_path(budget)
+      expect(page).not_to have_link "See results"
+
+      logout
+
+      login_as(admin.user)
+      visit budget_path(budget)
+      expect(page).not_to have_link "See results"
+    end
+
   end
 
   context "In Drafting phase" do


### PR DESCRIPTION
References
==========
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1474

Objectives
==========
Remove button 'See results' from budgets `#show` action view for all users unless the budget is finished.
