### PR TITLE
Force public results for budget

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -55,7 +55,7 @@ class Admin::BudgetsController < Admin::BaseController
 
     def budget_params
       descriptions = Budget::Phase::PHASE_KINDS.map{|p| "description_#{p}"}.map(&:to_sym)
-      valid_attributes = [:name, :phase, :currency_symbol] + descriptions
+      valid_attributes = [:name, :phase, :currency_symbol, :force_public] + descriptions
       params.require(:budget).permit(*valid_attributes)
     end
 

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -57,7 +57,7 @@ module BudgetsHelper
   end
 
   def budget_published?(budget)
-    !budget.drafting? || current_user&.administrator?
+    budget.force_public || !budget.drafting? || current_user&.administrator?
   end
 
   def display_support_alert?(investment)
@@ -100,4 +100,9 @@ module BudgetsHelper
                               ends_at:   balloting_phase.ends_at }),
             method: :post
   end
+
+  def show_the_stats_link?(budget, bool)
+    bool || budget.force_public
+  end
+
 end

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -25,7 +25,10 @@ module Abilities
       can [:read], Budget
       can [:read], Budget::Group
       can [:read, :print, :json_data], Budget::Investment
-      can [:read_results, :read_stats, :read_executions], Budget, phase: "finished"
+      can [:read_executions], Budget, phase: "finished"
+      can [:read_results, :read_stats], Budget do |budget|
+        budget.force_public || budget.phase == "finished"
+      end
       can :new, DirectMessage
       can [:read, :debate, :draft_publication, :allegations, :result_publication, :proposals], Legislation::Process, published: true
       can [:read, :changes, :go_to_version], Legislation::DraftVersion

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -11,6 +11,9 @@
     <div class="small-12 medium-3 column end">
       <%= f.select :currency_symbol, budget_currency_symbol_select_options %>
     </div>
+    <div class="small-12 medium-3 column">
+      <%= f.check_box :force_public %>
+    </div>
   </div>
 
   <% if @budget.phases.present? %>
@@ -69,7 +72,7 @@
                     class: "button hollow" %>
       <% end %>
 
-      <% if @budget.has_winning_investments? %>
+      <% if show_the_stats_link?(@budget, @budget.has_winning_investments? ) %>
         <%= link_to t("budgets.show.see_results"),
                     custom_budget_results_path(@budget),
                     class: "button hollow margin-left" %>

--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -17,6 +17,7 @@
       <th><%= t("admin.budgets.index.table_edit_groups") %></th>
       <th><%= t("admin.budgets.index.table_edit_budget") %></th>
       <th><%= t("admin.budgets.index.table_admin_ballots") %></th>
+      <th><%= t("admin.budgets.index.table_force_public") %></th>
     </tr>
   </thead>
   <tbody>
@@ -45,6 +46,10 @@
           <% else %>
             <%= link_to_create_budget_poll(budget) %>
           <% end %>
+        </td>
+        </td>
+        <td class="small">
+          <%= budget.force_public ? t("shared.yes") : t("shared.no") %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/budgets/show.html.erb
+++ b/app/views/admin/budgets/show.html.erb
@@ -1,6 +1,7 @@
 <%= back_link_to admin_budgets_path %>
 
 <h2><%= @budget.name %></h2>
+<h4><%= "#{t("admin.budgets.index.table_force_public")}: #{@budget.force_public ? t("shared.yes") : t("shared.no")}" %> </h4>
 
 <div id="<%= dom_id @budget %>_groups">
   <%= render "groups", groups: @budget.groups.order(:id) %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -53,7 +53,7 @@
             <% end %>
           <% end %>
 
-        <% if current_budget.finished? %>
+        <% if show_the_stats_link?(current_budget, current_budget.finished?) %>
           <%= link_to t("budgets.show.see_results"),
                       budget_results_path(current_budget, heading_id: current_budget.headings.first),
                       class: "button margin-top expanded" %>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -41,7 +41,7 @@
         <% end %>
       <% end %>
 
-      <% if @budget.finished? %>
+      <% if show_the_stats_link?(@budget, @budget.finished?) %>
         <%= link_to t("budgets.show.see_results"),
                   custom_budget_results_path(@budget),
                   class: "button margin-top expanded" %>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -61,8 +61,7 @@
             <% end %>
           <% end %>
 
-
-        <% if current_budget.finished? %>
+        <% if show_the_stats_link?(current_budget, current_budget.finished?) %>
           <%= link_to t("budgets.show.see_results"),
                       custom_budget_results_path(current_budget),
                       class: "button margin-top expanded" %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -121,6 +121,7 @@ en:
         description_finished: "Description when the budget is finished"
         phase: "Phase"
         currency_symbol: "Currency"
+        force_public: "Force public"
       budget/investment:
         heading_id: "Heading"
         title: "Title"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -86,6 +86,7 @@ en:
         table_edit_groups: Headings groups
         table_edit_budget: Edit
         table_admin_ballots: Ballots
+        table_force_public: Forced publication
         edit_groups: Edit headings groups
         edit_budget: Edit budget
         admin_ballots: Admin ballots

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -121,6 +121,7 @@ es:
         description_finished: "Descripción cuando el presupuesto ha finalizado / Resultados"
         phase: "Fase"
         currency_symbol: "Divisa"
+        force_public: "Forzar publicación"
       budget/investment:
         heading_id: "Partida presupuestaria"
         title: "Título"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -86,6 +86,7 @@ es:
         table_edit_groups: Grupos de partidas
         table_edit_budget: Editar
         table_admin_ballots: Urnas
+        table_force_public: Publicacion forzada
         edit_groups: Editar grupos de partidas
         edit_budget: Editar presupuesto
         admin_ballots: Gestionar urnas

--- a/db/migrate/20180710123526_force_public_buget_mark.rb
+++ b/db/migrate/20180710123526_force_public_buget_mark.rb
@@ -1,0 +1,5 @@
+class ForcePublicBugetMark < ActiveRecord::Migration
+  def change
+    add_column :budgets, :force_public, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -342,6 +342,7 @@ ActiveRecord::Schema.define(version: 20180727140800) do
     t.text     "description_drafting"
     t.text     "description_publishing_prices"
     t.text     "description_informing"
+    t.boolean  "force_public"
   end
 
   create_table "campaigns", force: :cascade do |t|

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -87,6 +87,13 @@ feature 'Budgets' do
 
       expect(page).to have_content "There are no budgets"
     end
+
+    scenario "See results button appears for forced budgets" do
+      create(:budget, force_public: true)
+
+      visit budgets_path
+      expect(page).to have_content "See results"
+    end
   end
 
   scenario 'Index shows only published phases' do
@@ -407,6 +414,22 @@ feature 'Budgets' do
       within("#finished_budgets") do
         expect(page).to have_link('See results', href: "/presupuestos/#{budget.slug}/resultados")
       end
+    end
+
+    scenario "See results button appears for forced budget" do
+      user = create(:user)
+      admin = create(:administrator)
+      budget = create(:budget, force_public: true)
+
+      login_as(user)
+      visit budget_path(budget)
+      expect(page).to have_link "See results"
+
+      logout
+
+      login_as(admin.user)
+      visit budget_path(budget)
+      expect(page).to have_link "See results"
     end
 
   end

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -10,6 +10,7 @@ describe Abilities::Everyone do
 
   let(:reviewing_ballot_budget) { create(:budget, phase: 'reviewing_ballots') }
   let(:finished_budget) { create(:budget, phase: 'finished') }
+  let(:forced_budget) { create(:budget, force_public: true) }
 
   it { should be_able_to(:index, Debate) }
   it { should be_able_to(:show, debate) }
@@ -49,4 +50,8 @@ describe Abilities::Everyone do
 
   it { should be_able_to(:read_results, finished_budget) }
   it { should_not be_able_to(:read_results, reviewing_ballot_budget) }
+
+  it { should be_able_to(:read_results, forced_budget) }
+  it { should be_able_to(:read_stats, forced_budget) }
+
 end


### PR DESCRIPTION
References
===================
https://github.com/AyuntamientoMadrid/consul/issues/1550

Objectives
===================
Add a checkbox that allows you to publish the statistics and the results of a budget ignoring the phase of it

Visual Changes
===================
- admin/index
![captura de pantalla de 2018-07-12 09-57-00](https://user-images.githubusercontent.com/33748390/42620460-4951e202-85bb-11e8-9eec-1650b97e3323.png)

-admin/edit
![captura de pantalla de 2018-07-12 09-57-15](https://user-images.githubusercontent.com/33748390/42620462-4976b4c4-85bb-11e8-9a9b-35b373534338.png)

-admin/show
![captura de pantalla de 2018-07-12 10-05-15](https://user-images.githubusercontent.com/33748390/42620463-49947e28-85bb-11e8-9fd9-c4cffc573dc0.png)


Notes
===================
none
