### PR TITLE
Do not display polls associated to a budget in admin poll questions

### DIFF
--- a/app/controllers/admin/poll/questions_controller.rb
+++ b/app/controllers/admin/poll/questions_controller.rb
@@ -5,7 +5,7 @@ class Admin::Poll::QuestionsController < Admin::Poll::BaseController
   load_and_authorize_resource :question, class: 'Poll::Question'
 
   def index
-    @polls = Poll.all
+    @polls = Poll.not_budget
     @search = search_params[:search]
 
     @questions = @questions.search(search_params).page(params[:page]).order("created_at DESC")

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -37,6 +37,7 @@ class Poll < ActiveRecord::Base
   scope :by_geozone_id, ->(geozone_id) { where(geozones: {id: geozone_id}.joins(:geozones)) }
   scope :public_for_api, -> { all }
   scope :with_nvotes, -> { where.not(nvotes_poll_id: nil) }
+  scope :not_budget,    -> { where(budget_id: nil) }
 
   scope :sort_for_list, -> { order(:geozone_restricted, :starts_at, :name) }
 

--- a/spec/features/budget_polls/questions_spec.rb
+++ b/spec/features/budget_polls/questions_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+feature "Poll Questions" do
+
+  before do
+    admin = create(:administrator).user
+    login_as(admin)
+  end
+
+  scenario "Do not display polls associated to a budget" do
+    budget = create(:budget)
+
+    poll1 = create(:poll, name: "Citizen Proposal Poll")
+    poll2 = create(:poll, budget: budget, name: "Participatory Budget Poll")
+
+    visit admin_questions_path
+
+    expect(page).to have_select("poll_id", text: "Citizen Proposal Poll")
+    expect(page).to_not have_select("poll_id", text: "Participatory Budget Poll")
+  end
+
+end

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -291,4 +291,24 @@ describe Poll do
 
   end
 
+  context "scopes" do
+
+    describe "#not_budget" do
+
+      it "returns polls not associated to a budget" do
+        budget = create(:budget)
+
+        poll1 = create(:poll)
+        poll2 = create(:poll)
+        poll3 = create(:poll, budget: budget)
+
+        expect(Poll.not_budget).to include(poll1)
+        expect(Poll.not_budget).to include(poll2)
+        expect(Poll.not_budget).to_not include(poll3)
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
References
===================
*Issue:* https://github.com/consul/consul/issues/2639

What
===================
Do not display polls associated to a budget in admin poll questions 

Why
===================
The `admin/questions` section is used to select to which poll a question belongs to

Budget polls are not meant to include questions that come from Citizen
Proposals or Government Questions, thus we do not display them

Visual Changes
===================
**Before** (displaying a poll associated to a budget)
![poll questions before](https://user-images.githubusercontent.com/4169/41096384-b993028a-6a54-11e8-99d8-9014c13d5c73.png)


**After** (not displaying a poll associated to a budget)
![poll questions after](https://user-images.githubusercontent.com/4169/41096388-bc3306d4-6a54-11e8-8585-72685b1ed800.png)

Notes
===================
None
