### PR TITLE
Increase max cache size to 2MB

### DIFF
--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -214,7 +214,7 @@ class Budget
       end
 
       def stats_cache(key, &block)
-        Rails.cache.fetch("budgets_stats/#{@budget.id}/#{key}/v9", &block)
+        Rails.cache.fetch("budgets_stats/#{@budget.id}/#{key}/v10", &block)
       end
   end
 end

--- a/config/environments/preproduction.rb
+++ b/config/environments/preproduction.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :dalli_store
+  config.cache_store = :dalli_store, { value_max_bytes: 2000000 }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :dalli_store
+  config.cache_store = :dalli_store, { value_max_bytes: 2000000 }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
What
===================
Increase max cache size from 1MB to 2MB

Why
========
We have lots of votes in this edition of Participatory Budgets and the default cache size (1MB) is not enough to hold certain cache fragments

Notes
===================
Execute `Budget::Stats.new(Budget.last).generate` in Preproduction environment, check out logs and make sure there are no messages on these lines: `Value for budgets_stats/3/voters/v8 over max size: 1048576 <= 1914924`
