### PR TITLE
Add permissions for admins and normal users to access budget results

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -65,7 +65,7 @@ module Abilities
       can [:hide, :update, :toggle_selection], Budget::Investment
       can [:valuate, :comment_valuation], Budget::Investment
       can :create, Budget::ValuatorAssignment
-      can :read_stats, Budget, phase: "reviewing_ballots"
+      can [:read_results, :read_stats], Budget, phase: "reviewing_ballots"
 
       can [:search, :edit, :update, :create, :index, :destroy], Banner
 

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -25,8 +25,7 @@ module Abilities
       can [:read], Budget
       can [:read], Budget::Group
       can [:read, :print, :json_data], Budget::Investment
-      can :read_results, Budget, phase: "finished"
-      can :read_stats, Budget, phase: "finished"
+      can [:read_results, :read_stats], Budget, phase: "finished"
       can :new, DirectMessage
       can [:read, :debate, :draft_publication, :allegations, :result_publication, :proposals], Legislation::Process, published: true
       can [:read, :changes, :go_to_version], Legislation::DraftVersion


### PR DESCRIPTION
References
===================
Related issue https://github.com/AyuntamientoMadrid/consul/issues/1556

Objectives
===================
Normal users can see budget results in its "finished" phase, and admins in both "reviewing_ballots" and "finished" phases.