### PR TITLE
Homepage cards

### DIFF
--- a/app/views/welcome/_card.html.erb
+++ b/app/views/welcome/_card.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id(card) %>" class="card small-12 medium-6 column margin-bottom end <%= 'large-4' unless feed_processes_enabled? %>">
+<div id="<%= dom_id(card) %>" class="card small-12 medium-6 column margin-bottom end <%= 'large-4' unless feed_processes_enabled? %>" data-equalizer-watch>
   <%= link_to card.link_url do %>
     <figure class="figure-card">
       <% if card.image.present? %>

--- a/app/views/welcome/_cards.html.erb
+++ b/app/views/welcome/_cards.html.erb
@@ -1,6 +1,6 @@
 <h3 class="title"><%= t("welcome.cards.title") %></h3>
 
-<div class="row">
+<div class="row" data-equalizer data-equalizer-on="medium">
   <% @cards.all.each do |card| %>
     <%= render "card", card: card %>
   <% end %>


### PR DESCRIPTION
Objectives
===================
Adds `data-equalizer` to fix height on homepage cards.

Visual Changes
===================
**Without data equalizer some cards shows in a different row**
![broken](https://user-images.githubusercontent.com/631897/41710842-f6ab31a4-7546-11e8-9371-b4b4f234e924.png)

**Fix with data equalizer**
![fix](https://user-images.githubusercontent.com/631897/41710841-f55b9fc8-7546-11e8-9092-76d3ac11acbc.png)

Notes
===================
Backport this PR to CONSUL repo.