### PR TITLE
Display 'Validate document' menu item only when applicable

### DIFF
--- a/app/views/officing/_menu.html.erb
+++ b/app/views/officing/_menu.html.erb
@@ -1,7 +1,9 @@
 <div class="admin-sidebar" data-equalizer-watch>
   <ul id="officing_menu">
     <% if vote_collection_shift? %>
-      <li <%= "class=is-active" if controller_name == "voters" %>>
+      <li class="<%= "js-vote-collection" %>
+                 <%= " is-active" if controller_name == "voters" %>
+                 <%= " is-hidden" if controller_name == "voters" && Poll.votable_by(@user).any? %>">
         <%= link_to new_officing_residence_path do %>
           <span class="icon-user"></span>
           <%= t("officing.menu.voters") %>

--- a/app/views/officing/voters/create.js.erb
+++ b/app/views/officing/voters/create.js.erb
@@ -1,3 +1,4 @@
 $("#<%= dom_id(@poll) %> #actions").html('<%= j render("voted") %>');
 $("#<%= dom_id(@poll) %> #can_vote_callout").hide();
 $("#not_voted").hide();
+$(".js-vote-collection").removeClass("is-hidden");

--- a/spec/features/budget_polls/voter_spec.rb
+++ b/spec/features/budget_polls/voter_spec.rb
@@ -149,4 +149,49 @@ feature "BudgetPolls" do
     end
 
   end
+
+  context "Side menu" do
+
+    scenario "'Validate document' menu item with votable polls", :js do
+      login_through_form_as_officer(officer.user)
+
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content poll.name
+
+      within("#side_menu") do
+        expect(page).to_not have_content("Validate document")
+      end
+
+      within("#poll_#{poll.id}") do
+        click_button("Confirm vote")
+        expect(page).to have_content "Vote introduced!"
+      end
+
+      within("#side_menu") do
+        expect(page).to have_content("Validate document")
+      end
+    end
+
+    scenario "'Validate document' menu item without votable polls", :js do
+      create(:poll_voter, poll: poll, user: user)
+
+      login_through_form_as_officer(officer.user)
+
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content poll.name
+
+      within("#poll_#{poll.id}") do
+        expect(page).to have_content "Has already participated in this poll"
+      end
+
+      within("#side_menu") do
+        expect(page).to have_content("Validate document")
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
References
===
**Issue:** https://github.com/consul/consul/issues/2639

Context
===
We are trying to avoid Officers from forgetting to click the “Confirm vote” button, which is necessary to keep track of who has voted a Poll

What
===
- Hide the menu item 'Validate document' by default in the voting page
- Once the Officer clicks the “Confirm Vote” display it again
- If there are no votable polls, display the menu item

Visual Changes
===================
![officing menu](https://user-images.githubusercontent.com/4169/41720871-a5a2faf8-7564-11e8-83a0-86c1b80ef18e.gif)


Notes
===================
Due to mobile version we have duplicate ids for menu items, so using classes for the menu items to hide them correctly

Maybe a custom layout for this page, without menu items, and instead buttons for the next actions, would be more appropriate, we'll explore the idea 😌