### PR TITLE
Adjustments for user recommendations

### DIFF
--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -50,6 +50,14 @@ class DebatesController < ApplicationController
     @resources = @resources.not_probe
   end
 
+  def disable_recommendations
+    if current_user.update(recommended_debates: false)
+      redirect_to debates_path, notice: t('debates.index.recommendations.actions.success')
+    else
+      redirect_to debates_path, error: t('debates.index.recommendations.actions.error')
+    end
+  end
+
   private
 
     def debate_params

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -73,8 +73,9 @@ class DebatesController < ApplicationController
     end
 
     def debates_recommendations
-      return unless current_user.recommended_debates
-      @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
+      if Setting['feature.user.recommendations_on_debates'] && current_user.recommended_debates
+        @recommended_debates = Debate.recommendations(current_user).sort_by_random.limit(3)
+      end
     end
 
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -92,6 +92,14 @@ class ProposalsController < ApplicationController
     @resource.sub_proceeding = params[:sub_proceeding]
   end
 
+  def disable_recommendations
+    if current_user.update(recommended_proposals: false)
+      redirect_to proposals_path, notice: t('proposals.index.recommendations.actions.success')
+    else
+      redirect_to proposals_path, error: t('proposals.index.recommendations.actions.error')
+    end
+  end
+
   private
 
     def proposal_params

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -182,7 +182,9 @@ class ProposalsController < ApplicationController
     end
 
     def proposals_recommendations
-      return unless current_user.recommended_proposals
-      @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
+      if Setting['feature.user.recommendations_on_proposals'] && current_user.recommended_proposals
+        @recommended_proposals = Proposal.recommendations(current_user).sort_by_random.limit(3)
+      end
     end
+
 end

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -115,6 +115,8 @@ module Abilities
 
       can [:create], Topic
       can [:update, :destroy], Topic, author_id: user.id
+
+      can :disable_recommendations, [Debate, Proposal]
     end
   end
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -35,7 +35,6 @@ module Abilities
       can :results_2017, Poll
       can :stats_2017, Poll
       can :info_2017, Poll
-      can :disable_recommendations, [Debate, Proposal]
     end
   end
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -35,6 +35,7 @@ module Abilities
       can :results_2017, Poll
       can :stats_2017, Poll
       can :info_2017, Poll
+      can :disable_recommendations, [Debate, Proposal]
     end
   end
 end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -156,7 +156,7 @@ class Debate < ActiveRecord::Base
 
   def self.debates_orders(user)
     orders = %w{hot_score confidence_score created_at relevance}
-    orders << "recommendations" if user&.recommended_debates
+    orders << "recommendations" if Setting['feature.user.recommendations_on_debates'] && user&.recommended_debates
     return orders
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -232,7 +232,7 @@ class Proposal < ActiveRecord::Base
 
   def self.proposals_orders(user)
     orders = %w{hot_score confidence_score created_at relevance archival_date}
-    orders << "recommendations" if user&.recommended_proposals
+    orders << "recommendations" if Setting['feature.user.recommendations_on_proposals'] && user&.recommended_proposals
     return orders
   end
 

--- a/app/views/custom/debates/index.html.erb
+++ b/app/views/custom/debates/index.html.erb
@@ -38,7 +38,7 @@
     <%= render "shared/section_header", i18n_namespace: "debates.index.section_header", image: "debates" %>
   <% end %>
 
-  <% if @recommended_debates.present? %>
+  <% if feature?('user.recommendations') && @recommended_debates.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_debates,
                                            disable_recommendations_path: recommendations_disable_debates_path,
                                            namespace: "debates" %>

--- a/app/views/custom/debates/index.html.erb
+++ b/app/views/custom/debates/index.html.erb
@@ -39,7 +39,9 @@
   <% end %>
 
   <% if @recommended_debates.present? %>
-    <%= render "shared/recommended_index", recommended: @recommended_debates %>
+    <%= render "shared/recommended_index", recommended: @recommended_debates,
+                                           disable_recommendations_path: recommendations_disable_debates_path,
+                                           namespace: "debates" %>
   <% end %>
 
   <div class="row">

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -41,7 +41,9 @@
   <% end %>
 
   <% if @recommended_proposals.present? %>
-    <%= render "shared/recommended_index", recommended: @recommended_proposals %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals,
+                                           disable_recommendations_path: recommendations_disable_proposals_path,
+                                           namespace: "proposals" %>
   <% end %>
 
   <div class="row">

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -40,7 +40,7 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
-  <% if @recommended_proposals.present? %>
+  <% if feature?('user.recommendations') && @recommended_proposals.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_proposals,
                                            disable_recommendations_path: recommendations_disable_proposals_path,
                                            namespace: "proposals" %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -35,7 +35,7 @@
     <%= render "shared/section_header", i18n_namespace: "debates.index.section_header", image: "debates" %>
   <% end %>
 
-  <% if @recommended_debates.present? %>
+  <% if feature?('user.recommendations') && @recommended_debates.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_debates,
                                            disable_recommendations_path: recommendations_disable_debates_path,
                                            namespace: "debates" %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -36,7 +36,9 @@
   <% end %>
 
   <% if @recommended_debates.present? %>
-    <%= render "shared/recommended_index", recommended: @recommended_debates %>
+    <%= render "shared/recommended_index", recommended: @recommended_debates,
+                                           disable_recommendations_path: recommendations_disable_debates_path,
+                                           namespace: "debates" %>
   <% end %>
 
   <div class="row">

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -37,7 +37,7 @@
     <%= render "shared/section_header", i18n_namespace: "proposals.index.section_header", image: "proposals" %>
   <% end %>
 
-  <% if @recommended_proposals.present? %>
+  <% if feature?('user.recommendations') && @recommended_proposals.present? %>
     <%= render "shared/recommended_index", recommended: @recommended_proposals,
                                            disable_recommendations_path: recommendations_disable_proposals_path,
                                            namespace: "proposals" %>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -38,7 +38,9 @@
   <% end %>
 
   <% if @recommended_proposals.present? %>
-    <%= render "shared/recommended_index", recommended: @recommended_proposals %>
+    <%= render "shared/recommended_index", recommended: @recommended_proposals,
+                                           disable_recommendations_path: recommendations_disable_proposals_path,
+                                           namespace: "proposals" %>
   <% end %>
 
   <div class="row">

--- a/app/views/shared/_recommended_index.html.erb
+++ b/app/views/shared/_recommended_index.html.erb
@@ -5,9 +5,13 @@
     </div>
 
     <div id="recommendations" data-toggler=".hide">
-      <%= link_to "#", title: t("shared.recommended_index.hide"),
-                       class: "float-right-medium small hide-recommendations",
-                       data: { toggle: "recommendations" } do %>
+      <%= link_to disable_recommendations_path, title: t("shared.recommended_index.hide"),
+                                                class: "float-right-medium small hide-recommendations",
+                                                data: {
+                                                  toggle: "recommendations",
+                                                  confirm: t("#{namespace}.index.recommendations.disable")
+                                                },
+                                                method: :put do %>
         <span class="icon-x"></span>
         <span class="show-for-sr"><%= t("shared.recommended_index.hide") %></span>
       <% end %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -113,6 +113,10 @@ en:
       recommendations:
         without_results: There are not debates related to your interests
         without_interests: Follow proposals so we can give you recommendations
+        disable: "If you dismiss debates recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        actions:
+          success: "Recommendations for debates are now disabled for this account"
+          error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for debates"
       search_form:
         button: Search
         placeholder: Search debates...
@@ -358,6 +362,10 @@ en:
       recommendations:
         without_results: There are not proposals related to your interests
         without_interests: Follow proposals so we can give you recommendations
+        disable: "If you dismiss proposals recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        actions:
+          success: "Recommendations for proposals are now disabled for this account"
+          error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for proposals"
       retired_proposals: Retired proposals
       retired_proposals_link: "Proposals retired by the author"
       retired_links:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -113,7 +113,7 @@ en:
       recommendations:
         without_results: There are not debates related to your interests
         without_interests: Follow proposals so we can give you recommendations
-        disable: "If you dismiss debates recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        disable: "Debates recommendations will stop showing if you dismiss them. You can enable them again in 'My account' page"
         actions:
           success: "Recommendations for debates are now disabled for this account"
           error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for debates"
@@ -362,7 +362,7 @@ en:
       recommendations:
         without_results: There are not proposals related to your interests
         without_interests: Follow proposals so we can give you recommendations
-        disable: "If you dismiss proposals recommendations, the setting will be automatically disabled. Do you wish to continue?"
+        disable: "Proposals recommendations will stop showing if you dismiss them. You can enable them again in 'My account' page"
         actions:
           success: "Recommendations for proposals are now disabled for this account"
           error: "An error has occured. Please go to 'Your account' page to manually disable recommendations for proposals"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -53,8 +53,8 @@ en:
       user:
         recommendations: Recommendations
         skip_verification: Skip user verification
-        recommendations_on_debates: Recommendeds on debates
-        recommendations_on_proposals: Recommendeds on proposals
+        recommendations_on_debates: Recommendations on debates
+        recommendations_on_proposals: Recommendations on proposals
       community: Community on proposals and investments
       map: Proposals and budget investments geolocation
       allow_images: Allow upload and show images

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -113,6 +113,10 @@ es:
       recommendations:
         without_results: No existen debates relacionados con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
+        disable: "Si ocultas las recomendaciones para debates, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        actions:
+          success: "Las recomendaciones de debates han sido desactivadas"
+          error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"
       search_form:
         button: Buscar
         placeholder: Buscar debates...
@@ -348,6 +352,10 @@ es:
       recommendations:
         without_results: No existen propuestas relacionadas con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
+        disable: "Si ocultas las recomendaciones para propuestas, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        actions:
+          success: "Las recomendaciones de propuestas han sido desactivadas"
+          error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"
       retired_proposals: Propuestas retiradas
       retired_proposals_link: "Propuestas retiradas por sus autores"
       retired_links:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -113,7 +113,7 @@ es:
       recommendations:
         without_results: No existen debates relacionados con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
-        disable: "Si ocultas las recomendaciones para debates, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        disable: "Si ocultas las recomendaciones para debates, no se volverán a mostrar. Puedes volver a activarlas en 'Mi cuenta'"
         actions:
           success: "Las recomendaciones de debates han sido desactivadas"
           error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"
@@ -352,7 +352,7 @@ es:
       recommendations:
         without_results: No existen propuestas relacionadas con tus intereses
         without_interests: Sigue propuestas para que podamos darte recomendaciones
-        disable: "Si ocultas las recomendaciones para propuestas, se desactivará automáticamente el ajuste. ¿Deseas continuar?"
+        disable: "Si ocultas las recomendaciones para propuestas, no se volverán a mostrar. Puedes volver a activarlas en 'Mi cuenta'"
         actions:
           success: "Las recomendaciones de propuestas han sido desactivadas"
           error: "Ha ocurrido un error. Por favor dirígete al apartado 'Mi cuenta' para desactivar las recomendaciones manualmente"

--- a/config/routes/debate.rb
+++ b/config/routes/debate.rb
@@ -10,5 +10,6 @@ resources :debates do
   collection do
     get :map
     get :suggest
+    put 'recommendations/disable', only: :index, controller: 'debates', action: :disable_recommendations
   end
 end

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -13,5 +13,6 @@ resources :proposals do
     get :map
     get :suggest
     get :summary
+    put 'recommendations/disable', only: :index, controller: 'proposals', action: :disable_recommendations
   end
 end

--- a/db/migrate/20180711224810_enable_recommendations_by_default.rb
+++ b/db/migrate/20180711224810_enable_recommendations_by_default.rb
@@ -1,0 +1,6 @@
+class EnableRecommendationsByDefault < ActiveRecord::Migration
+  def change
+    change_column_default :users, :recommended_debates, true
+    change_column_default :users, :recommended_proposals, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180704095538) do
+ActiveRecord::Schema.define(version: 20180711224810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1361,8 +1361,8 @@ ActiveRecord::Schema.define(version: 20180704095538) do
     t.text     "former_users_data_log",                                       default: ""
     t.integer  "balloted_heading_id"
     t.boolean  "public_interests",                                            default: false
-    t.boolean  "recommended_debates",                                         default: false
-    t.boolean  "recommended_proposals",                                       default: false
+    t.boolean  "recommended_debates",                                         default: true
+    t.boolean  "recommended_proposals",                                       default: true
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -105,4 +105,11 @@ namespace :users do
     end
   end
 
+  desc "Enable recommendations for existing users"
+  task enable_recommendations: :environment do
+    User.find_each do |user|
+      user.update(recommended_debates: true, recommended_proposals: true)
+    end
+  end
+
 end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -189,37 +189,37 @@ feature 'Account' do
       Setting['feature.user.recommendations_on_proposals'] = nil
     end
 
-    scenario 'are disabled by default' do
+    scenario 'are enabled by default' do
       visit account_path
 
       expect(page).to have_content('Recommendations')
       expect(page).to have_content('Show debates recommendations')
       expect(page).to have_content('Show proposals recommendations')
-      expect(find("#account_recommended_debates")).not_to be_checked
-      expect(find("#account_recommended_proposals")).not_to be_checked
+      expect(find("#account_recommended_debates")).to be_checked
+      expect(find("#account_recommended_proposals")).to be_checked
     end
 
-    scenario "can be enabled through 'My account' page" do
+    scenario "can be disabled through 'My account' page" do
       visit account_path
 
       expect(page).to have_content('Recommendations')
       expect(page).to have_content('Show debates recommendations')
       expect(page).to have_content('Show proposals recommendations')
-      expect(find("#account_recommended_debates")).not_to be_checked
-      expect(find("#account_recommended_proposals")).not_to be_checked
-
-      check 'account_recommended_debates'
-      check 'account_recommended_proposals'
-
-      click_button 'Save changes'
-
       expect(find("#account_recommended_debates")).to be_checked
       expect(find("#account_recommended_proposals")).to be_checked
 
+      uncheck 'account_recommended_debates'
+      uncheck 'account_recommended_proposals'
+
+      click_button 'Save changes'
+
+      expect(find("#account_recommended_debates")).not_to be_checked
+      expect(find("#account_recommended_proposals")).not_to be_checked
+
       @user.reload
 
-      expect(@user.recommended_debates).to be(true)
-      expect(@user.recommended_proposals).to be(true)
+      expect(@user.recommended_debates).to be(false)
+      expect(@user.recommended_proposals).to be(false)
     end
 
   end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -552,7 +552,7 @@ feature 'Debates' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'shown on index header are dismissable', :js do
+      scenario 'are automatically disabled when dismissed from index', :js do
         user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
@@ -566,13 +566,19 @@ feature 'Debates' do
           expect(page).to have_content('Medium')
           expect(page).to have_css('.recommendation', count: 3)
 
-          find('.icon-x').click
-
-          expect(page).not_to have_content('Best')
-          expect(page).not_to have_content('Worst')
-          expect(page).not_to have_content('Medium')
-          expect(page).not_to have_css('.recommendation', count: 3)
+          accept_confirm { click_link 'Hide recommendations' }
         end
+
+        expect(page).not_to have_link('recommendations')
+        expect(page).not_to have_css('.recommendation', count: 3)
+        expect(page).to have_content('Recommendations for debates are now disabled for this account')
+
+        user.reload
+
+        visit account_path
+
+        expect(find("#account_recommended_debates")).not_to be_checked
+        expect(user.recommended_debates).to be(false)
       end
     end
   end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -475,13 +475,13 @@ feature 'Debates' do
         Setting['feature.user.recommendations_on_debates'] = nil
       end
 
-      scenario "Debates can't be ordered by recommendations if there's no logged user" do
+      scenario "can't be sorted if there's no logged user" do
         visit debates_path
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Show recommended debates on index header when user has recommendations enabled' do
-        user     = create(:user, recommended_debates: true)
+      scenario 'are shown on index header when account setting is enabled' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -495,8 +495,8 @@ feature 'Debates' do
         expect(page).to have_link 'See more recommendations'
       end
 
-      scenario 'Should display text when there are not recommended results' do
-        user     = create(:user, recommended_debates: true)
+      scenario 'should display text when there are no results' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Distinct_to_sport')
         create(:follow, followable: proposal, user: user)
 
@@ -508,8 +508,8 @@ feature 'Debates' do
         expect(page).to have_content 'There are not debates related to your interests'
       end
 
-      scenario 'Should display text when user has not related interests' do
-        user = create(:user, recommended_debates: true)
+      scenario 'should display text when user has no related interests' do
+        user = create(:user)
 
         login_as(user)
         visit debates_path
@@ -519,8 +519,8 @@ feature 'Debates' do
         expect(page).to have_content 'Follow proposals so we can give you recommendations'
       end
 
-      scenario "Debates are ordered by recommendations when there's an user logged" do
-        user     = create(:user, recommended_debates: true)
+      scenario "can be sorted when there's a logged user" do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -540,8 +540,8 @@ feature 'Debates' do
         expect(current_url).to include('page=1')
       end
 
-      scenario 'are not shown if user does not have recommendations enabled' do
-        user     = create(:user)
+      scenario 'are not shown if account setting is disabled' do
+        user     = create(:user, recommended_debates: false)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -552,8 +552,8 @@ feature 'Debates' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'Recommendations shown in index are dismissable', :js do
-        user     = create(:user, recommended_debates: true)
+      scenario 'shown on index header are dismissable', :js do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -788,13 +788,13 @@ feature 'Proposals' do
         Setting['feature.user.recommendations_on_proposals'] = nil
       end
 
-      scenario "Proposals can't be ordered by recommendations if there's no logged user" do
+      scenario "can't be sorted if there's no logged user" do
         visit proposals_path
         expect(page).not_to have_selector('a', text: 'recommendations')
       end
 
-      scenario 'Show recommended proposals on index header when user has recommendations enabled' do
-        user     = create(:user, recommended_proposals: true)
+      scenario 'are shown on index header when account setting is enabled' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -808,8 +808,8 @@ feature 'Proposals' do
         expect(page).to have_link 'See more recommendations'
       end
 
-      scenario 'Should display text when there are not recommended results' do
-        user     = create(:user, recommended_proposals: true)
+      scenario 'should display text when there are no results' do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Distinct_to_sport')
         create(:follow, followable: proposal, user: user)
 
@@ -821,8 +821,8 @@ feature 'Proposals' do
         expect(page).to have_content 'There are not proposals related to your interests'
       end
 
-      scenario 'Should display text when user has not related interests' do
-        user = create(:user, recommended_proposals: true)
+      scenario 'should display text when user has no related interests' do
+        user = create(:user)
 
         login_as(user)
         visit proposals_path
@@ -832,8 +832,8 @@ feature 'Proposals' do
         expect(page).to have_content 'Follow proposals so we can give you recommendations'
       end
 
-      scenario "Proposals are ordered by recommendations when there's an user logged" do
-        user     = create(:user, recommended_proposals: true)
+      scenario "can be sorted when there's a logged user" do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -853,8 +853,8 @@ feature 'Proposals' do
         expect(current_url).to include('page=1')
       end
 
-      scenario 'are not shown if user does not have recommendations enabled' do
-        user     = create(:user)
+      scenario 'are not shown if account setting is disabled' do
+        user     = create(:user, recommended_proposals: false)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 
@@ -865,8 +865,8 @@ feature 'Proposals' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'Recommendations shown in index are dismissable', :js do
-        user     = create(:user, recommended_proposals: true)
+      scenario 'shown on index header are dismissable', :js do
+        user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -865,7 +865,7 @@ feature 'Proposals' do
         expect(page).not_to have_link('recommendations')
       end
 
-      scenario 'shown on index header are dismissable', :js do
+      scenario 'are automatically disabled when dismissed from index', :js do
         user     = create(:user)
         proposal = create(:proposal, tag_list: 'Sport')
         create(:follow, followable: proposal, user: user)
@@ -879,13 +879,19 @@ feature 'Proposals' do
           expect(page).to have_content('Medium')
           expect(page).to have_css('.recommendation', count: 3)
 
-          find('.icon-x').click
-
-          expect(page).not_to have_content('Best')
-          expect(page).not_to have_content('Worst')
-          expect(page).not_to have_content('Medium')
-          expect(page).not_to have_css('.recommendation', count: 3)
+          accept_confirm { click_link 'Hide recommendations' }
         end
+
+        expect(page).not_to have_link('recommendations')
+        expect(page).not_to have_css('.recommendation', count: 3)
+        expect(page).to have_content('Recommendations for proposals are now disabled for this account')
+
+        user.reload
+
+        visit account_path
+
+        expect(find("#account_recommended_proposals")).not_to be_checked
+        expect(user.recommended_proposals).to be(false)
       end
     end
   end

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -464,7 +464,6 @@ describe Abilities::Common do
     let(:spending_proposal) { create(:spending_proposal) }
     let(:own_spending_proposal) { create(:spending_proposal, author: user) }
 
-
     it { should_not be_able_to(:vote, Proposal) }
     it { should_not be_able_to(:vote_featured, Proposal) }
 
@@ -477,6 +476,11 @@ describe Abilities::Common do
 
     it { should_not be_able_to(:destroy, spending_proposal) }
     it { should_not be_able_to(:destroy, own_spending_proposal) }
+  end
+
+  describe "#disable_recommendations" do
+    it { should be_able_to(:disable_recommendations, Debate) }
+    it { should be_able_to(:disable_recommendations, Proposal) }
   end
 
 end


### PR DESCRIPTION
References
===================
* **Related PR**: #1521

Objectives
===================
Five (5) new changes are being introduced through this PR, which are:

* User settings for recommendations will be automatically disabled if recommendations are dismissed
on `debates#index` or `proposals#index`

* Recommendations are enabled by default for all users

* Fixed a bug where recommendations would show even if the settings were disabled

* Moved `disable_recommendations` permissions to `Abilities::Common` model

* Added rake task to enable recommendations to existing users

Visual Changes
===================
None

Notes
===================
* These changes will be included for the #1521 backport to CONSUL once approved and merged into `master`

Update
===
Remember to add the rake to the Notes section in the backport to CONSUL