### PR TITLE
UI changes budget ballots

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -20,7 +20,12 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   def create
     @poll = Poll.new(poll_params.merge(author: current_user))
     if @poll.save
-      redirect_to [:admin, @poll], notice: t("flash.actions.create.poll")
+      notice = t("flash.actions.create.poll")
+      if @poll.budget.present?
+        redirect_to admin_poll_booth_assignments_path(@poll), notice: notice
+      else
+        redirect_to [:admin, @poll], notice: notice
+      end
     else
       render :new
     end

--- a/app/helpers/officers_helper.rb
+++ b/app/helpers/officers_helper.rb
@@ -4,4 +4,8 @@ module OfficersHelper
     truncate([officer.name, officer.email].compact.join(' - '), length: 100)
   end
 
+  def final_recount_shift?
+    current_user.poll_officer.officer_assignments.final.where(date: Time.current.to_date)
+  end
+
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -133,4 +133,8 @@ class Poll < ActiveRecord::Base
     Rails.application.secrets["nvotes_server_url"] || ENV["nvotes_server_url"]
   end
 
+  def budget_poll?
+    budget.present?
+  end
+
 end

--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -41,7 +41,7 @@
         </td>
         <td class="small">
           <% if budget.poll.present? %>
-            <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_path(budget.poll) %>
+            <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_booth_assignments_path(budget.poll) %>
           <% else %>
             <%= link_to_create_budget_poll(budget) %>
           <% end %>

--- a/app/views/admin/poll/booth_assignments/index.html.erb
+++ b/app/views/admin/poll/booth_assignments/index.html.erb
@@ -11,7 +11,7 @@
               class: "button hollow float-right" %>
 
   <% if @booth_assignments.empty? %>
-    <div class="callout primary margin-top">
+    <div class="callout primary margin-top clear">
       <%= t("admin.poll_booth_assignments.index.no_booths") %>
     </div>
   <% else %>

--- a/app/views/admin/poll/polls/_subnav.html.erb
+++ b/app/views/admin/poll/polls/_subnav.html.erb
@@ -1,18 +1,20 @@
 <ul class="menu simple clear" id="assigned-resources-tabs">
-  <% if controller_name == "polls" %>
-    <li class="is-active">
-      <h2>
-        <%= t("admin.polls.show.questions_tab") %>
-        (<%= @poll.questions.count %>)
-      </h2>
-    </li>
-  <% else %>
-    <li>
-      <%= link_to admin_poll_path(@poll) do %>
-        <%= t("admin.polls.show.questions_tab") %>
-        (<%= @poll.questions.count %>)
-      <% end %>
-    </li>
+  <% unless @poll.budget_poll? %>
+    <% if controller_name == "polls" %>
+      <li class="is-active">
+        <h2>
+          <%= t("admin.polls.show.questions_tab") %>
+          (<%= @poll.questions.count %>)
+        </h2>
+      </li>
+    <% else %>
+      <li>
+        <%= link_to admin_poll_path(@poll) do %>
+          <%= t("admin.polls.show.questions_tab") %>
+          (<%= @poll.questions.count %>)
+        <% end %>
+      </li>
+    <% end %>
   <% end %>
 
   <% if controller_name == "booth_assignments" %>

--- a/app/views/admin/poll/recounts/index.html.erb
+++ b/app/views/admin/poll/recounts/index.html.erb
@@ -14,14 +14,18 @@
       <thead>
         <tr>
           <th class="text-center"></th>
-          <th class="text-center"><%= t("admin.recounts.index.total_final") %></th>
+          <% unless @poll.budget_poll? %>
+            <th class="text-center"><%= t("admin.recounts.index.total_final") %></th>
+          <% end %>
           <th class="text-center"><%= t("admin.recounts.index.total_system") %></th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td><strong><%= t("admin.recounts.index.all_booths_total") %></strong></td>
-          <td class="text-center" id="total_final"><%=  @all_booths_counts[:final] %></td>
+          <% unless @poll.budget_poll? %>
+            <td class="text-center" id="total_final"><%=  @all_booths_counts[:final] %></td>
+          <% end %>
           <td class="text-center" id="total_system"><%= @all_booths_counts[:system] %></td>
         </tr>
       </tbody>
@@ -30,7 +34,9 @@
     <table class="fixed margin">
       <thead>
         <th><%= t("admin.recounts.index.table_booth_name") %></th>
-        <th class="text-center"><%= t("admin.recounts.index.table_total_recount") %></th>
+        <% unless @poll.budget_poll? %>
+          <th class="text-center"><%= t("admin.recounts.index.table_total_recount") %></th>
+        <% end %>
         <th class="text-center"><%= t("admin.recounts.index.table_system_count") %></th>
       </thead>
       <tbody>
@@ -43,13 +49,15 @@
                 <%= link_to booth_assignment.booth.name, admin_poll_booth_assignment_path(@poll, booth_assignment, anchor: 'tab-recounts') %>
               </strong>
             </td>
-            <td class="text-center <%= 'count-error' if total_recounts.to_i != system_count %>" id="<%= dom_id(booth_assignment) %>_recount">
-              <% if total_recounts.present? %>
-                <strong><%= total_recounts %></strong>
-              <% else %>
-                <span>-</span>
-              <% end %>
-            </td>
+            <% unless @poll.budget_poll? %>
+              <td class="text-center <%= 'count-error' if total_recounts.to_i != system_count %>" id="<%= dom_id(booth_assignment) %>_recount">
+                <% if total_recounts.present? %>
+                  <strong><%= total_recounts %></strong>
+                <% else %>
+                  <span>-</span>
+                <% end %>
+              </td>
+            <% end %>
             <td class="text-center" id="<%= dom_id(booth_assignment) %>_system">
               <% if system_count.present? %>
                 <strong><%= system_count %></strong>

--- a/app/views/officing/_menu.html.erb
+++ b/app/views/officing/_menu.html.erb
@@ -7,11 +7,13 @@
       <% end %>
     </li>
 
-    <li <%= "class=is-active" if ["results"].include?(controller_name) || (controller_name == "polls" && action_name == "final") %>>
-      <%= link_to final_officing_polls_path do %>
-        <span class="icon-user"></span>
-        <%= t("officing.menu.total_recounts") %>
-      <% end %>
-    </li>
+    <% if final_recount_shift? %>
+      <li <%= "class=is-active" if ["results"].include?(controller_name) || (controller_name == "polls" && action_name == "final") %>>
+        <%= link_to final_officing_polls_path do %>
+          <span class="icon-user"></span>
+          <%= t("officing.menu.total_recounts") %>
+        <% end %>
+      </li>
+    <% end%>
   </ul>
 </div>

--- a/spec/features/budget_polls/budgets_spec.rb
+++ b/spec/features/budget_polls/budgets_spec.rb
@@ -40,4 +40,23 @@ feature 'Admin Budgets' do
 
   end
 
+  context "Show" do
+
+    scenario 'Do not show questions section if the budget have a poll associated' do
+      budget = create(:budget)
+      poll = create(:poll, budget: budget)
+
+      visit admin_poll_path(poll)
+
+      within "#poll-resources" do
+        expect(page).not_to have_content("Questions")
+        expect(page).to have_content("Booths")
+        expect(page).to have_content("Officers")
+        expect(page).to have_content("Recounting")
+        expect(page).to have_content("Results")
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Objectives
===================

- Hides question menu on budget poll and changes redirect when creating (redirects to booths tab).
- Hides total final and total recount cells on budget poll recounts.
- Fixes manage assignments button overlapping.
- Hides recount menu if an officer has no shift assigned.
