### PR TITLE
Hide budget polls

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -5,6 +5,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   before_action :load_geozones, only: [:new, :create, :edit, :update]
 
   def index
+    @polls = Poll.not_budget
   end
 
   def show

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -11,7 +11,7 @@ class PollsController < ApplicationController
   ::Poll::Answer # trigger autoload
 
   def index
-    @polls = @polls.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
+    @polls = @polls.not_budget.send(@current_filter).includes(:geozones).sort_for_list.page(params[:page])
   end
 
   def show

--- a/spec/features/budget_polls/polls_spec.rb
+++ b/spec/features/budget_polls/polls_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature "Polls" do
+
+  context "Admin index" do
+    it 'Budget polls should not appear in the list' do
+      login_as(create(:administrator).user)
+
+      poll = create(:poll)
+      budget_poll = create(:poll, budget: create(:budget))
+
+      visit admin_polls_path
+
+      expect(page).to have_content(poll.name)
+      expect(page).not_to have_content(budget_poll.name)
+    end
+  end
+
+end

--- a/spec/features/budget_polls/polls_spec.rb
+++ b/spec/features/budget_polls/polls_spec.rb
@@ -2,6 +2,18 @@ require 'rails_helper'
 
 feature "Polls" do
 
+  context "Public index" do
+    it 'Budget polls should not be listed' do
+      poll = create(:poll)
+      budget_poll = create(:poll, budget: create(:budget))
+
+      visit polls_path
+
+      expect(page).to have_content(poll.name)
+      expect(page).not_to have_content(budget_poll.name)
+    end
+  end
+
   context "Admin index" do
     it 'Budget polls should not appear in the list' do
       login_as(create(:administrator).user)


### PR DESCRIPTION
References
===================
Related issue consul#2639

Objectives
===================
Hide from public polls list (`/polls`) and admin (`admin/polls`) those polls associated to a budget.
