### PR TITLE
Replace `.all.each` with `.find_each` to reduce memory usage

### DIFF
--- a/app/views/pages/plaza_espana/_preselection.html.erb
+++ b/app/views/pages/plaza_espana/_preselection.html.erb
@@ -250,7 +250,7 @@
     </div>
 
     <map name="map_preselection" id="html_map_preselection">
-      <% Geozone.all.each do |geozone| %>
+      <% Geozone.find_each do |geozone| %>
         <area shape="poly"
               coords="<%= geozone.html_map_coordinates %>"
               href="#<%= geozone.name.parameterize %>-preselection"

--- a/app/views/pages/plaza_espana/_stats.html.erb
+++ b/app/views/pages/plaza_espana/_stats.html.erb
@@ -226,7 +226,7 @@
     </div>
 
     <map name="html_map" id="html_map">
-      <% Geozone.all.each do |geozone| %>
+      <% Geozone.find_each do |geozone| %>
         <area shape="poly"
               coords="<%= geozone.html_map_coordinates %>"
               href="#<%= geozone.name.parameterize %>"

--- a/app/views/pages/plaza_espana/_survey.html.erb
+++ b/app/views/pages/plaza_espana/_survey.html.erb
@@ -175,7 +175,7 @@
     </div>
 
     <map name="map_survey" id="html_map_survey">
-      <% Geozone.all.each do |geozone| %>
+      <% Geozone.find_each do |geozone| %>
         <area shape="poly"
               coords="<%= geozone.html_map_coordinates %>"
               href="#<%= geozone.name.parameterize %>-survey"

--- a/app/views/polls/stats_2018/_districts.html.erb
+++ b/app/views/polls/stats_2018/_districts.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <map name="html_map" id="html_map">
-  <% Geozone.all.each do |geozone| %>
+  <% Geozone.find_each do |geozone| %>
     <area shape="poly"
           coords="<%= geozone.html_map_coordinates %>"
           href="#<%= geozone.name.parameterize %>"

--- a/app/views/welcome/_cards.html.erb
+++ b/app/views/welcome/_cards.html.erb
@@ -1,7 +1,7 @@
 <h3 class="title"><%= t("welcome.cards.title") %></h3>
 
 <div class="row" data-equalizer data-equalizer-on="medium">
-  <% @cards.all.each do |card| %>
+  <% @cards.find_each do |card| %>
     <%= render "card", card: card %>
   <% end %>
 </div>

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -94,7 +94,7 @@ section "Marking investments as visible to valuators" do
 end
 
 section "Geolocating Investments" do
-  Budget.all.each do |budget|
+  Budget.find_each do |budget|
     budget.investments.each do |investment|
       MapLocation.create(latitude: Setting['map_latitude'].to_f + rand(-10..10)/100.to_f,
                          longitude: Setting['map_longitude'].to_f + rand(-10..10)/100.to_f,
@@ -191,7 +191,7 @@ section "Creating default Investment Milestone Statuses" do
 end
 
 section "Creating investment milestones" do
-  Budget::Investment.all.each do |investment|
+  Budget::Investment.find_each do |investment|
     milestone = Budget::Investment::Milestone.new(investment_id: investment.id, publication_date: Date.tomorrow, status_id: Budget::Investment::Status.all.sample)
     I18n.available_locales.map do |locale|
       neutral_locale = locale.to_s.downcase.underscore.to_sym

--- a/db/dev_seeds/communities.rb
+++ b/db/dev_seeds/communities.rb
@@ -1,10 +1,10 @@
 section "Creating Communities" do
-  Proposal.all.each { |proposal| proposal.update(community: Community.create) }
-  Budget::Investment.all.each { |investment| investment.update(community: Community.create) }
+  Proposal.find_each { |proposal| proposal.update(community: Community.create) }
+  Budget::Investment.find_each { |investment| investment.update(community: Community.create) }
 end
 
 section "Creating Communities Topics" do
-  Community.all.each do |community|
+  Community.find_each do |community|
     Topic.create(community: community, author: User.all.sample,
                  title: Faker::Lorem.sentence(3).truncate(60), description: Faker::Lorem.sentence)
   end

--- a/db/dev_seeds/legislation_processes.rb
+++ b/db/dev_seeds/legislation_processes.rb
@@ -22,7 +22,7 @@ section "Creating legislation processes" do
                                  published: true)
   end
 
-  Legislation::Process.all.each do |process|
+  Legislation::Process.find_each do |process|
     (1..3).each do |i|
       process.draft_versions.create!(title: "Version #{i}",
                                      body: Faker::Lorem.paragraphs.join("\n\n"))

--- a/db/dev_seeds/notifications.rb
+++ b/db/dev_seeds/notifications.rb
@@ -1,5 +1,5 @@
 section "Creating comment notifications" do
-  User.all.each do |user|
+  User.find_each do |user|
     debate = Debate.create!(author: user,
                             title: Faker::Lorem.sentence(3).truncate(60),
                             description: "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>",

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -37,7 +37,7 @@ section "Creating polls" do
 end
 
 section "Creating Poll Questions & Answers" do
-  Poll.all.each do |poll|
+  Poll.find_each do |poll|
     (1..4).to_a.sample.times do
       question = Poll::Question.create!(author: User.all.sample,
                                         title: Faker::Lorem.sentence(3).truncate(60) + '?',
@@ -61,10 +61,10 @@ section "Creating Poll Booths & BoothAssignments" do
 end
 
 section "Creating Poll Shifts for Poll Officers" do
-  Poll.all.each do |poll|
+  Poll.find_each do |poll|
     Poll::BoothAssignment.where(poll: poll).each do |booth_assignment|
       scrutiny = (poll.ends_at.to_datetime..poll.ends_at.to_datetime + Poll::RECOUNT_DURATION)
-      Poll::Officer.all.each do |poll_officer|
+      Poll::Officer.find_each do |poll_officer|
         {
           vote_collection: (poll.starts_at.to_datetime..poll.ends_at.to_datetime),
           recount_scrutiny: scrutiny
@@ -136,7 +136,7 @@ section "Creating Poll Voters" do
 end
 
 section "Creating Poll Recounts" do
-  Poll.all.each do |poll|
+  Poll.find_each do |poll|
     poll.booth_assignments.each do |booth_assignment|
       officer_assignment = poll.officer_assignments.first
       author = Poll::Officer.first.user
@@ -154,7 +154,7 @@ section "Creating Poll Recounts" do
 end
 
 section "Creating Poll Results" do
-  Poll.all.each do |poll|
+  Poll.find_each do |poll|
     poll.booth_assignments.each do |booth_assignment|
       officer_assignment = poll.officer_assignments.first
       author = Poll::Officer.first.user

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -33,7 +33,7 @@ namespace :budgets do
     require 'csv'
 
     csv_string = CSV.generate(col_sep: "^", row_sep: "*****") do |csv|
-      BudgetPoll.all.each do |budget_poll|
+      BudgetPoll.find_each do |budget_poll|
         csv << [
           budget_poll.name,
           budget_poll.email,

--- a/lib/tasks/polls.rake
+++ b/lib/tasks/polls.rake
@@ -205,7 +205,7 @@ namespace :polls do
 
   desc "Create Poll Question Answer for each Poll Question still with valid_answers values"
     task migrate_poll_question_valid_answers: :environment do
-      Poll::Question.all.each do |question|
+      Poll::Question.find_each do |question|
         valid_answers = question.valid_answers&.try(:split, ',')
         next unless valid_answers.present?
         valid_answers.each do |valid_answer|

--- a/lib/tasks/slugs.rake
+++ b/lib/tasks/slugs.rake
@@ -2,7 +2,7 @@ namespace :slugs do
   desc "Generate slug attribute for objects from classes that use Sluggable concern"
   task generate: :environment do
     %w(Budget Budget::Heading Budget::Group).each do |class_name|
-      class_name.constantize.all.each(&:generate_slug)
+      class_name.constantize.find_each(&:generate_slug)
     end
   end
 end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -3,7 +3,7 @@ namespace :spending_proposals do
   task migrate_to_budgets: :environment do
     puts "We have #{SpendingProposal.count} spending proposals"
     puts "Migrating!!..."
-    SpendingProposal.all.each { |sp| MigrateSpendingProposalsToInvestments.new.import(sp) }
+    SpendingProposal.find_each { |sp| MigrateSpendingProposalsToInvestments.new.import(sp) }
     puts "And now we've got #{Budget.where(name: '2016').first.investments.count} budgets"
   end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -2,7 +2,7 @@ namespace :users do
 
   desc "Recalculates all the failed census calls counters for users"
   task count_failed_census_calls: :environment do
-    User.find_each{ |user| User.reset_counters(user.id, :failed_census_calls)}
+    User.find_each { |user| User.reset_counters(user.id, :failed_census_calls) }
   end
 
   desc "Assigns official level to users with the officials' email domain"
@@ -100,7 +100,7 @@ namespace :users do
 
   desc "Update password changed at for existing users"
   task update_password_changed_at: :environment do
-    User.all.each do |user|
+    User.find_each do |user|
       user.update(password_changed_at: user.created_at)
     end
   end

--- a/spec/features/admin/admin_notifications_spec.rb
+++ b/spec/features/admin/admin_notifications_spec.rb
@@ -199,7 +199,7 @@ feature "Admin Notifications" do
 
       expect(page).to have_content "Notification sent successfully"
 
-      User.all.each do |user|
+      User.find_each do |user|
         expect(user.notifications.count).to eq(1)
       end
     end

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -41,7 +41,7 @@ feature "Admin newsletter emails" do
 
       expect(page).to have_css(".newsletter", count: 3)
 
-      Newsletter.all.each do |newsletter|
+      Newsletter.find_each do |newsletter|
         segment_recipient = I18n.t("admin.segment_recipient.#{newsletter.segment_recipient}")
         within("#newsletter_#{newsletter.id}") do
           expect(page).to have_content newsletter.subject

--- a/spec/features/admin/signature_sheets_spec.rb
+++ b/spec/features/admin/signature_sheets_spec.rb
@@ -15,7 +15,7 @@ feature 'Signature sheets' do
 
       expect(page).to have_css(".signature_sheet", count: 3)
 
-      SignatureSheet.all.each do |signature_sheet|
+      SignatureSheet.find_each do |signature_sheet|
         expect(page).to have_content signature_sheet.name
       end
     end

--- a/spec/features/admin/spending_proposals_spec.rb
+++ b/spec/features/admin/spending_proposals_spec.rb
@@ -623,7 +623,7 @@ feature 'Admin spending proposals' do
       proposal5 = create(:spending_proposal, geozone: new_york,   valuation_finished: false)
 
       valuator = create(:valuator, user: create(:user, username: 'Olga'))
-      SpendingProposal.all.each do |sp|
+      SpendingProposal.find_each do |sp|
         sp.valuators << valuator
       end
 

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -119,7 +119,7 @@ feature 'Stats' do
       create(:spending_proposal, :feasible, geozone: california)
       create(:spending_proposal, :feasible, geozone: nil)
 
-      SpendingProposal.all.each do |spending_proposal|
+      SpendingProposal.find_each do |spending_proposal|
         create(:ballot, spending_proposals: [spending_proposal], geozone: spending_proposal.geozone)
       end
 
@@ -222,7 +222,7 @@ feature 'Stats' do
         carabanchel_investment = create(:budget_investment, heading: carabanchel)
         carabanchel_investment = create(:budget_investment, heading: carabanchel)
 
-        Budget::Investment.all.each do |investment|
+        Budget::Investment.find_each do |investment|
           create(:vote, votable: investment)
         end
 
@@ -430,7 +430,7 @@ feature 'Stats' do
 
       expect(page).to have_css(".proposal_notification", count: 3)
 
-      ProposalNotification.all.each do |proposal_notification|
+      ProposalNotification.find_each do |proposal_notification|
         expect(page).to have_content proposal_notification.title
         expect(page).to have_content proposal_notification.body
       end


### PR DESCRIPTION
References
===================
* None

Objectives
===================
* As per [this section](http://guides.rubyonrails.org/v4.2/active_record_querying.html#retrieving-multiple-objects-in-batches) in the Ruby on Rails documentation, the usage of `.all.each` over an ActiveRecord model might exceed the amount of memory available if said model is associated with a table with a considerable amount of records. Thus, it has been replaced where possible with `.find_each`, which has considerable performance gains

Visual Changes
===================
* None

Notes
===================
* Backport to CONSUL once approved and merged into `master`