### PR TITLE
Adds Sluggable concern to Poll model

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -6,6 +6,7 @@ class Poll < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
   include Notifiable
+  include Sluggable
 
   RECOUNT_DURATION = 1.week
 
@@ -136,6 +137,10 @@ class Poll < ActiveRecord::Base
 
   def budget_poll?
     budget.present?
+  end
+
+  def generate_slug?
+    slug.nil?
   end
 
 end

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -70,6 +70,7 @@ feature 'Admin polls' do
     expect(page).to have_content "Upcoming poll"
     expect(page).to have_content I18n.l(start_date.to_date)
     expect(page).to have_content I18n.l(end_date.to_date)
+    expect(Poll.last.slug).to eq "#{Poll.last.name.to_s.parameterize}"
   end
 
   scenario "Edit" do


### PR DESCRIPTION
References
===================
Related issue #1559 

Objectives
===================
Add the Sluggable concern to Poll model to generate a slug when the Poll is created or updated.
