### PR TITLE
Officing voters

### DIFF
--- a/app/helpers/officers_helper.rb
+++ b/app/helpers/officers_helper.rb
@@ -5,7 +5,7 @@ module OfficersHelper
   end
 
   def vote_collection_shift?
-    current_user.poll_officer.officer_assignments.where(date: Time.current.to_date).any?
+    current_user.poll_officer.officer_assignments.voting_days.where(date: Time.current.to_date).any?
   end
 
   def final_recount_shift?

--- a/app/helpers/officers_helper.rb
+++ b/app/helpers/officers_helper.rb
@@ -12,4 +12,8 @@ module OfficersHelper
     current_user.poll_officer.officer_assignments.final.where(date: Time.current.to_date).any?
   end
 
+  def no_shifts?
+    current_user.poll_officer.officer_assignments.where(date: Time.current.to_date).blank?
+  end
+
 end

--- a/app/views/officing/dashboard/index.html.erb
+++ b/app/views/officing/dashboard/index.html.erb
@@ -3,7 +3,7 @@
 
   <p><%= t("officing.dashboard.index.info") %></p>
 
-  <% unless final_recount_shift? && vote_collection_shift? %>
+  <% if no_shifts? %>
     <div class="callout warning">
       <%= t("officing.dashboard.index.no_shifts") %>
     </div>

--- a/app/views/officing/voters/create.js.erb
+++ b/app/views/officing/voters/create.js.erb
@@ -1,2 +1,3 @@
 $("#<%= dom_id(@poll) %> #actions").html('<%= j render("voted") %>');
 $("#<%= dom_id(@poll) %> #can_vote_callout").hide();
+$("#not_voted").hide();

--- a/app/views/officing/voters/new.html.erb
+++ b/app/views/officing/voters/new.html.erb
@@ -46,4 +46,8 @@
 
 <% end %>
 
-<%= link_to t("officing.voters.new.not_to_vote"), namespaced_root_path, class: "button" %>
+<% if Poll.votable_by(@user).any? %>
+  <div id="not_voted">
+    <%= link_to t("officing.voters.new.not_to_vote"), namespaced_root_path, class: "button" %>
+  </div>
+<% end %>

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature 'Budget Poll Officing' do
 
-  scenario 'Show sidebar menu if officer has shifts assigned' do
+  scenario 'Show sidebar menus if officer has shifts assigned' do
     budget = create(:budget)
     poll = create(:poll, budget: budget)
     booth = create(:poll_booth)
@@ -11,13 +11,21 @@ feature 'Budget Poll Officing' do
     user = create(:user)
     officer = create(:poll_officer, user: user)
 
+    create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)
+
+    login_as user
+    visit officing_root_path
+
+    expect(page).not_to have_content("You don't have officing shifts today")
+    expect(page).to have_content("Validate document")
+    expect(page).not_to have_content("Total recounts and results")
+
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :recount_scrutiny)
 
     officer_assignment = create(:poll_officer_assignment,
                                  booth_assignment: booth_assignment,
                                  officer: officer)
 
-    login_as user
     visit officing_root_path
 
     expect(page).not_to have_content("You don't have officing shifts today")
@@ -25,7 +33,7 @@ feature 'Budget Poll Officing' do
     expect(page).to have_content("Total recounts and results")
   end
 
-  scenario 'Do not show sidebar menu if officer has no shifts assigned' do
+  scenario 'Do not show sidebar menus if officer has no shifts assigned' do
     user = create(:user)
     officer = create(:poll_officer, user: user)
 

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -117,6 +117,43 @@ feature "Voter" do
       end
     end
 
+    context "The person has decided not to vote at this time" do
+      let!(:user) { create(:user, :in_census) }
+
+      scenario "Show not to vote at this time button" do
+        login_through_form_as_officer(officer.user)
+
+        visit new_officing_residence_path
+        officing_verify_residence
+
+        expect(page).to have_content poll.name
+        expect(page).to have_button "Confirm vote"
+        expect(page).to have_content "Can vote"
+        expect(page).to have_link "The person has decided not to vote at this time"
+      end
+
+      scenario "Hides not to vote at this time button if already voted", :js do
+        login_through_form_as_officer(officer.user)
+
+        visit new_officing_residence_path
+        officing_verify_residence
+
+        within("#poll_#{poll.id}") do
+          click_button("Confirm vote")
+          expect(page).not_to have_button("Confirm vote")
+          expect(page).to have_content "Vote introduced!"
+          expect(page).not_to have_content "The person has decided not to vote at this time"
+        end
+
+        visit new_officing_residence_path
+        officing_verify_residence
+
+        expect(page).to have_content "Has already participated in this poll"
+        expect(page).not_to have_content "The person has decided not to vote at this time"
+      end
+
+    end
+
     context "Trying to vote the same poll in booth and web" do
       let!(:user) { create(:user, :in_census) }
 


### PR DESCRIPTION
Objectives
===================

- Hides sidebar menu if the officer has no shifts only shows the menu of the assigned shifts (validate votes or recount & results)
- Shows message on the index if the officer has no shifts.
- Hides not to vote at this time button if already voted.

Visual Changes
===================
![screen shot 2018-06-20 at 14 22 23](https://user-images.githubusercontent.com/631897/41658755-b2a1f132-7497-11e8-9df2-b797ec6ae6c5.png)

![screen shot 2018-06-20 at 14 39 25](https://user-images.githubusercontent.com/631897/41658774-c00fb70a-7497-11e8-80bd-488bc6961d71.png)

Notes
===================
Backport this PR to CONSUL repo.