### PR TITLE
Fix - Allow author notifications to be moderated

### DIFF
--- a/app/models/proposal_notification.rb
+++ b/app/models/proposal_notification.rb
@@ -64,6 +64,10 @@ class ProposalNotification < ActiveRecord::Base
     ignored_at.present?
   end
 
+  def after_restore
+    update(moderated: false)
+  end
+
   private
 
   def set_author

--- a/spec/features/admin/proposal_notifications_spec.rb
+++ b/spec/features/admin/proposal_notifications_spec.rb
@@ -25,6 +25,7 @@ feature 'Admin proposal notifications' do
 
     expect(proposal_notification.reload).not_to be_hidden
     expect(proposal_notification).to be_ignored
+    expect(proposal_notification).not_to be_moderated
   end
 
   scenario 'Confirm hide' do


### PR DESCRIPTION
References
===================
This is a fix for an already merged PR.

**ISSUE**: https://github.com/consul/consul/issues/2618
**Related PR**: https://github.com/AyuntamientoMadrid/consul/pull/1489

Objectives
===================
As @voodoorai2000 pointed out, the restore feature was not working properly. When pushed, the button was removing the notification from the admin's panel, but it was not appearing in the proposal.

I added an [`after_restore` function](https://github.com/AyuntamientoMadrid/consul/compare/master...wairbut-m2c-aytomadrid:2618-fix-allow-author-notifications-to-be-moderated#diff-9c28e8cb3083639c4df1c70cfe05f838R67) (that I missed in the first PR) so that the notification is unmarked as moderated. I also included a new [`expect`](https://github.com/AyuntamientoMadrid/consul/compare/master...wairbut-m2c-aytomadrid:2618-fix-allow-author-notifications-to-be-moderated#diff-35ff1dea7c70c00cd58787cab6d61023R28) in the specs to check that the notification's `moderate` attribute is unmarked.

Visual Changes
===================
#### Moderators view

![notifications01](https://user-images.githubusercontent.com/31625251/40730120-3d6b31fe-642e-11e8-81ab-0d2719cfec6b.gif)

#### Admin restore before confirming the moderation

![notifications02](https://user-images.githubusercontent.com/31625251/40730146-47118172-642e-11e8-9f6e-c23397213031.gif)

#### Admin restore after confirming moderation

![notifications03](https://user-images.githubusercontent.com/31625251/40730162-5056285a-642e-11e8-9461-632cd056546a.gif)


Notes
===================
Nothing to mention.
