### PR TITLE
i18n clean

### DIFF
--- a/app/views/custom/shared/_top_links.html.erb
+++ b/app/views/custom/shared/_top_links.html.erb
@@ -1,0 +1,33 @@
+<ul class="no-bullet external-links">
+  <li>
+    <%= link_to t("layouts.header.external_link_transparency"),
+                setting['transparency_url'].presence || t("layouts.header.external_link_transparency_url"),
+                target: "_blank",
+                rel: "nofollow",
+                title: t("shared.go_to_page") + t("layouts.header.external_link_transparency") + t('shared.target_blank_html') %>
+  </li>
+  <li>
+    <%= link_to t("layouts.header.external_link_opendata"),
+                setting['opendata_url'].presence || t("layouts.header.external_link_opendata_url"),
+                target: "_blank",
+                rel: "nofollow",
+                title: t("shared.go_to_page") + t("layouts.header.external_link_opendata") + t('shared.target_blank_html') %>
+  </li>
+  <li class="show-for-medium">
+    <%= link_to t("layouts.header.forums"),
+                participation_forums_path,
+                title: t("shared.go_to_page") + t("layouts.header.forums") %>
+  </li>
+
+  <% if setting['blog_url'] %>
+    <li>
+      <%= link_to t("layouts.header.external_link_blog"),
+                  setting['blog_url'],
+                  target: "_blank",
+                  rel: "nofollow",
+                  title: t("shared.go_to_page") + t("layouts.header.external_link_blog") + t('shared.target_blank_html') %>
+    </li>
+  <% end %>
+
+  <%= raw content_block("top_links", I18n.locale) %>
+</ul>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -14,95 +14,78 @@
         <%= link_to t("layouts.footer.faq"), faq_path %>
       </p>
     </div>
-
-    <div class="footer-sections small-12 large-8 column">
-      <div class="small-12 medium-4 column">
-        <%= link_to t("layouts.footer.participation_title"), root_path, class: "title" %>
-        <p><%= t("layouts.footer.participation_text") %></p>
-      </div>
-
-      <div class="small-12 medium-4 column">
-        <%= link_to t("layouts.footer.transparency_title"), setting['transparency_url'].presence || t("layouts.footer.transparency_url"),
-                    target: "_blank", title: t('shared.target_blank_html'), class: "title" %>
-        <p><%= t("layouts.footer.transparency_text") %></p>
-      </div>
-
-      <div class="small-12 medium-4 column">
-        <%= link_to t("layouts.footer.open_data_title"), setting['opendata_url'].presence || t("layouts.header.external_link_opendata_url"),
-                    target: "_blank", title: t('shared.target_blank_html'), class: "title" %>
-        <p><%= t("layouts.footer.open_data_text") %></p>
-      </div>
-    </div>
   </div>
 
-  <div class="subfooter row">
-    <div class="small-12 medium-8 column">
-      <%= t("layouts.footer.copyright", year: Time.current.year) %>&nbsp;|
-      <ul class="no-bullet inline-block">
-        <li class="inline-block"><%= link_to t("layouts.footer.privacy"), privacy_path %>&nbsp;|</li>
-        <li class="inline-block"><%= link_to t("layouts.footer.conditions"), conditions_path %>&nbsp;|</li>
-        <li class="inline-block"><%= link_to t("layouts.footer.accessibility"), accessibility_path %></li>
-      </ul>
-    </div>
-
-    <div class="small-12 medium-4 column social">
-      <div class="text-right">
-        <ul>
-          <% if setting['twitter_handle'] %>
-            <li class="inline-block">
-              <%= link_to "https://twitter.com/#{setting['twitter_handle']}", target: "_blank",
-                           title: t("shared.go_to_page") + t("social.twitter", org: setting['org_name']) + t('shared.target_blank_html') do %>
-                              <span class="show-for-sr"><%= t("social.twitter", org: setting['org_name']) %></span>
-                              <span class="icon-twitter" aria-hidden="true"></span>
-              <% end %>
-            </li>
-          <% end %>
-          <% if setting['facebook_handle'] %>
-            <li class="inline-block">
-              <%= link_to "https://www.facebook.com/#{setting['facebook_handle']}/", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.facebook", org: setting['org_name']) + t('shared.target_blank_html') do %>
-                          <span class="show-for-sr"><%= t("social.facebook", org: setting['org_name']) %></span>
-                          <span class="icon-facebook" aria-hidden="true"></span>
-              <% end %>
-            </li>
-          <% end %>
-          <%  if setting['blog_url'] %>
-            <li class="inline-block">
-              <%= link_to setting['blog_url'], target: "_blank",
-                          title: t("shared.go_to_page") + t("social.blog", org: setting['org_name']) + t('shared.target_blank_html') do %>
-                          <span class="show-for-sr"><%= t("social.blog", org: setting['org_name']) %></span>
-                          <span class="icon-blog" aria-hidden="true"></span>
-              <% end %>
-            </li>
-          <% end %>
-          <% if setting['youtube_handle'] %>
-            <li class="inline-block">
-              <%= link_to "https://www.youtube.com/#{setting['youtube_handle']}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.youtube", org: setting['org_name']) + t('shared.target_blank_html') do %>
-                          <span class="show-for-sr"><%= t("social.youtube", org: setting['org_name']) %></span>
-                          <span class="icon-youtube" aria-hidden="true"></span>
-              <% end %>
-            </li>
-          <% end %>
-          <% if setting['telegram_handle'] %>
-            <li class="inline-block">
-              <%= link_to "https://www.telegram.me/#{setting['telegram_handle']}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.telegram", org: setting['org_name']) + t('shared.target_blank_html') do %>
-                          <span class="show-for-sr"><%= t("social.telegram", org: setting['org_name']) %></span>
-                          <span class="icon-telegram" aria-hidden="true"></span>
-              <% end %>
-            </li>
-          <% end %>
-          <% if setting['instagram_handle'] %>
-            <li class="inline-block">
-              <%= link_to "https://www.instagram.com/#{setting['instagram_handle']}", target: "_blank",
-                          title: t("shared.go_to_page") + t("social.instagram", org: setting['org_name']) + t('shared.target_blank_html') do %>
-                          <span class="show-for-sr"><%= t("social.instagram", org: setting['org_name']) %></span>
-                          <span class="icon-instagram" aria-hidden="true"></span>
-              <% end %>
-            </li>
-          <% end %>
+  <div class="subfooter">
+    <div class="row">
+      <div class="small-12 medium-8 column">
+        <%= t("layouts.footer.copyright", year: Time.current.year) %>&nbsp;|
+        <ul class="no-bullet inline-block">
+          <li class="inline-block"><%= link_to t("layouts.footer.privacy"), privacy_path %>&nbsp;|</li>
+          <li class="inline-block"><%= link_to t("layouts.footer.conditions"), conditions_path %>&nbsp;|</li>
+          <li class="inline-block"><%= link_to t("layouts.footer.accessibility"), accessibility_path %></li>
         </ul>
+      </div>
+
+      <div class="small-12 medium-4 column social">
+        <div class="text-right">
+          <ul>
+            <% if setting['twitter_handle'] %>
+              <li class="inline-block">
+                <%= link_to "https://twitter.com/#{setting['twitter_handle']}", target: "_blank",
+                             title: t("shared.go_to_page") + t("social.twitter", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                                <span class="show-for-sr"><%= t("social.twitter", org: setting['org_name']) %></span>
+                                <span class="icon-twitter" aria-hidden="true"></span>
+                <% end %>
+              </li>
+            <% end %>
+            <% if setting['facebook_handle'] %>
+              <li class="inline-block">
+                <%= link_to "https://www.facebook.com/#{setting['facebook_handle']}/", target: "_blank",
+                            title: t("shared.go_to_page") + t("social.facebook", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                            <span class="show-for-sr"><%= t("social.facebook", org: setting['org_name']) %></span>
+                            <span class="icon-facebook" aria-hidden="true"></span>
+                <% end %>
+              </li>
+            <% end %>
+            <%  if setting['blog_url'] %>
+              <li class="inline-block">
+                <%= link_to setting['blog_url'], target: "_blank",
+                            title: t("shared.go_to_page") + t("social.blog", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                            <span class="show-for-sr"><%= t("social.blog", org: setting['org_name']) %></span>
+                            <span class="icon-blog" aria-hidden="true"></span>
+                <% end %>
+              </li>
+            <% end %>
+            <% if setting['youtube_handle'] %>
+              <li class="inline-block">
+                <%= link_to "https://www.youtube.com/#{setting['youtube_handle']}", target: "_blank",
+                            title: t("shared.go_to_page") + t("social.youtube", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                            <span class="show-for-sr"><%= t("social.youtube", org: setting['org_name']) %></span>
+                            <span class="icon-youtube" aria-hidden="true"></span>
+                <% end %>
+              </li>
+            <% end %>
+            <% if setting['telegram_handle'] %>
+              <li class="inline-block">
+                <%= link_to "https://www.telegram.me/#{setting['telegram_handle']}", target: "_blank",
+                            title: t("shared.go_to_page") + t("social.telegram", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                            <span class="show-for-sr"><%= t("social.telegram", org: setting['org_name']) %></span>
+                            <span class="icon-telegram" aria-hidden="true"></span>
+                <% end %>
+              </li>
+            <% end %>
+            <% if setting['instagram_handle'] %>
+              <li class="inline-block">
+                <%= link_to "https://www.instagram.com/#{setting['instagram_handle']}", target: "_blank",
+                            title: t("shared.go_to_page") + t("social.instagram", org: setting['org_name']) + t('shared.target_blank_html') do %>
+                            <span class="show-for-sr"><%= t("social.instagram", org: setting['org_name']) %></span>
+                            <span class="icon-instagram" aria-hidden="true"></span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_top_links.html.erb
+++ b/app/views/shared/_top_links.html.erb
@@ -1,33 +1,3 @@
 <ul class="no-bullet external-links">
-  <li>
-    <%= link_to t("layouts.header.external_link_transparency"),
-                setting['transparency_url'].presence || t("layouts.header.external_link_transparency_url"),
-                target: "_blank",
-                rel: "nofollow",
-                title: t("shared.go_to_page") + t("layouts.header.external_link_transparency") + t('shared.target_blank_html') %>
-  </li>
-  <li>
-    <%= link_to t("layouts.header.external_link_opendata"),
-                setting['opendata_url'].presence || t("layouts.header.external_link_opendata_url"),
-                target: "_blank",
-                rel: "nofollow",
-                title: t("shared.go_to_page") + t("layouts.header.external_link_opendata") + t('shared.target_blank_html') %>
-  </li>
-  <li class="show-for-medium">
-    <%= link_to t("layouts.header.forums"),
-                participation_forums_path,
-                title: t("shared.go_to_page") + t("layouts.header.forums") %>
-  </li>
-
-  <% if setting['blog_url'] %>
-    <li>
-      <%= link_to t("layouts.header.external_link_blog"),
-                  setting['blog_url'],
-                  target: "_blank",
-                  rel: "nofollow",
-                  title: t("shared.go_to_page") + t("layouts.header.external_link_blog") + t('shared.target_blank_html') %>
-    </li>
-  <% end %>
-
   <%= raw content_block("top_links", I18n.locale) %>
 </ul>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -67,8 +67,23 @@ en:
     footer:
       copyright: Ayuntamiento de Madrid, %{year}
       description: This portal uses the %{consul} which is %{open_source}. From Madrid out into the world.
+      participation_title: Participation
+      participation_text: Decide how to shape the Madrid you want to live in.
+      open_data_title: Open data
+      open_data_text: Every detail about the City Council is yours to access.
+      transparency_title: Transparency
+      transparency_text: Find out anything about the Madrid City Council.
+      transparency_url: http://transparencia.madrid.es
     header:
       logo: "Decide Madrid: portal of citizen participation of the City of Madrid."
+      external_link_opendata: Open data
+      external_link_opendata_url: http://datos.madrid.es
+      external_link_transparency: Transparencia
+      external_link_transparency_url: http://transparencia.madrid.es
+      external_link_blog: Blog
+      forums: "Local Forums"
+      help_translate: Help us translate
+      help_translate_info: How to help
   social:
     blog_link: "Blog"
     facebook_link: "Facebook"

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -76,13 +76,20 @@ es:
       description: Este portal usa la %{consul} que es %{open_source}. De Madrid, para el mundo entero.
       open_source: software libre
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
+      participation_title: Participación
       participation_text: Decide cómo debe ser la ciudad de Madrid que quieres.
+      open_data_title: Datos Abiertos
+      open_data_text: Todos los datos del Ayuntamiento son tuyos.
+      transparency_title: Transparencia
+      transparency_text: Obtén cualquier información sobre el Ayuntamiento de Madrid.
       transparency_url: http://transparencia.madrid.es
     header:
       logo: "Decide Madrid: portal de participación ciudadana del Ayuntamiento de Madrid."
+      external_link_opendata: Datos abiertos
       external_link_opendata_url: http://datos.madrid.es
       external_link_transparency: Transparencia
       external_link_transparency_url: http://transparencia.madrid.es
+      external_link_blog: Blog
       forums: "Foros Locales"
       help_translate: Ayúdanos a traducir
       help_translate_info: Cómo ayudar

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -231,30 +231,15 @@ en:
       copyright: CONSUL, %{year}
       description: This portal uses the %{consul} which is %{open_source}.
       faq: technical assistance
-      open_data_text: Every detail about the City Council is yours to access.
-      open_data_title: Open data
       open_source: open-source software
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
-      participation_text: Decide how to shape the Madrid you want to live in.
-      participation_title: Participation
       privacy: Privacy Policy
-      transparency_text: Find out anything about the Madrid City Council.
-      transparency_title: Transparency
-      transparency_url: http://transparencia.madrid.es
     header:
       administration_menu: Admin
       administration: Administration
       available_locales: Available languages
       collaborative_legislation: Processes
       debates: Debates
-      external_link_blog: Blog
-      external_link_opendata: Open data
-      external_link_opendata_url: http://datos.madrid.es
-      external_link_transparency: Transparency
-      external_link_transparency_url: http://transparencia.madrid.es
-      forums: "Local Forums"
-      help_translate: Help us translate
-      help_translate_info: How to help
       locale: 'Language:'
       logo: CONSUL logo
       management: Management

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -228,27 +228,15 @@ es:
       copyright: CONSUL, %{year}
       description: Este portal usa la %{consul} que es %{open_source}.
       faq: Asistencia técnica
-      open_data_text: Todos los datos del Ayuntamiento son tuyos.
-      open_data_title: Datos Abiertos
       open_source: software de código abierto
       open_source_url: http://www.gnu.org/licenses/agpl-3.0.html
-      participation_text: Decide cómo debe ser la ciudad que quieres.
-      participation_title: Participación
       privacy: Política de privacidad
-      transparency_text: Obtén cualquier información sobre el Ayuntamiento de Madrid.
-      transparency_title: Transparencia
-      transparency_url: https://transparency.consul
     header:
       administration_menu: Admin
       administration: Administración
       available_locales: Idiomas disponibles
       collaborative_legislation: Procesos
       debates: Debates
-      external_link_blog: Blog
-      external_link_opendata: Datos abiertos
-      external_link_opendata_url: https://opendata.consul
-      external_link_transparency: Transparencia
-      external_link_transparency_url: https://transparency.consul
       locale: 'Idioma:'
       logo: Logo de CONSUL
       management: Gestión


### PR DESCRIPTION
Objectives
===================
This PR moves the following custom i18n keys to custom yml files and remove it on non custom views.

```shell
open_data_text
open_data_title
participation_text
participation_title
transparency_text
transparency_title
transparency_url
external_link_blog
external_link_opendata
external_link_opendata_url
external_link_transparency
external_link_transparency_url
forums
help_translate
help_translate_info
```
Notes
===================
Backport this to CONSUL repo.