### PR TITLE
Simplify officing layout

### DIFF
--- a/app/views/custom/layouts/_admin_header.html.erb
+++ b/app/views/custom/layouts/_admin_header.html.erb
@@ -1,0 +1,49 @@
+<header class="header">
+  <div class="top-links">
+    <div class="expanded row">
+      <%= render "shared/locale_switcher" %>
+    </div>
+  </div>
+
+  <div class="expanded row admin-top-bar">
+    <div class="title-bar" data-responsive-toggle="responsive_menu" data-hide-for="medium">
+      <button class="menu-icon" type="button" data-toggle="responsive_menu"></button>
+      <div class="title-bar-title"><%= t("application.menu")%></div>
+    </div>
+
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="menu">
+          <li class="menu-text">
+            <% if namespace == "officing" %>
+              <h1>
+                <%= link_to "#" do %>
+                  <%= setting["org_name"] %>
+                  <br><small><%= namespaced_header_title %></small>
+                <% end %>
+              </h1>
+            <% else %>
+              <h1>
+                <%= link_to namespaced_root_path do %>
+                  <%= setting["org_name"] %>
+                  <br><small><%= namespaced_header_title %></small>
+                <% end %>
+              </h1>
+            <% end %>
+          </li>
+        </ul>
+      </div>
+
+      <div id="responsive_menu">
+        <div class="top-bar-right">
+          <ul class="dropdown menu" data-dropdown-menu>
+            <%= render "admin/shared/admin_shortcuts" %>
+            <%= render "shared/admin_login_items" %>
+            <%= render "layouts/notification_item" %>
+            <%= render "devise/menu/login_items" %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>

--- a/app/views/custom/shared/_admin_login_items.html.erb
+++ b/app/views/custom/shared/_admin_login_items.html.erb
@@ -1,0 +1,39 @@
+<% if show_admin_menu? %>
+  <li class="has-submenu">
+    <%= link_to t("layouts.header.administration_menu"), "#", rel: "nofollow", class: "hide-for-small-only" %>
+    <ul class="submenu menu vertical" data-submenu>
+      <% if current_user.administrator? %>
+        <li>
+          <%= link_to t("layouts.header.administration"), admin_root_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.administrator? || current_user.moderator? %>
+        <li>
+          <%= link_to t("layouts.header.moderation"), moderation_root_path %>
+        </li>
+      <% end %>
+
+      <% if (feature?(:spending_proposals) || feature?(:budgets)) &&
+            (current_user.administrator? || current_user.valuator?) %>
+        <li>
+          <%= link_to t("layouts.header.valuation"), valuation_root_path %>
+        </li>
+      <% end %>
+
+      <% if current_user.administrator? || current_user.manager? %>
+        <li>
+          <%= link_to t("layouts.header.management"), management_sign_in_path %>
+        </li>
+      <% end %>
+    </ul>
+  </li>
+<% end %>
+
+<% unless namespace == "officing" %>
+  <% if current_user && current_user.poll_officer? && Poll.current.any? %>
+    <li>
+      <%= link_to t("layouts.header.officing"), officing_root_path %>
+    </li>
+  <% end %>
+<% end %>

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -45,4 +45,28 @@ feature 'Budget Poll Officing' do
     expect(page).not_to have_content("Total recounts and results")
   end
 
+  context "layout" do
+
+    scenario "Logo" do
+      user = create(:user)
+      officer = create(:poll_officer, user: user)
+
+      login_as user
+      visit officing_root_path
+
+      expect(page).to_not have_link("Decide Madrid Polling", href: "/officing")
+    end
+
+    scenario "Polling officers header menu" do
+      user = create(:user)
+      officer = create(:poll_officer, user: user)
+
+      login_as user
+      visit officing_root_path
+
+      expect(page).to_not have_link("Polling officers", href: "/officing")
+    end
+
+  end
+
 end

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -28,8 +28,7 @@ feature 'Officing Results' do
     not_allowed_poll_2.update(ends_at: 1.day.ago)
     not_allowed_poll_3 = regular_officer_assignment_2.booth_assignment.poll
 
-    visit root_path
-    click_link 'Polling officers'
+    visit officing_root_path
 
     expect(page).to have_content('Poll officing')
 


### PR DESCRIPTION
References
===================
**Issue:** https://github.com/consul/consul/issues/2639

Context
===
Sometimes officers get confused and click a link that takes them away from the voting pages

What
===
- Remove logo from the officing section
- Remove link to officing in the header

Visual Changes
===================
Before:

![officing menu before](https://user-images.githubusercontent.com/4169/41736994-4fbcd79c-758e-11e8-9df1-10ae6b4f9907.png)

After:

![officing menu after](https://user-images.githubusercontent.com/4169/41736999-51fcdd40-758e-11e8-9729-abbb6300b20d.png)

Notes
===
None