### PR TITLE
Public budget stats permissions and new stats data

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -65,6 +65,7 @@ module Abilities
       can [:hide, :update, :toggle_selection], Budget::Investment
       can [:valuate, :comment_valuation], Budget::Investment
       can :create, Budget::ValuatorAssignment
+      can :read_stats, Budget, phase: "reviewing_ballots"
 
       can [:search, :edit, :update, :create, :index, :destroy], Banner
 

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -26,7 +26,7 @@ module Abilities
       can [:read], Budget::Group
       can [:read, :print, :json_data], Budget::Investment
       can :read_results, Budget, phase: "finished"
-      can :read_stats, Budget, phase: ['reviewing_ballots', 'finished']
+      can :read_stats, Budget, phase: "finished"
       can :new, DirectMessage
       can [:read, :debate, :draft_publication, :allegations, :result_publication, :proposals], Legislation::Process, published: true
       can [:read, :changes, :go_to_version], Legislation::DraftVersion

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -6,9 +6,11 @@ class Budget
     end
 
     def generate
-      stats = %w[total_participants total_participants_support_phase total_participants_vote_phase total_budget_investments total_votes
-                 total_selected_investments total_unfeasible_investments total_male_participants total_female_participants total_supports
-                 total_unknown_gender_or_age age_groups male_percentage female_percentage headings]
+      stats = %w[total_participants total_participants_support_phase total_participants_vote_phase
+                total_budget_investments total_votes total_selected_investments
+                total_unfeasible_investments total_male_participants total_female_participants
+                total_supports total_unknown_gender_or_age age_groups male_percentage
+                female_percentage headings total_participants_web total_participants_booths]
       stats.map { |stat_name| [stat_name.to_sym, send(stat_name)] }.to_h
     end
 
@@ -20,6 +22,16 @@ class Budget
 
       def total_participants_support_phase
         stats_cache('total_participants_support_phase') { voters.uniq.count }
+      end
+
+      def total_participants_web
+        stats_cache('total_participants_web') do
+          (balloters - poll_ballot_voters).uniq.compact.count
+        end
+      end
+
+      def total_participants_booths
+        stats_cache('total_participants_booths') { poll_ballot_voters.uniq.count }
       end
 
       def total_participants_vote_phase
@@ -96,7 +108,7 @@ class Budget
 
       def participants
         stats_cache('participants') do
-          User.where(id: (authors + voters + balloters + poll_ballot_voters).uniq)
+          User.where(id: (authors + voters + balloters + poll_ballot_voters).uniq.compact)
         end
       end
 

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -76,11 +76,18 @@
             <%= @stats[:total_supports] %> <em><%= t("budgets.stats.supports") %></em><br>
           </span>
 
-          <span class="label balloting"></span>&nbsp;
-          <span class="uppercase"><strong><%= t("budgets.stats.total_participants_vote_phase") %></strong></span>:
-          <span id="total_participants_vote_phase">
-            <%= @stats[:total_participants_vote_phase] %> <em><%= t("budgets.stats.participants") %></em>,
-            <%= @stats[:total_votes] %> <em><%= t("budgets.stats.votes") %></em><br>
+          <br>
+
+          <span class="label"></span>&nbsp;
+          <span class="uppercase"><strong><%= t("budgets.stats.total_participants_web") %></strong></span>:
+          <span id="total_participants_web">
+            <%= @stats[:total_participants_web] %><br>
+          </span>
+
+          <span class="label"></span>&nbsp;
+          <span class="uppercase"><strong><%= t("budgets.stats.total_participants_booths") %></strong></span>:
+          <span id="total_participants_booths">
+            <%= @stats[:total_participants_booths] %><br>
           </span>
         </p>
       </div>

--- a/config/locales/custom/en/budgets.yml
+++ b/config/locales/custom/en/budgets.yml
@@ -24,6 +24,8 @@ en:
       total_selected_investments: Proposals on final phase
       total_unfeasible_investments: Unfeasible proposals
       total_participants_support_phase: Support phase
+      total_participants_web: Vote phase web participants
+      total_participants_booths: Vote phase booth participants
       participants: Participants
       supports: Supports
       votes: Votes

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -38,6 +38,8 @@ es:
       total_selected_investments: Propuestas en la fase final
       total_unfeasible_investments: Propuestas inviables
       total_participants_support_phase: Fase de apoyos
+      total_participants_web: Participantes web en votación final
+      total_participants_booths: Participantes en urnas votación final
       participants: Participantes
       supports: Apoyos
       votes: Votos

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+feature 'Stats' do
+
+  let(:budget)  { create(:budget) }
+  let(:group)   { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group, price: 1000) }
+
+  describe "Show" do
+
+    it "is not accessible to normal users if phase is not 'finished'" do
+      budget.update(phase: 'reviewing_ballots')
+
+      visit budget_stats_path(budget.id)
+      expect(page).to have_content "You do not have permission to carry out the action "\
+                                   "'read_stats' on budget."
+    end
+
+    it "is accessible to normal users if phase is 'finished'" do
+      budget.update(phase: 'finished')
+
+      visit budget_stats_path(budget.id)
+      expect(page).to have_content "Stats"
+    end
+
+    it "is accessible to administrators when budget has phase 'reviewing_ballots'" do
+      budget.update(phase: 'reviewing_ballots')
+
+      login_as(create(:administrator).user)
+
+      visit budget_stats_path(budget.id)
+      expect(page).to have_content "Stats"
+    end
+
+  end
+
+end

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -68,6 +68,22 @@ describe Budget::Stats do
 
   end
 
+  context "#total_participants_web" do
+
+    it "returns the number of total participants in the votes phase via web" do
+      expect(@stats[:total_participants_web]).to be 3
+    end
+
+  end
+
+  context "#total_participants_booths" do
+
+    it "returns the number of total participants in the votes phase in booths" do
+      expect(@stats[:total_participants_booths]).to be 1
+    end
+
+  end
+
   context "#total_budget_investments" do
 
     it "returns the number of total budget investments" do


### PR DESCRIPTION
References
===================
Related issue: #1547 
Related issue: #1548 

Objectives
===================
This PR achieves the issues above.

- Normal users can see a budget stats in its "finished" phase, and admins in "reviewing_ballots" and "finished" phases.
- Added new stats data related to participation in the vote phase in web and booths.
