### PR TITLE
Admin form improvements

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -60,7 +60,6 @@ class Admin::Legislation::ProcessesController < Admin::Legislation::BaseControll
         :draft_publication_enabled,
         :result_publication_enabled,
         :published,
-        :proposals_description,
         :custom_list,
         documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
       )

--- a/app/controllers/admin/poll/booth_assignments_controller.rb
+++ b/app/controllers/admin/poll/booth_assignments_controller.rb
@@ -55,7 +55,7 @@ class Admin::Poll::BoothAssignmentsController < Admin::Poll::BaseController
   end
 
   def manage
-    @booths = ::Poll::Booth.all
+    @booths = ::Poll::Booth.all.order(name: :asc).page(params[:page]).per(300)
     @poll = Poll.find(params[:poll_id])
   end
 

--- a/app/controllers/admin/poll/questions_controller.rb
+++ b/app/controllers/admin/poll/questions_controller.rb
@@ -55,7 +55,7 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
   private
 
     def question_params
-      params.require(:poll_question).permit(:poll_id, :title, :question, :proposal_id, :video_url)
+      params.require(:poll_question).permit(:poll_id, :title, :question, :proposal_id)
     end
 
     def search_params

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -4,7 +4,7 @@
 
   <div class="row margin-top">
     <div class="small-12 medium-9 column">
-      <%= f.select :phase, budget_phases_select_options %>
+      <%= f.select :phase, budget_phases_select_options, selected: "drafting" %>
     </div>
     <div class="small-12 medium-3 column">
       <%= f.select :currency_symbol, budget_currency_symbol_select_options %>

--- a/app/views/admin/legislation/proposals/_form.html.erb
+++ b/app/views/admin/legislation/proposals/_form.html.erb
@@ -17,19 +17,6 @@
 
   <div class="row">
     <div class="small-12 medium-4 column">
-      <%= label_tag t('admin.legislation.proposals.form.header_information') %>
-      <small><%= t('admin.legislation.proposals.form.header_information_description') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :proposals_description,
-                       label: false,
-                       rows: 5,
-                       placeholder: t('admin.legislation.proposals.form.header_information_placeholder') %>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="small-12 medium-4 column">
       <%= label_tag t('admin.legislation.proposals.form.custom_categories') %>
       <small><%= t('admin.legislation.proposals.form.custom_categories_description') %></small>
     </div>

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -25,4 +25,6 @@
     <% end %>
     </tbody>
   </table>
+
+  <%= paginate @booths %>
 <% end %>

--- a/app/views/admin/poll/booths/_form.html.erb
+++ b/app/views/admin/poll/booths/_form.html.erb
@@ -12,9 +12,13 @@
   </div>
 
   <div class="small-12 column">
-    <%= f.check_box :physical,
-                     placeholder: t("admin.booths.new.physical"),
-                     label:       t("admin.booths.new.physical") %>
+    <%= f.select :physical, {} do %>
+      <%= options_for_select({
+          t("admin.booths.new.physical") => true,
+          t("admin.booths.new.digital")  => false
+        }, @booth.physical)
+      %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -55,17 +55,6 @@
     </div>
   </div>
 
-  <% if controller_name == "polls" && action_name == "edit" %>
-    <div class="row">
-      <fieldset class="fieldset">
-        <legend><%= t('admin.polls.new.show_results_and_stats') %></legend>
-        <%= f.check_box :results_enabled, checked: @poll.results_enabled?, label: t('admin.polls.new.show_results') %>
-        <%= f.check_box :stats_enabled, checked: @poll.stats_enabled?, label: t('admin.polls.new.show_stats') %>
-        <p class="small"><%= t('admin.polls.new.results_and_stats_reminder') %></p>
-      </fieldset>
-    </div>
-  <% end %>
-
   <div class="row">
     <div class="small-12 medium-4 column">
       <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),

--- a/app/views/admin/poll/questions/_form.html.erb
+++ b/app/views/admin/poll/questions/_form.html.erb
@@ -14,19 +14,6 @@
 
     <%= f.text_field :title %>
 
-    <div class="small-12">
-      <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
-
-      <p class="help-text" id="video-url-help-text">
-        <%= t("proposals.form.proposal_video_url_note") %>
-      </p>
-
-      <%= f.text_field :video_url,
-                        placeholder: t("proposals.form.proposal_video_url"),
-                        label: false,
-                        aria: {describedby: "video-url-help-text"} %>
-    </div>
-
     <div class="small-12 medium-6 large-4 margin-top">
       <%= f.submit(class: "button expanded", value: t("shared.save")) %>
     </div>

--- a/app/views/admin/poll/results/_show_results.html.erb
+++ b/app/views/admin/poll/results/_show_results.html.erb
@@ -1,0 +1,17 @@
+<%= form_for [:admin, @poll], action: "update" do |f| %>
+  <div class="row">
+    <fieldset class="fieldset">
+      <legend><%= t("admin.polls.new.show_results_and_stats") %></legend>
+      <%= f.check_box :results_enabled, checked: @poll.results_enabled?, label: t("admin.polls.new.show_results") %>
+      <%= f.check_box :stats_enabled, checked: @poll.stats_enabled?, label: t("admin.polls.new.show_stats") %>
+      <p class="small"><%= t("admin.polls.new.results_and_stats_reminder") %></p>
+    </fieldset>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-4 column">
+      <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),
+                   class: "button success expanded" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -1,4 +1,5 @@
 <%= render "/admin/poll/polls/poll_header" %>
+
 <div id="poll-resources">
   <%= render "/admin/poll/polls/subnav" %>
 
@@ -12,5 +13,6 @@
     <%= render "recount", resource: @poll %>
     <%= render "result" %>
     <%= render "results_by_booth" %>
+    <%= render "show_results", resource: @poll %>
   <% end %>
 </div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -238,6 +238,8 @@ en:
       image:
         title: Title
         attachment: Attachment
+      poll/booth:
+        physical: Booth kind
       poll/question/answer:
         title: Answer
         description: Description

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -944,6 +944,7 @@ en:
         name: "Name"
         location: "Location"
         physical: "Physical booth"
+        digital: "Digital booth"
         submit_button: "Create booth"
       edit:
         title: "Edit booth"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -416,9 +416,6 @@ en:
           title: Proposals
           back: Back
         form:
-          header_information: Information header
-          header_information_description: Provide information about the proposals. This text will be displayed as an alert in the Proposals section inside this Process. Use Markdown to format the text.
-          header_information_placeholder: Add information for the proposals' header
           custom_categories: Categories
           custom_categories_description: Categories that users can select creating the proposal.
       draft_versions:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -238,6 +238,8 @@ es:
       image:
         title: Título
         attachment: Archivo adjunto
+      poll/booth:
+        physical: Tipo de urna
       poll/question/answer:
         title: Respuesta
         description: Descripción

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -944,6 +944,7 @@ es:
         name: "Nombre"
         location: "Ubicación"
         physical: "Urna física"
+        digital: "Urna digital"
         submit_button: "Crear urna"
       edit:
         title: "Editar urna"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -416,9 +416,6 @@ es:
           title: Propuestas
           back: Volver
         form:
-          header_information: Encabezado de información
-          header_information_description: Proporciona información sobre el recorrido de las propuestas. Este texto se mostrará como una alerta en el encabezado de la sección de Propuestas dentro de este proceso. Usa Markdown para formatear el texto.
-          header_information_placeholder: Añade información para el encabezado de las las propuestas
           custom_categories: Categorías
           custom_categories_description: Categorías que el usuario puede seleccionar al crear la propuesta.
       draft_versions:

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -4,7 +4,6 @@ section "Creating legislation processes" do
                                  description: Faker::Lorem.paragraphs.join("\n\n"),
                                  summary: Faker::Lorem.paragraph,
                                  additional_info: Faker::Lorem.paragraphs.join("\n\n"),
-                                 proposals_description: Faker::Lorem.paragraph,
                                  start_date: Date.current - 3.days,
                                  end_date: Date.current + 3.days,
                                  debate_start_date: Date.current - 3.days,

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -142,8 +142,8 @@ feature 'Admin booths' do
 
       visit edit_admin_booth_path(Poll::Booth.last)
 
-      physical_booth = find('#poll_booth_physical')
-      expect(physical_booth).to be_checked
+      booth_kind = find('#poll_booth_physical')
+      expect(booth_kind.value).to eq('true')
     end
 
     scenario "Choose digital booth instead of physical booth" do
@@ -152,7 +152,7 @@ feature 'Admin booths' do
 
       fill_in "poll_booth_name", with: "Upcoming booth"
       fill_in "poll_booth_location", with: "39th Street, number 2, ground floor"
-      uncheck "poll_booth_physical"
+      select 'Digital booth', from: 'poll_booth_physical'
 
       click_button "Create booth"
 
@@ -160,8 +160,8 @@ feature 'Admin booths' do
 
       visit edit_admin_booth_path(Poll::Booth.last)
 
-      physical_booth = find('#poll_booth_physical')
-      expect(physical_booth).not_to be_checked
+      booth_kind = find('#poll_booth_physical')
+      expect(booth_kind.value).to eq('false')
     end
 
   end

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -36,19 +36,16 @@ feature 'Admin poll questions' do
       Pursued by the Empire's sinister agents, Princess Leia races home aboard her starship, custodian of the stolen plans that can save her
        people and restore freedom to the galaxy....
     }
-    video_url = "https://puppyvideos.com"
 
     visit admin_questions_path
     click_link "Create question"
 
     select 'Movies', from: 'poll_question_poll_id'
     fill_in 'poll_question_title', with: title
-    fill_in 'poll_question_video_url', with: video_url
 
     click_button 'Save'
 
     expect(page).to have_content(title)
-    expect(page).to have_content(video_url)
   end
 
   scenario 'Create from successful proposal index' do


### PR DESCRIPTION
References
===================
* Related issue: #2624

Objectives
===================
* Move 'Show stats and results' form to `Admin::Poll#results` tab (commit [`f194e66`](https://github.com/AyuntamientoMadrid/consul/commit/f194e66972c739196af96d1737732333e193e003))

* Remove `video_url` attribute from `Admin::Poll::Question` form (commit [`37c1c62`](https://github.com/AyuntamientoMadrid/consul/commit/37c1c625683ea04153fe526297721d298361a307))

* Use 'drafting' as default value when creating a new budget (commit [`c63a671`](https://github.com/AyuntamientoMadrid/consul/commit/c63a67102797e8a69814735fc0110d478a4ab2cb))

* Use dropdown when selecting booth type instead of checkbox (commit [`c987e20`](https://github.com/AyuntamientoMadrid/consul/commit/c987e203e9e32b196763454611371101c83e6b39))

* Remove `proposals_description` attribute from `Admin::Legislation::Processes` module (commit [`3ab883f`](https://github.com/AyuntamientoMadrid/consul/commit/3ab883fe07939403f177edf456d6966ba35da196))

* Sort booths by name and enable pagination (commit [`b4536b6`](https://github.com/AyuntamientoMadrid/consul/commit/b4536b69d612d05d499b109096d82503bf0f6a2a))

Visual Changes
===================
Here are several screenshots (ordered as described above) to demonstrate how the proposed changes affect the UI

## First commit

![screenshot_2018-05-22_08-18-54](https://user-images.githubusercontent.com/9470839/40362070-7ce24c78-5d99-11e8-8560-455b21a6a76b.png)

## Second commit

![screenshot_2018-05-22_08-19-50](https://user-images.githubusercontent.com/9470839/40362190-d1d1d2c6-5d99-11e8-913b-3cbc3ca0c3ac.png)

## Third commit

![screenshot_2018-05-22_08-20-35](https://user-images.githubusercontent.com/9470839/40362205-d8027d8a-5d99-11e8-80d6-c3fa97fcda7c.png)

## Fourth commit

![screenshot_2018-05-22_08-21-29](https://user-images.githubusercontent.com/9470839/40362208-dada1d9c-5d99-11e8-8be1-b83c6a1bfafc.png)

## Fifth commit

![screenshot_2018-05-22_08-22-06](https://user-images.githubusercontent.com/9470839/40362267-0cada1e0-5d9a-11e8-8d93-87dcbb36bc95.png)

## Sixth commit

![screenshot_2018-05-22_08-23-13](https://user-images.githubusercontent.com/9470839/40362278-145fe326-5d9a-11e8-8720-3d9b6cf710ff.png)

Notes
===================
*  :warning: The `video_url` attribute for the `poll_questions` table is getting deprecated in upcoming CONSUL releases :warning:

* :warning: The `proposals_description` attribute from the `legislation_processes` table is getting deprecated as well in upcoming CONSUL releases :warning:
