### PR TITLE
Adds "Admin ballots" button in admin budgets index

### DIFF
--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -16,6 +16,7 @@
       <th><%= t("admin.budgets.index.table_investments") %></th>
       <th><%= t("admin.budgets.index.table_edit_groups") %></th>
       <th><%= t("admin.budgets.index.table_edit_budget") %></th>
+      <th><%= t("admin.budgets.index.table_admin_ballots") %></th>
     </tr>
   </thead>
   <tbody>
@@ -37,6 +38,11 @@
         </td>
         <td class="small">
           <%= link_to t("admin.budgets.index.edit_budget"), edit_admin_budget_path(budget) %>
+        </td>
+        <td class="small">
+          <% if budget.poll.present? %>
+            <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_path(budget.poll) %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -80,8 +80,10 @@ en:
         table_investments: Investments
         table_edit_groups: Headings groups
         table_edit_budget: Edit
+        table_admin_ballots: Ballots
         edit_groups: Edit headings groups
         edit_budget: Edit budget
+        admin_ballots: Admin ballots
       create:
         notice: New participatory budget created successfully!
       update:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -80,8 +80,10 @@ es:
         table_investments: Proyectos de gasto
         table_edit_groups: Grupos de partidas
         table_edit_budget: Editar
+        table_admin_ballots: Urnas
         edit_groups: Editar grupos de partidas
         edit_budget: Editar presupuesto
+        admin_ballots: Gestionar urnas
       create:
         notice: "¡Presupuestos participativos creados con éxito!"
       update:

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -81,6 +81,16 @@ feature 'Admin budgets' do
       end
     end
 
+    scenario 'Admin ballots link appears if budget has a poll associated' do
+      budget = create(:budget)
+      create(:poll, budget: budget)
+
+      visit admin_budgets_path
+
+      within "#budget_#{budget.id}" do
+        expect(page).to have_link("Admin ballots")
+      end
+    end
   end
 
   context 'New' do

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -81,16 +81,6 @@ feature 'Admin budgets' do
       end
     end
 
-    scenario 'Admin ballots link appears if budget has a poll associated' do
-      budget = create(:budget)
-      create(:poll, budget: budget)
-
-      visit admin_budgets_path
-
-      within "#budget_#{budget.id}" do
-        expect(page).to have_link("Admin ballots")
-      end
-    end
   end
 
   context 'New' do

--- a/spec/features/budget_polls/budgets_spec.rb
+++ b/spec/features/budget_polls/budgets_spec.rb
@@ -9,12 +9,12 @@ feature 'Admin Budgets' do
 
   scenario 'Admin ballots link appears if budget has a poll associated' do
     budget = create(:budget)
-    create(:poll, budget: budget)
+    poll = create(:poll, budget: budget)
 
     visit admin_budgets_path
 
     within "#budget_#{budget.id}" do
-      expect(page).to have_link("Admin ballots")
+      expect(page).to have_link("Admin ballots", admin_poll_path(poll))
     end
   end
 

--- a/spec/features/budget_polls/budgets_spec.rb
+++ b/spec/features/budget_polls/budgets_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'Admin Budgets' do
+
+  background do
+    admin = create(:administrator).user
+    login_as(admin)
+  end
+
+  scenario 'Admin ballots link appears if budget has a poll associated' do
+    budget = create(:budget)
+    create(:poll, budget: budget)
+
+    visit admin_budgets_path
+
+    within "#budget_#{budget.id}" do
+      expect(page).to have_link("Admin ballots")
+    end
+  end
+
+end


### PR DESCRIPTION
References
===================
Related issue https://github.com/consul/consul/issues/2639

Objectives
===================
In the admin budgets index (`/admin/budgets`) added link on every budget that has a poll associated to access the poll ballots.

Visual Changes
===================
<img width="1030" alt="screen shot 2018-06-07 at 18 32 11" src="https://user-images.githubusercontent.com/2141690/41113249-6730327e-6a81-11e8-82da-fa2e08620352.png">
