### PR TITLE
Sort beta testers by `created_at` attribute

### DIFF
--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -60,7 +60,7 @@ class UserSegments
                  alberto@decabeza.es
                  voodoorai2000@gmail.com)
 
-    User.where(email: testers)
+    User.where(email: testers).order('created_at ASC')
   end
 
   def self.geozones

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -8,7 +8,7 @@ describe UserSegments do
   describe "#all_users" do
     it "returns all active users enabled" do
       active_user = create(:user)
-      erased_user  = create(:user, erased_at: Time.current)
+      erased_user = create(:user, erased_at: Time.current)
 
       expect(described_class.all_users).to include active_user
       expect(described_class.all_users).not_to include erased_user
@@ -203,6 +203,12 @@ describe UserSegments do
     it "returns only users with specific emails" do
       expect(described_class.beta_testers.count).to eq(5)
       expect(described_class.beta_testers.pluck(:email)).to match_array(beta_testers)
+    end
+
+    it "returns users sorted by `created_at` attribute" do
+      users   = described_class.beta_testers.pluck(:email)
+      testers = User.order('created_at ASC').pluck(:email).last(5)
+      expect(users).to eq(testers)
     end
   end
 


### PR DESCRIPTION
References
===================
* **Related issue**: #1479

Objectives
===================
* Sort beta testers by their `created_at` attribute. This way emails will be sent in a predictable way, allowing easier debugging

Visual Changes
===================
* None

Notes
===================
* None
