### PR TITLE
Admin settings

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -46,6 +46,10 @@ $sidebar-active: #f4fcd0;
 
   .top-links {
     background: #000;
+
+    a {
+      line-height: rem-calc($line-height * 1.5);
+    }
   }
 
   .admin-top-bar {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -194,6 +194,11 @@ $sidebar-active: #f4fcd0;
 
     &.with-button {
       line-height: $line-height * 2;
+
+      .button {
+        background: #fff;
+        color: $brand;
+      }
     }
   }
 
@@ -212,6 +217,19 @@ $sidebar-active: #f4fcd0;
 
   table {
 
+    thead {
+      color: #fff;
+    }
+
+    th {
+      background: $brand;
+      color: #fff;
+
+      label {
+        color: #fff;
+      }
+    }
+
     .break {
       word-break: break-word;
     }
@@ -228,7 +246,6 @@ $sidebar-active: #f4fcd0;
 
       @include breakpoint(medium) {
         margin-left: $line-height / 2;
-        margin-right: $line-height / 2;
         margin-top: 0;
       }
     }
@@ -341,6 +358,14 @@ $sidebar-active: #f4fcd0;
 
 .no-margin-bottom {
   margin-bottom: 0 !important;
+}
+
+.enabled {
+  color: $color-success;
+}
+
+.disabled {
+  color: $text-medium;
 }
 
 // 02. Sidebar
@@ -1161,11 +1186,6 @@ $sidebar-active: #f4fcd0;
       content: '\76';
     }
   }
-}
-
-.current-of-max-headings {
-  color: #000;
-  font-weight: bold;
 }
 
 // 11. Newsletters

--- a/app/views/admin/admin_notifications/index.html.erb
+++ b/app/views/admin/admin_notifications/index.html.erb
@@ -9,7 +9,7 @@
         <th><%= t("admin.admin_notifications.index.title") %></th>
         <th><%= t("admin.admin_notifications.index.segment_recipient") %></th>
         <th><%= t("admin.admin_notifications.index.sent") %></th>
-        <th class="small-5 text-right"><%= t("admin.admin_notifications.index.actions") %></th>
+        <th class="small-5"><%= t("admin.admin_notifications.index.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -28,21 +28,29 @@
             <%= l admin_notification.sent_at.to_date %>
           <% end %>
         </td>
-        <td class="text-right">
+        <td>
           <% if admin_notification.draft? %>
-            <%= link_to t("admin.admin_notifications.index.edit"),
-                        edit_admin_admin_notification_path(admin_notification),
-                        method: :get, class: "button hollow" %>
-            <%= link_to t("admin.admin_notifications.index.delete"),
-                        admin_admin_notification_path(admin_notification),
-                        method: :delete, class: "button hollow alert" %>
-            <%= link_to t("admin.admin_notifications.index.preview"),
-                        admin_admin_notification_path(admin_notification),
-                        class: "button" %>
+            <div class="small-4 column">
+              <%= link_to t("admin.admin_notifications.index.edit"),
+                          edit_admin_admin_notification_path(admin_notification),
+                          method: :get, class: "button expanded hollow" %>
+            </div>
+            <div class="small-4 column">
+              <%= link_to t("admin.admin_notifications.index.delete"),
+                          admin_admin_notification_path(admin_notification),
+                          method: :delete, class: "button expanded hollow alert" %>
+            </div>
+            <div class="small-4 column">
+              <%= link_to t("admin.admin_notifications.index.preview"),
+                          admin_admin_notification_path(admin_notification),
+                          class: "button expanded" %>
+            </div>
           <% else %>
-            <%= link_to t("admin.admin_notifications.index.view"),
-                        admin_admin_notification_path(admin_notification),
-                        class: "button" %>
+            <div class="small-4 column">
+              <%= link_to t("admin.admin_notifications.index.view"),
+                          admin_admin_notification_path(admin_notification),
+                          class: "button expanded" %>
+            </div>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/admin_notifications/show.html.erb
+++ b/app/views/admin/admin_notifications/show.html.erb
@@ -2,76 +2,74 @@
 
 <h2><%= t("admin.admin_notifications.show.section_title") %></h2>
 
-<div class="small-12 column">
-  <div class="callout highlight">
-    <div class="row">
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.admin_notifications.show.sent_at") %></strong><br>
-        <% if @admin_notification.draft? %>
-          <%= t("admin.admin_notifications.index.draft") %>
-        <% else %>
-          <%= l(@admin_notification.sent_at.to_date) %>
-        <% end %>
-      </div>
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.admin_notifications.show.title") %></strong><br>
-        <%= @admin_notification.title %>
-      </div>
-    </div>
-    <div class="row">
-
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.admin_notifications.show.body") %></strong><br>
-        <%= @admin_notification.body %>
-      </div>
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.admin_notifications.show.link") %></strong><br>
-        <%= @admin_notification.link %>
-      </div>
-    </div>
-    <div class="row">
-      <div class="small-12 column">
-          <strong><%= t("admin.admin_notifications.show.segment_recipient") %></strong><br>
-        <%= segment_name(@admin_notification.segment_recipient) %>
-        <% if @admin_notification.draft? %>
-          <%= t("admin.admin_notifications.show.will_get_notified",
-                n: @admin_notification.list_of_recipients_count) %>
-        <% else %>
-          <%= t("admin.admin_notifications.show.got_notified",
-                n: @admin_notification.recipients_count) %>
-        <% end %>
-      </div>
-    </div>
-  </div>
-
-  <p class="help-text" id="phase-description-help-text">
+<div class="small-12 column callout highlight">
+  <div class="small-12 medium-6 column">
+    <strong><%= t("admin.admin_notifications.show.sent_at") %></strong><br>
     <% if @admin_notification.draft? %>
-      <%= t("admin.admin_notifications.show.preview_guide") %>
+      <%= t("admin.admin_notifications.index.draft") %>
     <% else %>
-      <%= t("admin.admin_notifications.show.sent_guide") %>
+      <%= l(@admin_notification.sent_at.to_date) %>
     <% end %>
-  </p>
-  <hr>
-  <div class="admin_notification-body-content">
-    <ul class="no-bullet clear notifications-list">
-      <li class="notification unread">
-        <% locals = { notification: nil,
-                      title: @admin_notification.title,
-                      body: @admin_notification.body,
-                      timestamp: Time.current } %>
-        <% link_text = render partial: '/notifications/notification_body', locals: locals %>
-        <%= link_to_if @admin_notification.link.present?, link_text, @admin_notification.link %>
-      </li>
-    </ul>
   </div>
-  <hr>
+
+  <div class="small-12 medium-6 column">
+    <strong><%= t("admin.admin_notifications.show.title") %></strong><br>
+    <%= @admin_notification.title %>
+  </div>
+
+  <div class="small-12 medium-6 column">
+    <strong><%= t("admin.admin_notifications.show.body") %></strong><br>
+    <%= @admin_notification.body %>
+  </div>
+
+  <div class="small-12 medium-6 column">
+    <strong><%= t("admin.admin_notifications.show.link") %></strong><br>
+    <%= @admin_notification.link %>
+  </div>
+
+  <div class="small-12 column">
+      <strong><%= t("admin.admin_notifications.show.segment_recipient") %></strong><br>
+    <%= segment_name(@admin_notification.segment_recipient) %>
+    <% if @admin_notification.draft? %>
+      <%= t("admin.admin_notifications.show.will_get_notified",
+            n: @admin_notification.list_of_recipients_count) %>
+    <% else %>
+      <%= t("admin.admin_notifications.show.got_notified",
+            n: @admin_notification.recipients_count) %>
+    <% end %>
+  </div>
 </div>
+
+<p class="help-text" id="phase-description-help-text">
+  <% if @admin_notification.draft? %>
+    <%= t("admin.admin_notifications.show.preview_guide") %>
+  <% else %>
+    <%= t("admin.admin_notifications.show.sent_guide") %>
+  <% end %>
+</p>
+<hr>
+<div class="admin_notification-body-content">
+  <ul class="no-bullet clear notifications-list">
+    <li class="notification unread">
+      <% locals = { notification: nil,
+                    title: @admin_notification.title,
+                    body: @admin_notification.body,
+                    timestamp: Time.current } %>
+      <% link_text = render partial: '/notifications/notification_body', locals: locals %>
+      <%= link_to_if @admin_notification.link.present?, link_text, @admin_notification.link %>
+    </li>
+  </ul>
+</div>
+<hr>
+
 <% if @admin_notification.draft? && @admin_notification.valid_segment_recipient? %>
-  <%= link_to t("admin.admin_notifications.show.send"),
-              deliver_admin_admin_notification_path(@admin_notification),
-              "data-alert": t("admin.admin_notifications.show.send_alert",
-                              n: @admin_notification.list_of_recipients_count),
-              method: :post,
-              id: "js-send-admin_notification-alert",
-              class: "button success" %>
+  <div class="small-12 medium-6 large-3 column end">
+    <%= link_to t("admin.admin_notifications.show.send"),
+                deliver_admin_admin_notification_path(@admin_notification),
+                "data-alert": t("admin.admin_notifications.show.send_alert",
+                                n: @admin_notification.list_of_recipients_count),
+                method: :post,
+                id: "js-send-admin_notification-alert",
+                class: "button success expanded" %>
+  </div>
 <% end %>

--- a/app/views/admin/banners/index.html.erb
+++ b/app/views/admin/banners/index.html.erb
@@ -1,5 +1,5 @@
 <%= link_to t("admin.banners.index.create"),
-              new_admin_banner_path, class: "button success float-right" %>
+              new_admin_banner_path, class: "button float-right" %>
 
 <h2 class="inline-block"><%= t("admin.banners.index.title") %></h2>
 
@@ -13,14 +13,14 @@
       <tr id="<%= dom_id(banner) %>">
         <th scope="col"><%= t("admin.banners.banner.post_started_at")%></th>
         <th scope="col"><%= t("admin.banners.banner.post_ended_at")%></th>
-        <th scope="col" class="text-center"><%= t("admin.actions.actions")%></th>
+        <th scope="col" class="small-4"><%= t("admin.actions.actions")%></th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td><%= banner.post_started_at %></td>
         <td><%= banner.post_ended_at %></td>
-        <td class="text-right">
+        <td>
           <div class="small-12 medium-6 column">
             <%= link_to t("admin.banners.index.edit"), edit_admin_banner_path(banner),
                         class: 'button hollow expanded' %>
@@ -33,10 +33,8 @@
         </td>
       </tr>
       <tr>
-        <th colspan="3" scope="col" class="text-center"><%= t("admin.banners.index.preview") %></th>
-      </tr>
-      <tr>
         <td colspan="3">
+          <span class="help-text"><%= t("admin.banners.index.preview") %></span>
           <div class="banner" style="background-color:<%= banner.background_color %>">
             <%= link_to banner.target_url do %>
               <h2 style="color:<%= banner.font_color %>"><%= banner.title %></h2>

--- a/app/views/admin/budget_investments/_search_form.html.erb
+++ b/app/views/admin/budget_investments/_search_form.html.erb
@@ -1,61 +1,61 @@
 <% init_advanced_menu %>
 <%= form_tag(admin_budget_budget_investments_path(budget: @budget), method: :get, enforce_utf8: false) do %>
-  <div class="row">
-    <div class="small-12 medium-8 large-12 column">
-      <%= link_to "#advanced_filters_content",
-                  data: {toggle: "advanced_filters"},
-                  class: "advanced-filters float-right clear" do %>
-        <%= t("admin.budget_investments.index.advanced_filters") %>
-      <% end %>
-    </div>
+  <div class="small-12 column">
+    <%= link_to "#advanced_filters_content",
+                data: {toggle: "advanced_filters"},
+                class: "advanced-filters float-right clear" do %>
+      <%= t("admin.budget_investments.index.advanced_filters") %>
+    <% end %>
   </div>
-  <div id="advanced_filters" class="row advanced-filters-content <%= advanced_menu_visibility %>" data-toggler=".hide">
-    <div class="small-12 medium-8 large-12 column">
-      <% ["feasible", "selected", "undecided", "unfeasible"].each do |option| %>
+
+  <div id="advanced_filters" class="<%= advanced_menu_visibility %>" data-toggler=".hide">
+    <div class="small-12 column">
+      <div class="advanced-filters-content">
+        <% ["feasible", "selected", "undecided", "unfeasible"].each do |option| %>
+          <div class="filter">
+            <%= check_box_tag "advanced_filters[]", option, params[:advanced_filters].index(option), id: "advanced_filters_#{option}" %>
+            <%= t("admin.budget_investments.index.filters.#{option}") %>
+          </div>
+        <% end %>
         <div class="filter">
-          <%= check_box_tag "advanced_filters[]", option, params[:advanced_filters].index(option), id: "advanced_filters_#{option}" %>
-          <%= t("admin.budget_investments.index.filters.#{option}") %>
+          <%= text_field_tag :min_total_supports, params["min_total_supports"], placeholder: t("admin.budget_investments.index.filters.min_total_supports") %>
         </div>
-      <% end %>
-      <div class="filter">
-        <%= text_field_tag :min_total_supports, params["min_total_supports"], placeholder: t("admin.budget_investments.index.filters.min_total_supports") %>
       </div>
     </div>
   </div>
-  <div class="row" >
-    <div class="small-12 medium-3 column">
-      <%= select_tag :administrator_id,
-                     options_for_select(admin_select_options, params[:administrator_id]),
-                     { prompt: t("admin.budget_investments.index.administrator_filter_all"),
-                       label: false} %>
-    </div>
-    <div class="small-12 medium-3 column">
-      <%= select_tag :valuator_or_group_id,
-                     options_for_select(valuator_or_group_select_options, params[:valuator_or_group_id]),
-                     { prompt: t("admin.budget_investments.index.valuator_filter_all"),
-                       label: false} %>
-    </div>
-    <div class="small-12 medium-3 column">
-      <%= select_tag :heading_id,
-                     options_for_select(budget_heading_select_options(@budget), params[:heading_id]),
-                     { prompt: t("admin.budget_investments.index.heading_filter_all"),
-                       label: false} %>
-    </div>
-    <div class="small-12 medium-3 column">
-      <%= select_tag :tag_name,
-                     options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
-                     { prompt: t("admin.budget_investments.index.tags_filter_all"),
-                       label: false} %>
+
+  <div class="small-12 medium-3 column">
+    <%= select_tag :administrator_id,
+                   options_for_select(admin_select_options, params[:administrator_id]),
+                   { prompt: t("admin.budget_investments.index.administrator_filter_all"),
+                     label: false} %>
+  </div>
+  <div class="small-12 medium-3 column">
+    <%= select_tag :valuator_or_group_id,
+                   options_for_select(valuator_or_group_select_options, params[:valuator_or_group_id]),
+                   { prompt: t("admin.budget_investments.index.valuator_filter_all"),
+                     label: false} %>
+  </div>
+  <div class="small-12 medium-3 column">
+    <%= select_tag :heading_id,
+                   options_for_select(budget_heading_select_options(@budget), params[:heading_id]),
+                   { prompt: t("admin.budget_investments.index.heading_filter_all"),
+                     label: false} %>
+  </div>
+  <div class="small-12 medium-3 column">
+    <%= select_tag :tag_name,
+                   options_for_select(investment_tags_select_options(@budget), params[:tag_name]),
+                   { prompt: t("admin.budget_investments.index.tags_filter_all"),
+                     label: false} %>
+  </div>
+
+  <div class="small-12 medium-6 column">
+    <div class="input-group">
+      <%= text_field_tag :title_or_id, params["title_or_id"], placeholder: t("admin.budget_investments.index.placeholder") %>
     </div>
   </div>
-  <div class="row" >
-    <div class="small-12 medium-6 column">
-      <div class="input-group">
-        <%= text_field_tag :title_or_id, params["title_or_id"], placeholder: t("admin.budget_investments.index.placeholder") %>
-      </div>
-    </div>
-    <div class="small-12 medium-6 column">
-      <%= submit_tag t("admin.budget_investments.index.buttons.filter"), class: "button expanded" %>
-    </div>
+
+  <div class="small-12 medium-3 column end">
+    <%= submit_tag t("admin.budget_investments.index.buttons.filter"), class: "button expanded" %>
   </div>
 <% end %>

--- a/app/views/admin/budget_phases/_form.html.erb
+++ b/app/views/admin/budget_phases/_form.html.erb
@@ -1,67 +1,59 @@
 <%= form_for [:admin, @phase.budget, @phase] do |f| %>
 
-  <div class="row">
-    <div class="row">
-      <div class="small-12 medium-6 column">
-        <%= f.label :starts_at, t("admin.budget_phases.edit.start_date") %>
-        <%= f.text_field :starts_at,
-                          value: format_date_for_calendar_form(@phase.starts_at),
-                          class: "js-calendar-full",
-                          id: "start_date",
-                          label: false %>
-      </div>
-      <div class="small-12 medium-6 column">
-        <%= f.label :ends_at, t("admin.budget_phases.edit.end_date") %>
-        <%= f.text_field :ends_at,
-                          value: format_date_for_calendar_form(@phase.ends_at),
-                          class: "js-calendar-full",
-                          id: "end_date",
-                          label: false %>
-      </div>
-    </div>
-
-    <div class="row margin-top">
-      <div class="small-12 medium-12 column">
-        <%= f.label :description, t("admin.budget_phases.edit.description") %>
-
-        <p class="help-text" id="phase-description-help-text">
-          <%= t("admin.budget_phases.edit.description_help_text") %>
-        </p>
-
-        <%= f.cktext_area :description,
-                          maxlength: Budget::Phase::DESCRIPTION_MAX_LENGTH,
-                          ckeditor: { language: I18n.locale },
-                          label: false %>
-      </div>
-    </div>
-
-    <div class="row margin-top">
-      <div class="small-12 medium-12 column">
-        <%= f.label :summary, t("admin.budget_phases.edit.summary") %>
-
-        <p class="help-text" id="phase-summary-help-text">
-          <%= t("admin.budget_phases.edit.summary_help_text") %>
-        </p>
-
-        <%= f.cktext_area :summary,
-                          maxlength: Budget::Phase::SUMMARY_MAX_LENGTH,
-                          ckeditor: { language: I18n.locale },
-                          label: false %>
-      </div>
-    </div>
-
-    <div class="row margin-top">
-      <div class="small-12 medium-12 column">
-        <%= f.check_box :enabled, label: t("admin.budget_phases.edit.enabled") %>
-
-        <p class="help-text" id="phase-summary-help-text">
-          <%= t("admin.budget_phases.edit.enabled_help_text") %>
-        </p>
-      </div>
-    </div>
-
-    <div class="margin-top">
-      <%= f.submit t("admin.budget_phases.edit.save_changes"), class: "button success" %>
-    </div>
+  <div class="small-12 medium-6 column">
+    <%= f.label :starts_at, t("admin.budget_phases.edit.start_date") %>
+    <%= f.text_field :starts_at,
+                      value: format_date_for_calendar_form(@phase.starts_at),
+                      class: "js-calendar-full",
+                      id: "start_date",
+                      label: false %>
   </div>
+  <div class="small-12 medium-6 column">
+    <%= f.label :ends_at, t("admin.budget_phases.edit.end_date") %>
+    <%= f.text_field :ends_at,
+                      value: format_date_for_calendar_form(@phase.ends_at),
+                      class: "js-calendar-full",
+                      id: "end_date",
+                      label: false %>
+  </div>
+
+  <div class="small-12 column">
+    <%= f.label :description, t("admin.budget_phases.edit.description") %>
+
+    <span class="help-text" id="phase-description-help-text">
+      <%= t("admin.budget_phases.edit.description_help_text") %>
+    </span>
+
+    <%= f.cktext_area :description,
+                      maxlength: Budget::Phase::DESCRIPTION_MAX_LENGTH,
+                      ckeditor: { language: I18n.locale },
+                      label: false %>
+  </div>
+
+  <div class="small-12 column margin-top">
+    <%= f.label :summary, t("admin.budget_phases.edit.summary") %>
+
+    <span class="help-text" id="phase-summary-help-text">
+      <%= t("admin.budget_phases.edit.summary_help_text") %>
+    </span>
+
+    <%= f.cktext_area :summary,
+                      maxlength: Budget::Phase::SUMMARY_MAX_LENGTH,
+                      ckeditor: { language: I18n.locale },
+                      label: false %>
+  </div>
+
+
+  <div class="small-12 column margin-top">
+    <%= f.check_box :enabled, label: t("admin.budget_phases.edit.enabled") %>
+
+    <span class="help-text" id="phase-summary-help-text">
+      <%= t("admin.budget_phases.edit.enabled_help_text") %>
+    </span>
+  </div>
+
+  <div class="small-12 medium-4 large-3 column end margin-top">
+    <%= f.submit t("admin.budget_phases.edit.save_changes"), class: "button success expanded" %>
+  </div>
+
 <% end %>

--- a/app/views/admin/budget_phases/edit.html.erb
+++ b/app/views/admin/budget_phases/edit.html.erb
@@ -1,5 +1,7 @@
 <%= back_link_to edit_admin_budget_path(@phase.budget) %>
 
-<h2><%= t("admin.budgets.edit.title") %> - <%= t("budgets.phase.#{@phase.kind}") %></h2>
+<div class="small-12 column">
+  <h2><%= t("admin.budgets.edit.title") %> - <%= t("budgets.phase.#{@phase.kind}") %></h2>
+</div>
 
 <%= render '/admin/budget_phases/form' %>

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -1,59 +1,65 @@
 <%= form_for [:admin, @budget] do |f| %>
 
-  <%= f.text_field :name, maxlength: Budget.title_max_length %>
+  <div class="small-12 medium-9 column">
+    <%= f.text_field :name, maxlength: Budget.title_max_length %>
+  </div>
 
-  <div class="row margin-top">
-    <div class="small-12 medium-9 column">
+  <div class="margin-top">
+    <div class="small-12 medium-6 column">
       <%= f.select :phase, budget_phases_select_options, selected: "drafting" %>
     </div>
-    <div class="small-12 medium-3 column">
+    <div class="small-12 medium-3 column end">
       <%= f.select :currency_symbol, budget_currency_symbol_select_options %>
     </div>
   </div>
 
   <% if @budget.phases.present? %>
-    <table id='budget-phases-table' class="table-for-mobile">
-      <thead>
-        <tr>
-          <th><%= t("admin.budgets.edit.phase") %></th>
-          <th><%= t("admin.budgets.edit.dates") %></th>
-          <th class="text-center"><%= t("admin.budgets.edit.enabled") %></th>
-          <th><%= t("admin.budgets.edit.actions") %></th>
-        </tr>
-      </thead>
+    <div class="small-12 column">
+      <table id="budget-phases-table" class="table-for-mobile">
+        <thead>
+          <tr>
+            <th><%= t("admin.budgets.edit.phase") %></th>
+            <th><%= t("admin.budgets.edit.dates") %></th>
+            <th class="text-center"><%= t("admin.budgets.edit.enabled") %></th>
+            <th><%= t("admin.budgets.edit.actions") %></th>
+          </tr>
+        </thead>
 
-      <% @budget.phases.order(:id).each do |phase| %>
-        <tr id="<%= dom_id(phase) %>" class="phase">
-          <td>
-            <%= t("budgets.phase.#{phase.kind}") %>
-            <% if @budget.current_phase == phase %>
-              <span class="label success"><strong><%= t("admin.budgets.edit.active") %></strong></span>
-            <% end %>
-          </td>
-          <td>
-            <% if phase.starts_at.present? || phase.ends_at.present? %>
-              <%= l(phase.starts_at.to_date) if phase.starts_at.present? %>
-              -
-              <%= l(phase.ends_at.to_date) if phase.ends_at.present? %>
-            <% else %>
-              <em><%= t("admin.budgets.edit.blank_dates") %></em>
-            <% end %>
-          </td>
-          <td class="text-center">
-            <span class="budget-phase-enabled <%= phase.enabled? ? 'enabled' : 'disabled' %>"></span>
-          </td>
-          <td>
-            <%= link_to t("admin.budgets.edit.edit_phase"),
-                        edit_admin_budget_budget_phase_path(@budget, phase),
-                        method: :get, class: "button hollow" %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
+        <% @budget.phases.order(:id).each do |phase| %>
+          <tr id="<%= dom_id(phase) %>" class="phase">
+            <td>
+              <%= t("budgets.phase.#{phase.kind}") %>
+              <% if @budget.current_phase == phase %>
+                <span class="label success"><strong><%= t("admin.budgets.edit.active") %></strong></span>
+              <% end %>
+            </td>
+            <td>
+              <% if phase.starts_at.present? || phase.ends_at.present? %>
+                <%= l(phase.starts_at.to_date) if phase.starts_at.present? %>
+                -
+                <%= l(phase.ends_at.to_date) if phase.ends_at.present? %>
+              <% else %>
+                <em><%= t("admin.budgets.edit.blank_dates") %></em>
+              <% end %>
+            </td>
+            <td class="text-center">
+              <span class="budget-phase-enabled <%= phase.enabled? ? 'enabled' : 'disabled' %>"></span>
+            </td>
+            <td>
+              <%= link_to t("admin.budgets.edit.edit_phase"),
+                          edit_admin_budget_budget_phase_path(@budget, phase),
+                          method: :get, class: "button hollow expanded" %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
   <% end %>
 
-  <div class="margin-top">
-    <%= f.submit nil, class: "button success" %>
+  <div class="small-12 column">
+    <div class="clear small-12 medium-4 large-3 inline-block">
+      <%= f.submit nil, class: "button success" %>
+    </div>
 
     <div class="float-right">
       <% if @budget.balloting_process? %>
@@ -72,9 +78,9 @@
         <%= link_to t("admin.budgets.edit.delete"),
             admin_budget_path(@budget),
             method: :delete,
-            class: "button hollow alert float-right margin-left" %>
+            class: "delete float-right margin-left" %>
       <% end %>
     </div>
-
   </div>
+
 <% end %>

--- a/app/views/admin/budgets/_max_supportable_headings_label.html.erb
+++ b/app/views/admin/budgets/_max_supportable_headings_label.html.erb
@@ -1,4 +1,3 @@
 <%= t("admin.budgets.form.max_supportable_headings")%>
 <%= content_tag(:strong,
-                t('admin.budgets.form.current_of_max_headings', current: current, max: max ),
-                class:"current-of-max-headings") %>
+                t("admin.budgets.form.current_of_max_headings", current: current, max: max )) %>

--- a/app/views/admin/budgets/_max_votable_headings_label.html.erb
+++ b/app/views/admin/budgets/_max_votable_headings_label.html.erb
@@ -1,4 +1,3 @@
 <%= t("admin.budgets.form.max_votable_headings")%>
 <%= content_tag(:strong,
-                t('admin.budgets.form.current_of_max_headings', current: current, max: max ),
-                class:"current-of-max-headings") %>
+                t("admin.budgets.form.current_of_max_headings", current: current, max: max)) %>

--- a/app/views/admin/budgets/edit.html.erb
+++ b/app/views/admin/budgets/edit.html.erb
@@ -1,5 +1,7 @@
 <%= back_link_to admin_budgets_path %>
 
-<h2><%= t("admin.budgets.edit.title") %></h2>
+<div class="small-12 column">
+  <h2><%= t("admin.budgets.edit.title") %></h2>
+</div>
 
 <%= render '/admin/budgets/form' %>

--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= link_to t("admin.budgets.index.new_link"),
             new_admin_budget_path,
-            class: "button float-right margin-right" %>
+            class: "button float-right" %>
 
 <%= render 'shared/filter_subnav', i18n_namespace: "admin.budgets.index" %>
 

--- a/app/views/admin/budgets/new.html.erb
+++ b/app/views/admin/budgets/new.html.erb
@@ -1,7 +1,5 @@
-<div class="row">
-  <div class="small-12 medium-9 column">
-    <h2><%= t("admin.budgets.new.title") %></h2>
-
-    <%= render '/admin/budgets/form' %>
-  </div>
+<div class="small-12 column">
+  <h2><%= t("admin.budgets.new.title") %></h2>
 </div>
+
+<%= render '/admin/budgets/form' %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,9 +1,3 @@
-<div class="float-right">
-  <%= link_to root_path do %>
-    <%= t("admin.dashboard.index.back", org: setting['org_name']) %>
-  <% end %>
-</div>
-
 <h2 class="title inline-block"><%= t("admin.dashboard.index.title") %></h2>
 
 <p><%= t("admin.dashboard.index.description", org: setting['org_name']) %></p>

--- a/app/views/admin/emails_download/index.html.erb
+++ b/app/views/admin/emails_download/index.html.erb
@@ -5,15 +5,13 @@
                method: :get,
                id: "admin_download_emails" do %>
 
-    <label><%= t('admin.emails_download.index.download_segment') %></label>
+    <label><%= t("admin.emails_download.index.download_segment") %></label>
     <p class="help-text" id="emails-help-text">
-      <%= t('admin.emails_download.index.download_segment_help_text') %>
+      <%= t("admin.emails_download.index.download_segment_help_text") %>
     </p>
 
     <%= select_tag :users_segment, options_for_select(user_segments_options) %>
 
-    <div class="margin-top">
-      <%= submit_tag t('admin.emails_download.index.download_emails_button'), class: "button" %>
-    </div>
+    <%= submit_tag t("admin.emails_download.index.download_emails_button"), class: "button" %>
   <% end %>
 </div>

--- a/app/views/admin/geozones/_errors.html.erb
+++ b/app/views/admin/geozones/_errors.html.erb
@@ -1,4 +1,3 @@
-
 <% if @geozone.errors.any? %>
 
   <div id="error_explanation" data-alert class="callout alert" data-closable>

--- a/app/views/admin/geozones/_form.html.erb
+++ b/app/views/admin/geozones/_form.html.erb
@@ -2,28 +2,24 @@
 
   <%= render 'errors' %>
 
-  <div clas="row">
-    <div class="small-12 medium-6 large-4 column">
-      <%= f.label :name, t("admin.geozones.geozone.name") %>
-      <%= f.text_field :name, label: false %>
-    </div>
-    <div class="small-12 medium-6 large-4 column">
-      <%= f.label :html_map_coordinates, t("admin.geozones.geozone.coordinates") %>
-      <%= f.text_field :html_map_coordinates, label: false %>
-    </div>
-    <div class="small-12 medium-6 large-2 column">
-      <%= f.label :external_code, t("admin.geozones.geozone.external_code") %>
-      <%= f.text_field :external_code, label: false %>
-    </div>
-    <div class="small-12 medium-6 large-2 column">
-      <%= f.label :census_code, t("admin.geozones.geozone.census_code") %>
-      <%= f.text_field :census_code, label: false %>
-    </div>
+  <div class="small-12 medium-6 large-4 column">
+    <%= f.label :name, t("admin.geozones.geozone.name") %>
+    <%= f.text_field :name, label: false %>
+  </div>
+  <div class="small-12 medium-6 large-4 column">
+    <%= f.label :html_map_coordinates, t("admin.geozones.geozone.coordinates") %>
+    <%= f.text_field :html_map_coordinates, label: false %>
+  </div>
+  <div class="small-12 medium-6 large-2 column">
+    <%= f.label :external_code, t("admin.geozones.geozone.external_code") %>
+    <%= f.text_field :external_code, label: false %>
+  </div>
+  <div class="small-12 medium-6 large-2 column">
+    <%= f.label :census_code, t("admin.geozones.geozone.census_code") %>
+    <%= f.text_field :census_code, label: false %>
   </div>
 
-  <div class="row">
-    <div class="actions small-12 large-3 medium-3 column">
-      <%= f.submit(class: "button expanded", value: t("admin.geozones.edit.form.submit_button")) %>
-    </div>
+  <div class="small-12 large-3 medium-3 column end">
+    <%= f.submit(class: "button success expanded", value: t("admin.geozones.edit.form.submit_button")) %>
   </div>
 <% end %>

--- a/app/views/admin/geozones/edit.html.erb
+++ b/app/views/admin/geozones/edit.html.erb
@@ -1,9 +1,7 @@
-<div class="row">
-  <div class="small-12 column">
-    <%= back_link_to admin_geozones_path, t("admin.geozones.edit.back") %>
+<%= back_link_to admin_geozones_path, t("admin.geozones.edit.back") %>
 
-    <h1><%= t("admin.geozones.edit.editing") %></h1>
-
-    <%= render "form" %>
-  </div>
+<div class="small-12 column">
+  <h2><%= t("admin.geozones.edit.editing") %></h2>
 </div>
+
+<%= render 'form' %>

--- a/app/views/admin/geozones/index.html.erb
+++ b/app/views/admin/geozones/index.html.erb
@@ -1,5 +1,5 @@
 <%= link_to t("admin.geozones.index.create"),
-              new_admin_geozone_path, class: "button success float-right" %>
+              new_admin_geozone_path, class: "button float-right" %>
 
 <h2 class="inline-block"><%= t("admin.geozones.index.title") %></h2>
 
@@ -10,7 +10,7 @@
       <th><%= t("admin.geozones.geozone.external_code") %></th>
       <th><%= t("admin.geozones.geozone.census_code") %></th>
       <th><%= t("admin.geozones.geozone.coordinates") %></th>
-      <th colspan="2"></th>
+      <th><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>
 
@@ -22,10 +22,17 @@
         <td><%= geozone.census_code %></td>
         <td class="break"><%= geozone.html_map_coordinates %></td>
         <td>
-          <%= link_to t("admin.geozones.index.edit"), edit_admin_geozone_path(geozone), class: 'edit-banner button hollow' %>
-        </td>
-        <td>
-          <%= link_to t("admin.geozones.index.delete"), admin_geozone_path(geozone), method: :delete, class: 'button hollow alert' %>
+          <div class="small-6 column">
+            <%= link_to t("admin.geozones.index.edit"),
+                        edit_admin_geozone_path(geozone),
+                        class: "button hollow expanded" %>
+          </div>
+          <div class="small-6 column">
+            <%= link_to t("admin.geozones.index.delete"),
+                        admin_geozone_path(geozone),
+                        method: :delete,
+                        class: "button hollow alert expanded" %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/geozones/new.html.erb
+++ b/app/views/admin/geozones/new.html.erb
@@ -1,9 +1,7 @@
-<div class="geozone-new row">
-  <div class="small-12 column">
-    <%= back_link_to admin_geozones_path, t("admin.geozones.new.back") %>
+<%= back_link_to admin_geozones_path, t("admin.geozones.new.back") %>
 
-    <h1><%= t("admin.geozones.new.creating") %></h1>
-
-    <%= render "form" %>
-  </div>
+<div class="small-12 column">
+  <h2><%= t("admin.geozones.new.creating") %></h2>
 </div>
+
+<%= render 'form' %>

--- a/app/views/admin/legislation/draft_versions/_form.html.erb
+++ b/app/views/admin/legislation/draft_versions/_form.html.erb
@@ -13,80 +13,66 @@
     </div>
   <% end %>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :title %>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_field :title, label: false, placeholder: t('admin.legislation.draft_versions.form.title_placeholder') %>
-    </div>
+  <div class="small-12 medium-9 column">
+    <%= f.label :title %>
+    <%= f.text_field :title, label: false, placeholder: t("admin.legislation.draft_versions.form.title_placeholder") %>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :changelog %>
-      <small><%= t('admin.legislation.draft_versions.form.use_markdown') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :changelog, label: false, rows: 5, placeholder: t('admin.legislation.draft_versions.form.changelog_placeholder') %>
-    </div>
+  <div class="small-12 medium-9 column">
+    <%= f.label :changelog %>
+    <span class="help-text"><%= t("admin.legislation.draft_versions.form.use_markdown") %></span>
+    <%= f.text_area :changelog, label: false, rows: 5, placeholder: t("admin.legislation.draft_versions.form.changelog_placeholder") %>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :status %>
-    </div>
-    <div class="small-12 medium-8 column">
-      <% ::Legislation::DraftVersion::VALID_STATUSES.each do |status| %>
-        <%= f.radio_button :status, status, label: false %>
-        <%= f.label "status_#{status}", t("admin.legislation.draft_versions.statuses.#{status}") %>
-        <small><%= t("admin.legislation.draft_versions.form.hints.status.#{status}") %></small>
-        <br/>
+  <div class="small-12 medium-9 column">
+    <%= f.label :status %>
+    <% ::Legislation::DraftVersion::VALID_STATUSES.each do |status| %>
+      <%= f.radio_button :status, status, label: false %>
+      <%= f.label "status_#{status}", t("admin.legislation.draft_versions.statuses.#{status}") %>
+      <span class="help-text"><%= t("admin.legislation.draft_versions.form.hints.status.#{status}") %></span>
+      <br>
+    <% end %>
+  </div>
+
+  <div class="small-12 medium-9 column">
+    <%= f.label :final_version %>
+    <%= f.check_box :final_version, label: false %>
+    <span class="help-text"><%= t("admin.legislation.draft_versions.form.hints.final_version") %></span>
+  </div>
+
+  <div class="small-12 medium-4 column">
+    <%= f.label :body %>
+    <span class="help-text"><%= t("admin.legislation.draft_versions.form.use_markdown") %></span>
+  </div>
+
+  <div class="markdown-editor clear">
+    <div class="small-12 medium-8 column fullscreen-container">
+      <div class="markdown-editor-header truncate">
+        <%= t("admin.legislation.draft_versions.form.title_html",
+               draft_version_title: @draft_version.title,
+               process_title: @process.title ) %>
+      </div>
+
+      <div class="markdown-editor-buttons">
+        <%= f.submit(class: "button", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
+      </div>
+
+      <%= link_to "#", class: 'fullscreen-toggle' do %>
+        <span data-closed-text="<%= t("admin.legislation.draft_versions.form.launch_text_editor")%>"
+              data-open-text="<%= t("admin.legislation.draft_versions.form.close_text_editor")%>">
+          <strong><%= t("admin.legislation.draft_versions.form.launch_text_editor")%></strong>
+        </span>
       <% end %>
     </div>
-  </div>
-
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :final_version %>
+    <div class="small-12 medium-6 column markdown-area">
+      <%= f.text_area :body, label: false, placeholder: t("admin.legislation.draft_versions.form.body_placeholder") %>
     </div>
-    <div class="small-12 medium-8 column">
-      <%= f.check_box :final_version, label: false %>
-      <small><%= t("admin.legislation.draft_versions.form.hints.final_version") %></small>
+
+    <div id="markdown-preview" class="small-12 medium-6 column markdown-preview">
     </div>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :body %>
-      <small><%= t('admin.legislation.draft_versions.form.use_markdown') %></small>
-    </div>
-    <div class="markdown-editor">
-      <div class="small-12 medium-8 column fullscreen-container">
-        <div class="markdown-editor-header truncate"><%= t('admin.legislation.draft_versions.form.title_html', draft_version_title: @draft_version.title, process_title: @process.title ) %></div>
-
-        <div class="markdown-editor-buttons">
-          <%= f.submit(class: "button", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
-        </div>
-
-        <%= link_to "#", class: 'fullscreen-toggle' do %>
-          <span data-closed-text="<%= t("admin.legislation.draft_versions.form.launch_text_editor")%>"
-                data-open-text="<%= t("admin.legislation.draft_versions.form.close_text_editor")%>">
-            <strong><%= t("admin.legislation.draft_versions.form.launch_text_editor")%></strong>
-          </span>
-        <% end %>
-      </div>
-      <div class="small-12 medium-6 column markdown-area">
-        <%= f.text_area :body, label: false, placeholder: t('admin.legislation.draft_versions.form.body_placeholder') %>
-      </div>
-      <div id="markdown-preview" class="small-12 medium-6 column markdown-preview">
-      </div>
-    </div>
-  </div>
-
-  <div class="row margin-top primary-buttons">
-    <div class="actions small-12 medium-3 column legislation-process-save">
-      <%= f.submit(class: "button expanded", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
-    </div>
+  <div class="small-12 medium-3 column clear end margin-top">
+    <%= f.submit(class: "button success expanded", value: t("admin.legislation.draft_versions.#{admin_submit_action(@draft_version)}.submit_button")) %>
   </div>
 <% end %>

--- a/app/views/admin/legislation/draft_versions/edit.html.erb
+++ b/app/views/admin/legislation/draft_versions/edit.html.erb
@@ -1,8 +1,8 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.draft_versions.index.title") %> - <%= @draft_version.title %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.draft_versions.index.title") %> - <%= @draft_version.title %>
 <% end %>
 
-<div class="legislation-admin legislation-draft-versions-edit legislation-draft-versions-form row">
+<div class="legislation-draft-versions-edit legislation-draft-versions-form">
   <div class="small-12 column">
     <%= back_link_to admin_legislation_process_draft_versions_path(@process),
                      t("admin.legislation.draft_versions.edit.back") %>
@@ -11,17 +11,16 @@
 
     <%= render 'admin/legislation/processes/subnav', process: @process, active: 'draft_versions' %>
 
-    <div class="row">
-      <div class="small-12 column">
-        <div class="callout warning" style="display: none;">
-          <%= t("admin.legislation.draft_versions.edit.warning") %>
-        </div>
+    <div class="small-12 column">
+      <div class="callout warning" style="display: none;">
+        <%= t("admin.legislation.draft_versions.edit.warning") %>
       </div>
+    </div>
 
-      <div class="small-12 medium-9 column">
-        <h3><%= @draft_version.title %></h3>
-      </div>
-      <div class="small-12 medium-3 column legislation-question-delete">
+    <div class="small-12 column">
+      <h3 class="inline-block"><%= @draft_version.title %></h3>
+
+      <div class="float-right">
         <%= link_to t("admin.legislation.draft_versions.index.delete"),
                     admin_legislation_process_draft_version_path(@process, @draft_version),
                     method: :delete,

--- a/app/views/admin/legislation/draft_versions/index.html.erb
+++ b/app/views/admin/legislation/draft_versions/index.html.erb
@@ -1,23 +1,20 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.draft_versions.index.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.draft_versions.index.title") %>
 <% end %>
 
-<div class="legislation-admin legislation-draft-versions-index row">
+<div class="legislation-draft-versions-index">
+
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.edit.back") %>
+
+  <h2><%= @process.title %></h2>
+
+  <%= render 'admin/legislation/processes/subnav', process: @process, active: 'draft_versions' %>
+
   <div class="small-12 column">
-    <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.edit.back") %>
+    <h4 class="inline-block"><%= t("admin.legislation.draft_versions.index.title") %></h4>
 
-    <h2><%= @process.title %></h2>
-
-    <%= render 'admin/legislation/processes/subnav', process: @process, active: 'draft_versions' %>
-
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <h4><%= t("admin.legislation.draft_versions.index.title") %></h4>
-      </div>
-
-      <div class="small-12 medium-3 column legislation-process-version">
-        <%= link_to t("admin.legislation.draft_versions.index.create"), new_admin_legislation_process_draft_version_path, class: "button" %>
-      </div>
+    <div class="float-right">
+      <%= link_to t("admin.legislation.draft_versions.index.create"), new_admin_legislation_process_draft_version_path, class: "button" %>
     </div>
 
     <% if @process.draft_versions.any? %>
@@ -27,8 +24,8 @@
             <th><%= t("admin.legislation.draft_versions.table.title") %></th>
             <th><%= t("admin.legislation.draft_versions.table.created_at") %></th>
             <th><%= t("admin.legislation.draft_versions.table.status") %></th>
-            <th><%= t("admin.legislation.draft_versions.table.comments") %></th>
-            <th><%= t("admin.legislation.draft_versions.table.final_version") %></th>
+            <th class="text-center"><%= t("admin.legislation.draft_versions.table.comments") %></th>
+            <th class="text-center"><%= t("admin.legislation.draft_versions.table.final_version") %></th>
           </tr>
         </thead>
         <tbody>
@@ -46,8 +43,8 @@
                 <%= t("admin.legislation.draft_versions.statuses.published") %>
               <% end %>
             </td>
-            <td><%= draft_version.total_comments %></td>
-            <td>
+            <td class="text-center"><%= draft_version.total_comments %></td>
+            <td class="text-center">
               <% if draft_version.final_version %>
                 <span class="icon-check" title="<%= draft_version.final_version %>"></span>
               <% else %>

--- a/app/views/admin/legislation/draft_versions/new.html.erb
+++ b/app/views/admin/legislation/draft_versions/new.html.erb
@@ -1,8 +1,8 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.draft_versions.index.title") %> - <%= t("admin.legislation.draft_versions.new.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.draft_versions.index.title") %> - <%= t("admin.legislation.draft_versions.new.title") %>
 <% end %>
 
-<div class="legislation-admin legislation-draft-versions-new legislation-draft-versions-form row">
+<div class="legislation-draft-versions-new legislation-draft-versions-form">
   <div class="small-12 column">
     <%= back_link_to admin_legislation_process_draft_versions_path(@process),
                      t("admin.legislation.draft_versions.new.back") %>
@@ -11,10 +11,8 @@
 
     <%= render 'admin/legislation/processes/subnav', process: @process, active: 'draft_versions' %>
 
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <h3><%= t("admin.legislation.draft_versions.new.title") %></h3>
-      </div>
+    <div class="small-12 column">
+      <h3><%= t("admin.legislation.draft_versions.new.title") %></h3>
     </div>
 
     <%= render 'form', url: admin_legislation_process_draft_versions_path(@process) %>

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -15,238 +15,197 @@
 
   <% end %>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <label><%= t('admin.legislation.processes.form.process') %></label>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-start">
-      <%= t('admin.legislation.processes.form.start') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :start_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.start_date),
-                        class: "js-calendar-full",
-                        id: "start_date" %>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-end">
-      <%= t('admin.legislation.processes.form.end') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :end_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.end_date),
-                        class: "js-calendar-full",
-                        id: "end_date" %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.check_box :published, checked: @process.published?, label: t('admin.legislation.processes.form.enabled') %>
-    </div>
-
-    <div class="small-12 column">
-      <hr>
-    </div>
+  <div class="small-12 medium-4 column">
+    <label><%= t("admin.legislation.processes.form.process") %></label>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <label><%= t('admin.legislation.processes.form.debate_phase') %></label>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-start">
-      <%= t('admin.legislation.processes.form.start') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :debate_start_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.debate_start_date),
-                        class: "js-calendar-full",
-                        id: "debate_start_date" %>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-end">
-      <%= t('admin.legislation.processes.form.end') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :debate_end_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.debate_end_date),
-                        class: "js-calendar-full",
-                        id: "debate_end_date" %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.check_box :debate_phase_enabled, checked: @process.debate_phase.enabled?, label: t('admin.legislation.processes.form.enabled') %>
-    </div>
-
-    <div class="small-12 column">
-      <hr>
-    </div>
+  <div class="small-12 medium-3 column">
+    <%= f.label :start_date, t("admin.legislation.processes.form.start") %>
+    <%= f.text_field :start_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.start_date),
+                      class: "js-calendar-full",
+                      id: "start_date" %>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <label><%= t('admin.legislation.processes.form.proposals_phase') %></label>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-start">
-      <%= t('admin.legislation.processes.form.start') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :proposals_phase_start_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.proposals_phase_start_date),
-                        class: "js-calendar-full",
-                        id: "proposals_phase_start_date" %>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-end">
-      <%= t('admin.legislation.processes.form.end') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :proposals_phase_end_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.proposals_phase_end_date),
-                        class: "js-calendar-full",
-                        id: "proposals_phase_end_date" %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.check_box :proposals_phase_enabled, checked: @process.proposals_phase.enabled?, label: t('admin.legislation.processes.form.enabled') %>
-    </div>
-
-    <div class="small-12 column">
-      <hr>
-    </div>
+  <div class="small-12 medium-3 column">
+    <%= f.label :end_date, t("admin.legislation.processes.form.end") %>
+    <%= f.text_field :end_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.end_date),
+                      class: "js-calendar-full",
+                      id: "end_date" %>
+  </div>
+  <div class="small-12 medium-2 column margin-top">
+    <%= f.check_box :published, checked: @process.published?, label: t("admin.legislation.processes.form.enabled") %>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <label><%= t('admin.legislation.processes.form.allegations_phase') %></label>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-start">
-      <%= t('admin.legislation.processes.form.start') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :allegations_start_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.allegations_start_date),
-                        class: "js-calendar-full",
-                        id: "allegations_start_date" %>
-    </div>
-    <div class="small-12 medium-1 column legislation-process-end">
-      <%= t('admin.legislation.processes.form.end') %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.text_field :allegations_end_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.allegations_end_date),
-                        class: "js-calendar-full",
-                        id: "allegations_end_date" %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.check_box :allegations_phase_enabled, checked: @process.allegations_phase.enabled?, label: t('admin.legislation.processes.form.enabled') %>
-    </div>
-
-    <div class="small-12 column">
-      <hr>
-    </div>
+  <div class="small-12 column">
+    <hr>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :draft_publication_date %>
-    </div>
-    <div class="small-12 medium-2 column end">
-      <%= f.text_field :draft_publication_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.draft_publication_date),
-                        class: "js-calendar-full",
-                        id: "draft_publication_date" %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.check_box :draft_publication_enabled, checked: @process.draft_publication.enabled?, label: t('admin.legislation.processes.form.enabled') %>
-    </div>
-
-    <div class="small-12 column">
-      <hr>
-    </div>
+  <div class="small-12 medium-4 column">
+    <label><%= t("admin.legislation.processes.form.debate_phase") %></label>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :result_publication_date %>
-    </div>
-    <div class="small-12 medium-2 column end">
-      <%= f.text_field :result_publication_date,
-                        label: false,
-                        value: format_date_for_calendar_form(@process.result_publication_date),
-                        class: "js-calendar-full",
-                        id: "result_publication_date" %>
-    </div>
-    <div class="small-12 medium-2 column">
-      <%= f.check_box :result_publication_enabled, checked: @process.result_publication.enabled?, label: t('admin.legislation.processes.form.enabled') %>
-    </div>
+  <div class="small-12 medium-3 column">
+    <%= f.label :debate_start_date, t("admin.legislation.processes.form.start") %>
+    <%= f.text_field :debate_start_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.debate_start_date),
+                      class: "js-calendar-full",
+                      id: "debate_start_date" %>
+  </div>
 
-    <div class="small-12 column">
-      <hr>
-    </div>
+  <div class="small-12 medium-3 column">
+    <%= f.label :debate_end_date, t("admin.legislation.processes.form.end") %>
+    <%= f.text_field :debate_end_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.debate_end_date),
+                      class: "js-calendar-full",
+                      id: "debate_end_date" %>
+  </div>
+  <div class="small-12 medium-2 column margin-top">
+    <%= f.check_box :debate_phase_enabled, checked: @process.debate_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+  </div>
+
+  <div class="small-12 column">
+    <hr>
+  </div>
+
+  <div class="small-12 medium-4 column">
+    <label><%= t("admin.legislation.processes.form.proposals_phase") %></label>
+  </div>
+
+  <div class="small-12 medium-3 column">
+    <%= f.label :proposals_phase_start_date, t("admin.legislation.processes.form.start") %>
+    <%= f.text_field :proposals_phase_start_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.proposals_phase_start_date),
+                      class: "js-calendar-full",
+                      id: "proposals_phase_start_date" %>
+  </div>
+
+  <div class="small-12 medium-3 column">
+    <%= f.label :proposals_phase_end_date, t("admin.legislation.processes.form.end") %>
+    <%= f.text_field :proposals_phase_end_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.proposals_phase_end_date),
+                      class: "js-calendar-full",
+                      id: "proposals_phase_end_date" %>
+  </div>
+  <div class="small-12 medium-2 column margin-top">
+    <%= f.check_box :proposals_phase_enabled, checked: @process.proposals_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+  </div>
+
+  <div class="small-12 column">
+    <hr>
+  </div>
+
+  <div class="small-12 medium-4 column">
+    <label><%= t("admin.legislation.processes.form.allegations_phase") %></label>
+  </div>
+
+  <div class="small-12 medium-3 column">
+    <%= f.label :allegations_start_date, t("admin.legislation.processes.form.start") %>
+    <%= f.text_field :allegations_start_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.allegations_start_date),
+                      class: "js-calendar-full",
+                      id: "allegations_start_date" %>
+  </div>
+
+  <div class="small-12 medium-3 column">
+    <%= f.label :allegations_end_date, t("admin.legislation.processes.form.end") %>
+    <%= f.text_field :allegations_end_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.allegations_end_date),
+                      class: "js-calendar-full",
+                      id: "allegations_end_date" %>
+  </div>
+  <div class="small-12 medium-2 column margin-top">
+    <%= f.check_box :allegations_phase_enabled, checked: @process.allegations_phase.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+  </div>
+
+  <div class="small-12 column">
+    <hr>
+  </div>
+
+  <div class="small-12 medium-3 column end">
+    <%= f.label :draft_publication_date %>
+    <%= f.text_field :draft_publication_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.draft_publication_date),
+                      class: "js-calendar-full",
+                      id: "draft_publication_date" %>
+  </div>
+  <div class="small-12 medium-2 column margin-top">
+    <%= f.check_box :draft_publication_enabled, checked: @process.draft_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+  </div>
+
+  <div class="small-12 column">
+    <hr>
+  </div>
+
+  <div class="small-12 medium-3 column end">
+    <%= f.label :result_publication_date %>
+    <%= f.text_field :result_publication_date,
+                      label: false,
+                      value: format_date_for_calendar_form(@process.result_publication_date),
+                      class: "js-calendar-full",
+                      id: "result_publication_date" %>
+  </div>
+  <div class="small-12 medium-2 column margin-top">
+    <%= f.check_box :result_publication_enabled, checked: @process.result_publication.enabled?, label: t("admin.legislation.processes.form.enabled") %>
+  </div>
+
+  <div class="small-12 column">
+    <hr>
   </div>
 
   <div class="documents small-12 column">
     <%= render 'documents/nested_documents', documentable: @process, f: f %>
-    <div class="small-12 column">
-      <hr>
-    </div>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :title %>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_field :title,
-                       label: false,
-                       placeholder: t('admin.legislation.processes.form.title_placeholder') %>
-    </div>
+  <div class="small-12 column">
+    <hr>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :summary %>
-      <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :summary,
-                       label: false,
-                       rows: 2,
-                       placeholder: t('admin.legislation.processes.form.summary_placeholder') %>
-    </div>
+  <div class="small-12 medium-9 column">
+    <%= f.label :title %>
+    <%= f.text_field :title,
+                     label: false,
+                     placeholder: t("admin.legislation.processes.form.title_placeholder") %>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :description %>
-      <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :description,
-                       label: false,
-                       rows: 5,
-                       placeholder: t('admin.legislation.processes.form.description_placeholder') %>
-    </div>
+  <div class="small-12 medium-9 column">
+    <%= f.label :summary %>
+    <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
+    <%= f.text_area :summary,
+                     label: false,
+                     rows: 2,
+                     placeholder: t("admin.legislation.processes.form.summary_placeholder") %>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= f.label :additional_info %>
-      <small><%= t('admin.legislation.processes.form.use_markdown') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_area :additional_info,
-                       label: false,
-                       rows: 10,
-                       placeholder: t('admin.legislation.processes.form.additional_info_placeholder') %>
-    </div>
+  <div class="small-12 medium-9 column">
+    <%= f.label :description %>
+    <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
+    <%= f.text_area :description,
+                     label: false,
+                     rows: 5,
+                     placeholder: t("admin.legislation.processes.form.description_placeholder") %>
   </div>
 
-  <div class="row">
-    <div class="actions small-12 medium-3 column legislation-process-save">
-      <%= f.submit(class: "button expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
-    </div>
+  <div class="small-12 medium-9 column">
+    <%= f.label :additional_info %>
+    <span class="help-text"><%= t("admin.legislation.processes.form.use_markdown") %></span>
+    <%= f.text_area :additional_info,
+                     label: false,
+                     rows: 10,
+                     placeholder: t("admin.legislation.processes.form.additional_info_placeholder") %>
+  </div>
+
+  <div class="small-12 medium-3 column clear end">
+    <%= f.submit(class: "button success expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
   </div>
 <% end %>

--- a/app/views/admin/legislation/processes/edit.html.erb
+++ b/app/views/admin/legislation/processes/edit.html.erb
@@ -1,16 +1,13 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %>
 <% end %>
 
-<div class="legislation-admin legislation-process-edit row">
+<div class="legislation-process-edit">
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.edit.back") %>
 
-  <div class="small-12 column">
-    <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.edit.back") %>
+  <h2><%= @process.title %></h2>
 
-    <h2><%= @process.title %></h2>
+  <%= render 'subnav', process: @process, active: 'info' %>
 
-    <%= render 'subnav', process: @process, active: 'info' %>
-
-    <%= render "form" %>
-  </div>
+  <%= render 'form' %>
 </div>

--- a/app/views/admin/legislation/processes/index.html.erb
+++ b/app/views/admin/legislation/processes/index.html.erb
@@ -1,11 +1,11 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= t("admin.legislation.processes.index.filters.#{@current_filter}") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= t("admin.legislation.processes.index.filters.#{@current_filter}") %>
 <% end %>
 
 <h2 class="inline-block"><%= t("admin.legislation.processes.index.title") %></h2>
 
 <%= link_to t("admin.legislation.processes.index.create"), new_admin_legislation_process_path,
-            class: "button success float-right" %>
+            class: "button float-right" %>
 
 <%= render 'shared/filter_subnav', i18n_namespace: "admin.legislation.processes.index" %>
 
@@ -18,7 +18,7 @@
         <th><%= t("admin.legislation.processes.process.title") %></th>
         <th><%= t("admin.legislation.processes.process.status") %></th>
         <th><%= t("admin.legislation.processes.process.creation_date") %></th>
-        <th><%= t("admin.legislation.processes.process.comments") %></th>
+        <th class="text-center"><%= t("admin.legislation.processes.process.comments") %></th>
         <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
@@ -26,16 +26,16 @@
     <tbody>
       <% @processes.each do |process| %>
         <tr id="<%= dom_id(process) %>">
-          <td class="small-12 medium-8">
+          <td class="small-12 medium-6">
             <%= link_to process.title, edit_admin_legislation_process_path(process) %>
           </td>
           <td><%= t("admin.legislation.processes.process.status_#{process.status}") %></td>
           <td><%= I18n.l process.created_at.to_date %></td>
-          <td><%= process.total_comments %></td>
+          <td class="text-center"><%= process.total_comments %></td>
           <td>
             <%= link_to t("admin.legislation.processes.index.delete"), admin_legislation_process_path(process),
                         method: :delete,
-                        class: 'button hollow alert' %>
+                        class: 'button hollow alert expanded' %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/legislation/processes/new.html.erb
+++ b/app/views/admin/legislation/processes/new.html.erb
@@ -1,14 +1,11 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= t("admin.legislation.processes.new.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= t("admin.legislation.processes.new.title") %>
 <% end %>
 
-<div class="legislation-admin legislation-process-new row">
+<div class="legislation-process-new">
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.new.back") %>
 
-  <div class="small-12 column">
-    <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.new.back") %>
+  <h2><%= t("admin.legislation.processes.new.title") %></h2>
 
-    <h2><%= t("admin.legislation.processes.new.title") %></h2>
-
-    <%= render "form" %>
-  </div>
+  <%= render "form" %>
 </div>

--- a/app/views/admin/legislation/proposals/_form.html.erb
+++ b/app/views/admin/legislation/proposals/_form.html.erb
@@ -15,23 +15,17 @@
 
   <% end %>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
-      <%= label_tag t('admin.legislation.proposals.form.custom_categories') %>
-      <small><%= t('admin.legislation.proposals.form.custom_categories_description') %></small>
-    </div>
-    <div class="small-12 medium-8 column">
-      <%= f.text_field :custom_list, value: @process.tag_list_on(:customs).to_s,
-                        label: false,
-                        placeholder: t("admin.legislation.proposals.form.custom_categories_placeholder"),
-                        class: 'js-tag-list',
-                        aria: {describedby: "tag-list-help-text"} %>
-    </div>
+  <div class="small-12 medium-8 column">
+    <%= f.label :custom_list, t("admin.legislation.proposals.form.custom_categories") %>
+    <span class="help-text"><%= t("admin.legislation.proposals.form.custom_categories_description") %></span>
+    <%= f.text_field :custom_list, value: @process.tag_list_on(:customs).to_s,
+                      label: false,
+                      placeholder: t("admin.legislation.proposals.form.custom_categories_placeholder"),
+                      class: 'js-tag-list',
+                      aria: {describedby: "tag-list-help-text"} %>
   </div>
 
-  <div class="row">
-    <div class="actions small-12 medium-3 column legislation-process-save">
-      <%= f.submit(class: "button expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
-    </div>
+  <div class="small-12 medium-3 column clear end">
+    <%= f.submit(class: "button expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
   </div>
 <% end %>

--- a/app/views/admin/legislation/proposals/index.html.erb
+++ b/app/views/admin/legislation/proposals/index.html.erb
@@ -1,16 +1,14 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.proposals.index.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.proposals.index.title") %>
 <% end %>
 
-<div class="legislation-admin legislation-draft-versions-index row">
-  <div class="small-12 column">
-    <%= back_link_to admin_legislation_processes_path, t("admin.legislation.proposals.index.back") %>
+<div class="legislation-admin legislation-draft-versions-index">
 
-    <h2><%= @process.title %></h2>
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.proposals.index.back") %>
 
-    <%= render 'admin/legislation/processes/subnav', process: @process, active: 'proposals' %>
+  <h2><%= @process.title %></h2>
 
-    <%= render "form" %>
+  <%= render 'admin/legislation/processes/subnav', process: @process, active: 'proposals' %>
 
-  </div>
+  <%= render 'form' %>
 </div>

--- a/app/views/admin/legislation/questions/_form.html.erb
+++ b/app/views/admin/legislation/questions/_form.html.erb
@@ -30,12 +30,12 @@
     <% end %>
   </div>
 
-  <div class="small-12 medium-9 column margin">
+  <div class="small-12 medium-9 column">
     <%= link_to_add_association t("admin.legislation.questions.form.add_option"),
-                                f, :question_options, class: "button hollow medium" %>
+                                f, :question_options, class: "button hollow" %>
   </div>
 
-  <div class="small-12 medium-6 large-4 column end">
-    <%= f.submit(class: "button expanded", value: t("admin.legislation.questions.#{admin_submit_action(@question)}.submit_button")) %>
+  <div class="small-12 medium-6 large-3 clear column end margin-top">
+    <%= f.submit(class: "button success expanded", value: t("admin.legislation.questions.#{admin_submit_action(@question)}.submit_button")) %>
   </div>
 <% end %>

--- a/app/views/admin/legislation/questions/_question_option_fields.html.erb
+++ b/app/views/admin/legislation/questions/_question_option_fields.html.erb
@@ -1,12 +1,10 @@
 <div class="nested-fields">
   <div class="field">
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <%= f.text_field :value, label: false, placeholder: t("admin.legislation.questions.form.value_placeholder") %>
-      </div>
-      <div class="small-12 medium-3 column">
-        <%= link_to_remove_association "<span class=\"icon-x\" aria-hidden=\"true\"></span> <span>#{t(".remove_option")}</span>".html_safe, f %>
-      </div>
+    <div class="small-12 medium-9 column">
+      <%= f.text_field :value, label: false, placeholder: t("admin.legislation.questions.form.value_placeholder") %>
+    </div>
+    <div class="small-12 medium-3 column">
+      <%= link_to_remove_association t("admin.legislation.questions.question_option_fields.remove_option"), f, class: "delete"%>
     </div>
   </div>
 </div>

--- a/app/views/admin/legislation/questions/edit.html.erb
+++ b/app/views/admin/legislation/questions/edit.html.erb
@@ -1,8 +1,8 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.questions.index.title") %> - <%= @question.title %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.questions.index.title") %> - <%= @question.title %>
 <% end %>
 
-<div class="legislation-admin legislation-questions-edit legislation-questions-form row">
+<div class="legislation-questions-edit legislation-questions-form">
   <div class="small-12 column">
     <%= back_link_to admin_legislation_process_questions_path(@process), t("admin.legislation.questions.edit.back") %>
 
@@ -10,11 +10,10 @@
 
     <%= render 'admin/legislation/processes/subnav', process: @process, active: 'questions' %>
 
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <h3><%= t("admin.legislation.questions.edit.title", question_title: @question.title) %></h3>
-      </div>
-      <div class="small-12 medium-3 column legislation-question-delete">
+    <div class="small-12 column">
+      <h3 class="inline-block"><%= t("admin.legislation.questions.edit.title", question_title: @question.title) %></h3>
+
+      <div class="float-right">
         <%= link_to t("admin.legislation.questions.index.delete"), admin_legislation_process_question_path(@process, @question),
                     method: :delete,
                     class: 'button hollow alert' %>

--- a/app/views/admin/legislation/questions/index.html.erb
+++ b/app/views/admin/legislation/questions/index.html.erb
@@ -1,23 +1,19 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.questions.index.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.questions.index.title") %>
 <% end %>
 
-<div class="legislation-admin legislation-draft-versions-index row">
+<div class="legislation-draft-versions-index">
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.questions.index.back") %>
+
+  <h2><%= @process.title %></h2>
+
+  <%= render 'admin/legislation/processes/subnav', process: @process, active: 'questions' %>
+
   <div class="small-12 column">
-    <%= back_link_to admin_legislation_processes_path, t("admin.legislation.questions.index.back") %>
+    <h4 class="inline-block"><%= t("admin.legislation.questions.index.title") %></h4>
 
-    <h2><%= @process.title %></h2>
-
-    <%= render 'admin/legislation/processes/subnav', process: @process, active: 'questions' %>
-
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <h4><%= t("admin.legislation.questions.index.title") %></h4>
-      </div>
-
-      <div class="small-12 medium-3 column legislation-process-question">
-        <%= link_to t("admin.legislation.questions.index.create"), new_admin_legislation_process_question_path, class: "button" %>
-      </div>
+    <div class="float-right">
+      <%= link_to t("admin.legislation.questions.index.create"), new_admin_legislation_process_question_path, class: "button" %>
     </div>
 
     <% if @process.questions.any? %>
@@ -26,8 +22,8 @@
           <tr>
             <th><%= t("admin.legislation.questions.table.title") %></th>
             <th><%= t("admin.legislation.questions.table.question_options") %></th>
-            <th><%= t("admin.legislation.questions.table.answers_count") %></th>
-            <th><%= t("admin.legislation.questions.table.comments_count") %></th>
+            <th class="text-center"><%= t("admin.legislation.questions.table.answers_count") %></th>
+            <th class="text-center"><%= t("admin.legislation.questions.table.comments_count") %></th>
           </tr>
         </thead>
         <tbody>
@@ -45,8 +41,8 @@
                 <% end %>
               <% end %>
             </td>
-            <td><%= question.answers_count %></td>
-            <td><%= link_to question.comments.count, legislation_process_question_path(@process, question, anchor: 'comments') %></td>
+            <td class="text-center"><%= question.answers_count %></td>
+            <td class="text-center"><%= link_to question.comments.count, legislation_process_question_path(@process, question, anchor: 'comments') %></td>
           </tr>
         <% end %>
         </tbody>

--- a/app/views/admin/legislation/questions/new.html.erb
+++ b/app/views/admin/legislation/questions/new.html.erb
@@ -1,21 +1,18 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.questions.index.title") %> - <%= t("admin.legislation.questions.new.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.questions.index.title") %> - <%= t("admin.legislation.questions.new.title") %>
 <% end %>
 
-<div class="legislation-admin legislation-questions-new legislation-questions-form row">
+<div class="legislation-questions-new legislation-questions-form">
+
+  <%= back_link_to admin_legislation_process_questions_path(@process), t("admin.legislation.questions.new.back") %>
+
+  <h2><%= @process.title %></h2>
+
+  <%= render 'admin/legislation/processes/subnav', process: @process, active: 'questions' %>
+
   <div class="small-12 column">
-    <%= back_link_to admin_legislation_process_questions_path(@process), t("admin.legislation.questions.new.back") %>
-
-    <h2><%= @process.title %></h2>
-
-    <%= render 'admin/legislation/processes/subnav', process: @process, active: 'questions' %>
-
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <h3><%= t("admin.legislation.questions.new.title") %></h3>
-      </div>
-    </div>
-
-    <%= render 'form', url: admin_legislation_process_questions_path(@process) %>
+    <h3><%= t("admin.legislation.questions.new.title") %></h3>
   </div>
+
+  <%= render 'form', url: admin_legislation_process_questions_path(@process) %>
 </div>

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -6,10 +6,10 @@
   <table id="newsletters">
     <thead>
       <tr>
-        <th><%= t("admin.newsletters.index.subject") %></th>
+        <th class="small-2"><%= t("admin.newsletters.index.subject") %></th>
         <th><%= t("admin.newsletters.index.segment_recipient") %></th>
         <th><%= t("admin.newsletters.index.sent") %></th>
-        <th class="small-5 text-right"><%= t("admin.newsletters.index.actions") %></th>
+        <th class="small-4"><%= t("admin.newsletters.index.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -28,13 +28,19 @@
             <%= l newsletter.sent_at.to_date %>
           <% end %>
         </td>
-        <td class="text-right">
+        <td>
+          <div class="small-4 column">
           <%= link_to t("admin.newsletters.index.edit"), edit_admin_newsletter_path(newsletter),
-                                                         method: :get, class: "button hollow" %>
+                                                         method: :get, class: "button hollow expanded" %>
+          </div>
+          <div class="small-4 column">
           <%= link_to t("admin.newsletters.index.delete"), admin_newsletter_path(newsletter),
-                                                           method: :delete, class: "button hollow alert" %>
+                                                           method: :delete, class: "button hollow alert expanded" %>
+          </div>
+          <div class="small-4 column">
           <%= link_to t("admin.newsletters.index.preview"), admin_newsletter_path(newsletter),
-                                                            class: "button" %>
+                                                            class: "button expanded" %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -4,39 +4,37 @@
 
 <% recipients_count = @newsletter.valid_segment_recipient? ? @newsletter.list_of_recipient_emails.count : 0 %>
 
-<div class="small-12 column">
-  <div class="callout highlight">
-    <div class="row">
-      <div class="small-12 medium-2 column">
-        <strong><%= t("admin.newsletters.show.sent_at") %></strong><br>
-        <% if @newsletter.draft? %>
-          <%= t("admin.newsletters.index.draft") %>
-        <% else %>
-          <%= l @newsletter.sent_at.to_date %>
-        <% end %>
-      </div>
-      <div class="small-12 medium-6 column">
-        <strong><%= t("admin.newsletters.show.from") %></strong><br>
-        <%= @newsletter.from %>
-      </div>
-      <div class="small-12 medium-4 column">
-        <strong><%= t("admin.newsletters.show.subject") %></strong><br>
-        <%= @newsletter.subject %>
-      </div>
+  <div class="small-12 column callout highlight">
+    <div class="small-12 medium-2 column">
+      <strong><%= t("admin.newsletters.show.sent_at") %></strong><br>
+      <% if @newsletter.draft? %>
+        <%= t("admin.newsletters.index.draft") %>
+      <% else %>
+        <%= l @newsletter.sent_at.to_date %>
+      <% end %>
     </div>
-    <div class="row margin-top">
-      <div class="small-12 column">
-        <strong><%= t("admin.newsletters.show.segment_recipient") %></strong><br>
-        <%= segment_name(@newsletter.segment_recipient) %>
-        <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
-      </div>
+    <div class="small-12 medium-6 column">
+      <strong><%= t("admin.newsletters.show.from") %></strong><br>
+      <%= @newsletter.from %>
+    </div>
+    <div class="small-12 medium-4 column">
+      <strong><%= t("admin.newsletters.show.subject") %></strong><br>
+      <%= @newsletter.subject %>
+    </div>
+    <div class="small-12 column">
+      <strong><%= t("admin.newsletters.show.segment_recipient") %></strong><br>
+      <%= segment_name(@newsletter.segment_recipient) %>
+      <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
     </div>
   </div>
 
-  <strong><%= t("admin.newsletters.show.body") %></strong>
-  <p class="help-text" id="phase-description-help-text">
-    <%= t("admin.newsletters.show.body_help_text") %>
-  </p>
+  <div class="small-12 column">
+    <strong><%= t("admin.newsletters.show.body") %></strong>
+    <p class="help-text" id="phase-description-help-text">
+      <%= t("admin.newsletters.show.body_help_text") %>
+    </p>
+  </div>
+
   <div class="newsletter-body-content">
     <%= render file: "app/views/layouts/_mailer_header.html.erb" %>
 

--- a/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
+++ b/app/views/admin/poll/booth_assignments/_booth_assignment.html.erb
@@ -6,27 +6,29 @@
 </td>
 <% if booth_assignment.present? %>
   <td>
-    <span class="verified"><%= t("admin.booth_assignments.manage.status.assigned") %></span>
+    <span class="enabled">
+      <strong><%= t("admin.booth_assignments.manage.status.assigned") %></strong>
+    </span>
   </td>
-  <td class="text-right">
+  <td>
     <%= link_to t("admin.booth_assignments.manage.actions.unassign"),
                 admin_poll_booth_assignment_path(@poll, booth_assignment, booth_id: booth.id),
                 method: :delete,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.unassign"),
-                class: "button hollow alert",
+                class: "button hollow alert expanded",
                 data: (booth_assignment.shifts? ? {confirm: "#{t("admin.poll_booth_assignments.alert.shifts")}"} : nil) if !@poll.expired? %>
   </td>
 <% else %>
   <td>
-    <span class="delete"><%= t("admin.booth_assignments.manage.status.unassigned") %></span>
+    <span class="disabled"><%= t("admin.booth_assignments.manage.status.unassigned") %></span>
   </td>
-  <td class="text-right">
+  <td>
     <%= link_to t("admin.booth_assignments.manage.actions.assign"),
                 admin_poll_booth_assignments_path(@poll, booth_id: booth.id),
                 method: :post,
                 remote: true,
                 title: t("admin.booth_assignments.manage.actions.assign"),
-                class: "button" if !@poll.expired? %>
+                class: "button hollow expanded" if !@poll.expired? %>
   </td>
 <% end %>

--- a/app/views/admin/poll/booth_assignments/_search_booths.html.erb
+++ b/app/views/admin/poll/booth_assignments/_search_booths.html.erb
@@ -1,16 +1,14 @@
-<div class="row">
-  <div class="small-12 medium-6 column">
-    <%= form_tag(search_booths_admin_poll_booth_assignments_path(@poll), method: :get, remote: true) do |f| %>
-      <div class="input-group">
-        <%= text_field_tag :search,
-                           @search,
-                           placeholder: t("admin.shared.booths_search.placeholder"), id: "search-booths" %>
-        <div class="input-group-button">
-          <%= submit_tag t("admin.shared.booths_search.button"), class: "button" %>
-        </div>
+<div class="small-12 medium-6 margin-top">
+  <%= form_tag(search_booths_admin_poll_booth_assignments_path(@poll), method: :get, remote: true) do |f| %>
+    <div class="input-group">
+      <%= text_field_tag :search,
+                         @search,
+                         placeholder: t("admin.shared.booths_search.placeholder"), id: "search-booths" %>
+      <div class="input-group-button">
+        <%= submit_tag t("admin.shared.booths_search.button"), class: "button" %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>
 
 <div id="search-booths-results"></div>

--- a/app/views/admin/poll/booth_assignments/index.html.erb
+++ b/app/views/admin/poll/booth_assignments/index.html.erb
@@ -4,7 +4,7 @@
   <%= render "/admin/poll/polls/subnav" %>
   <%= render "search_booths" %>
 
-  <h3><%= t("admin.poll_booth_assignments.index.booths_title") %></h3>
+  <h3 class="inline-block"><%= t("admin.poll_booth_assignments.index.booths_title") %></h3>
 
   <%= link_to t("admin.booth_assignments.manage_assignments"),
               manage_admin_poll_booth_assignments_path(@poll),

--- a/app/views/admin/poll/booth_assignments/manage.html.erb
+++ b/app/views/admin/poll/booth_assignments/manage.html.erb
@@ -1,9 +1,6 @@
-<%= link_to booth_assignments_admin_polls_path do %>
-  <span class="icon-angle-left"></span> <%= t("shared.back") %>
-<% end %>
-<hr>
+<%= back_link_to booth_assignments_admin_polls_path %>
 
-<h2 class="inline-block"><%= t("admin.booth_assignments.manage.assignments_list", poll: @poll.name) %></h2>
+<h2><%= t("admin.booth_assignments.manage.assignments_list", poll: @poll.name) %></h2>
 
 <% if @booths.empty? %>
   <div class="callout primary">
@@ -15,7 +12,7 @@
       <th><%= t("admin.booths.index.name") %></th>
       <th><%= t("admin.booths.index.location") %></th>
       <th><%= t("admin.booth_assignments.manage.status.assign_status") %></th>
-      <th class="text-right"><%= t("admin.actions.actions") %></th>
+      <th class="small-3"><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>
     <% @booths.each do |booth| %>

--- a/app/views/admin/poll/booths/_form.html.erb
+++ b/app/views/admin/poll/booths/_form.html.erb
@@ -1,30 +1,26 @@
-<div class="row">
-  <div class="small-12 medium-6 column">
-    <%= f.text_field :name,
-                     placeholder: t('admin.booths.new.name'),
-                     label:       t("admin.booths.new.name") %>
-  </div>
-
-  <div class="small-12 column">
-    <%= f.text_field :location,
-                     placeholder: t("admin.booths.new.location"),
-                     label:       t("admin.booths.new.location") %>
-  </div>
-
-  <div class="small-12 column">
-    <%= f.select :physical, {} do %>
-      <%= options_for_select({
-          t("admin.booths.new.physical") => true,
-          t("admin.booths.new.digital")  => false
-        }, @booth.physical)
-      %>
-    <% end %>
-  </div>
+<div class="small-12 medium-6 column">
+  <%= f.text_field :name,
+                   placeholder: t('admin.booths.new.name'),
+                   label:       t("admin.booths.new.name") %>
 </div>
 
-<div class="row">
-  <div class="small-12 medium-4 column">
-    <%= f.submit t("admin.booths.#{admin_submit_action(@booth)}.submit_button"),
-                 class: "button success expanded" %>
-  </div>
+<div class="small-12 medium-6 column clear">
+  <%= f.text_field :location,
+                   placeholder: t("admin.booths.new.location"),
+                   label:       t("admin.booths.new.location") %>
+</div>
+
+<div class="small-12 medium-6 large-3 column clear">
+  <%= f.select :physical, {} do %>
+    <%= options_for_select({
+        t("admin.booths.new.physical") => true,
+        t("admin.booths.new.digital")  => false
+      }, @booth.physical)
+    %>
+  <% end %>
+</div>
+
+<div class="small-12 medium-4 large-3 column clear end">
+  <%= f.submit t("admin.booths.#{admin_submit_action(@booth)}.submit_button"),
+               class: "button success expanded" %>
 </div>

--- a/app/views/admin/poll/booths/edit.html.erb
+++ b/app/views/admin/poll/booths/edit.html.erb
@@ -1,6 +1,8 @@
 <%= back_link_to admin_booths_path %>
 
-<h2><%= t("admin.booths.edit.title") %></h2>
+<div class="small-12 column">
+  <h2><%= t("admin.booths.edit.title") %></h2>
+</div>
 
 <%= form_for @booth, url: admin_booth_path(@booth) do |f| %>
   <%= render "form", f: f %>

--- a/app/views/admin/poll/booths/index.html.erb
+++ b/app/views/admin/poll/booths/index.html.erb
@@ -1,7 +1,7 @@
 <h2 class="inline-block"><%= t("admin.booths.index.title") %></h2>
 
 <% if controller_name == "booths" && action_name != "available" %>
-  <%= link_to t("admin.booths.index.add_booth"), new_admin_booth_path, class: "button success float-right" %>
+  <%= link_to t("admin.booths.index.add_booth"), new_admin_booth_path, class: "button float-right" %>
 <% end %>
 
 <% if @booths.empty? %>

--- a/app/views/admin/poll/booths/new.html.erb
+++ b/app/views/admin/poll/booths/new.html.erb
@@ -1,6 +1,8 @@
 <%= back_link_to admin_booths_path %>
 
-<h2><%= t("admin.booths.new.title") %></h2>
+<div class="small-12 column">
+  <h2><%= t("admin.booths.new.title") %></h2>
+</div>
 
 <%= form_for @booth, url: admin_booths_path(@booth) do |f| %>
   <%= render "form", f: f %>

--- a/app/views/admin/poll/officer_assignments/_search_officers.html.erb
+++ b/app/views/admin/poll/officer_assignments/_search_officers.html.erb
@@ -1,16 +1,14 @@
-<div class="row">
-  <div class="small-12 medium-6 column">
-    <%= form_tag(search_officers_admin_poll_officer_assignments_path(@poll), method: :get, remote: true) do |f| %>
-      <div class="input-group">
-        <%= text_field_tag :search,
-                           @search,
-                           placeholder: t("admin.shared.poll_officers_search.placeholder"), id: "search-officers" %>
-        <div class="input-group-button">
-          <%= submit_tag t("admin.shared.poll_officers_search.button"), class: "button" %>
-        </div>
+<div class="small-12 medium-6 margin-top">
+  <%= form_tag(search_officers_admin_poll_officer_assignments_path(@poll), method: :get, remote: true) do |f| %>
+    <div class="input-group">
+      <%= text_field_tag :search,
+                         @search,
+                         placeholder: t("admin.shared.poll_officers_search.placeholder"), id: "search-officers" %>
+      <div class="input-group-button">
+        <%= submit_tag t("admin.shared.poll_officers_search.button"), class: "button" %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>
 
 <div id="search-officers-results"></div>

--- a/app/views/admin/poll/officers/_officer.html.erb
+++ b/app/views/admin/poll/officers/_officer.html.erb
@@ -1,8 +1,9 @@
 <table>
   <thead>
     <tr>
-      <th><%= t('admin.poll_officers.officer.name') %></th>
-      <th colspan="2"><%= t('admin.poll_officers.officer.email') %></th>
+      <th><%= t("admin.poll_officers.officer.name") %></th>
+      <th><%= t("admin.poll_officers.officer.email") %></th>
+      <th class="small-3"><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>
   <tbody>
@@ -13,16 +14,16 @@
       <td>
         <%= officer.email %>
       </td>
-      <td class="text-right">
+      <td>
         <% if officer.persisted? %>
-          <%= link_to t('admin.poll_officers.officer.delete'),
+          <%= link_to t("admin.poll_officers.officer.delete"),
                       admin_officer_path(officer),
                       method: :delete,
-                      class: "button hollow alert" %>
+                      class: "button hollow alert expanded" %>
         <% else %>
-          <%= link_to t('admin.poll_officers.officer.add'),{ controller: "admin/poll/officers", action: :create, user_id: officer.user_id },
+          <%= link_to t("admin.poll_officers.officer.add"),{ controller: "admin/poll/officers", action: :create, user_id: officer.user_id },
                       method: :post,
-                      class: "button success" %>
+                      class: "button success expanded" %>
         <% end %>
       </td>
     </tr>

--- a/app/views/admin/poll/officers/index.html.erb
+++ b/app/views/admin/poll/officers/index.html.erb
@@ -1,23 +1,22 @@
 <h2><%= t("admin.poll_officers.index.title") %></h2>
 
-<div class="row">
-  <div class="small-12 medium-6 column">
-    <%= render 'search' %>
-  </div>
+<div class="small-12 medium-6">
+  <%= render 'search' %>
 </div>
 
 <div id="search-result"></div>
 
 <h3>
-  <%= page_entries_info @officers, entry_name: t('admin.poll_officers.officer.entry_name') %>
+  <%= page_entries_info @officers, entry_name: t("admin.poll_officers.officer.entry_name") %>
 </h3>
 
 <% if @officers.any? %>
   <table id="officers">
     <thead>
       <tr>
-        <th><%= t('admin.poll_officers.officer.name') %></th>
-        <th colspan="2"><%= t('admin.poll_officers.officer.email') %></th>
+        <th><%= t("admin.poll_officers.officer.name") %></th>
+        <th><%= t("admin.poll_officers.officer.email") %></th>
+        <th class="small-3"><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -29,19 +28,19 @@
         <td>
           <%= officer.email %>
         </td>
-        <td class="text-right">
+        <td>
           <% if officer.persisted? %>
-            <%= link_to t('admin.poll_officers.officer.delete'),
+            <%= link_to t("admin.poll_officers.officer.delete"),
                         admin_officer_path(officer),
                         method: :delete,
-                        class: "button hollow alert"
+                        class: "button hollow alert expanded"
             %>
           <% else %>
-            <%= link_to t('admin.poll_officers.officer.add'),
+            <%= link_to t("admin.poll_officers.officer.add"),
                         { controller: "admin/poll/officers", action: :create,
                           user_id: officer.user_id },
                         method: :post,
-                        class: "button success" %>
+                        class: "button success expanded" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -1,11 +1,9 @@
 <%= form_for [:admin, @poll] do |f| %>
-  <div class="row">
-    <div class="small-12 medium-6 column">
-      <%= f.text_field :name %>
-    </div>
+  <div class="small-12 medium-6 column">
+    <%= f.text_field :name %>
   </div>
 
-  <div class="row">
+  <div class="clear">
     <div class="small-12 medium-6 column">
       <%= f.text_field :starts_at,
                         value: @poll.starts_at.present? ? l(@poll.starts_at.to_date) : nil,
@@ -19,25 +17,19 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="small-12 column">
-      <%=f.text_area :summary, rows: 4%>
-    </div>
+  <div class="small-12 column">
+    <%=f.text_area :summary, rows: 4%>
   </div>
 
-  <div class="row">
-    <div class="small-12 column">
-      <%=f.text_area :description, rows: 8%>
-    </div>
+  <div class="small-12 column">
+    <%=f.text_area :description, rows: 8%>
   </div>
 
-  <div class="row">
-    <div class="small-12 column">
-      <%= render 'images/admin_image', imageable: @poll, f: f %>
-    </div>
+  <div class="small-12 column">
+    <%= render 'images/admin_image', imageable: @poll, f: f %>
   </div>
 
-  <div class="row">
+  <div class="clear">
     <div class="small-6 medium-6 column">
       <%= f.check_box :geozone_restricted, data: { checkbox_toggle: "#geozones" } %>
     </div>
@@ -55,10 +47,10 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="small-12 medium-4 column">
+  <div class="clear">
+    <div class="small-12 medium-4 large-2 column">
       <%= f.submit t("admin.polls.#{admin_submit_action(@poll)}.submit_button"),
-                   class: "button success expanded" %>
+                   class: "button success expanded margin-top" %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/poll/polls/_poll.html.erb
+++ b/app/views/admin/poll/polls/_poll.html.erb
@@ -8,11 +8,15 @@
     <%= l poll.starts_at.to_date %> - <%= l poll.ends_at.to_date %>
   </td>
   <td class="text-right">
+    <div class="small-6 column">
     <%= link_to t("admin.actions.edit"),
                 edit_admin_poll_path(poll),
-                class: "button hollow" %>
+                class: "button hollow expanded" %>
+    </div>
+    <div class="small-6 column">
     <%= link_to t("admin.actions.configure"),
                 admin_poll_path(poll),
-                class: "button hollow" %>
+                class: "button hollow expanded" %>
+    </div>
   </td>
 </tr>

--- a/app/views/admin/poll/polls/_questions.html.erb
+++ b/app/views/admin/poll/polls/_questions.html.erb
@@ -2,13 +2,13 @@
 
 <% if @poll.questions.empty? %>
   <div class="callout primary margin-top">
-    <%= t('admin.polls.show.no_questions') %>
+    <%= t("admin.polls.show.no_questions") %>
   </div>
 <% else %>
   <table class="fixed margin">
     <thead>
       <tr>
-        <th><%= t('admin.polls.show.table_title') %></th>
+        <th><%= t("admin.polls.show.table_title") %></th>
       </tr>
     </thead>
     <% @poll.questions.each do |question| %>

--- a/app/views/admin/poll/polls/index.html.erb
+++ b/app/views/admin/poll/polls/index.html.erb
@@ -2,14 +2,14 @@
 
 <%= link_to t("admin.polls.index.create"),
             new_admin_poll_path,
-            class: "button success float-right" %>
+            class: "button float-right" %>
 
 <% if @polls.any? %>
   <table>
     <thead>
-      <th class="medium-6"><%= t("admin.polls.index.name") %></th>
+      <th class="small-6"><%= t("admin.polls.index.name") %></th>
       <th><%= t("admin.polls.index.dates") %></th>
-      <th class="text-right"><%= t("admin.actions.actions") %></th>
+      <th><%= t("admin.actions.actions") %></th>
     </thead>
     <tbody>
       <%= render @polls %>

--- a/app/views/admin/poll/polls/new.html.erb
+++ b/app/views/admin/poll/polls/new.html.erb
@@ -1,6 +1,8 @@
-<%= back_link_to %>
+<div class="small-12 column">
+  <%= back_link_to %>
 
-<h2><%= t("admin.polls.new.title") %></h2>
+  <h2><%= t("admin.polls.new.title") %></h2>
+</div>
 
 <div class="polls-form">
   <%= render "form" %>

--- a/app/views/admin/poll/questions/_form.html.erb
+++ b/app/views/admin/poll/questions/_form.html.erb
@@ -14,8 +14,8 @@
 
     <%= f.text_field :title %>
 
-    <div class="small-12 medium-6 large-4 margin-top">
-      <%= f.submit(class: "button expanded", value: t("shared.save")) %>
+    <div class="small-12 medium-4 large-2 margin-top">
+      <%= f.submit(class: "button success expanded", value: t("shared.save")) %>
     </div>
   </div>
 

--- a/app/views/admin/poll/questions/_questions.html.erb
+++ b/app/views/admin/poll/questions/_questions.html.erb
@@ -4,23 +4,27 @@
 
 <% if @questions.count == 0 %>
   <div class="callout primary margin-top">
-    <%= t('admin.questions.index.no_questions') %>
+    <%= t("admin.questions.index.no_questions") %>
   </div>
 <% else %>
   <table class="fixed">
     <thead>
       <tr>
-        <th><%= t('admin.questions.index.table_question') %></th>
-        <th class="text-right"><%= t("admin.actions.actions") %></th>
+        <th class="small-8"><%= t("admin.questions.index.table_question") %></th>
+        <th><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>
       <% @questions.each do |question| %>
         <tr id="<%= dom_id(question) %>">
           <td><%= link_to question.title, admin_question_path(question) %></td>
-          <td class="text-right">
-            <%= link_to t('shared.edit'), edit_admin_question_path(question), class: "button hollow" %>
-            <%= link_to t('shared.delete'), admin_question_path(question), class: "button hollow alert", method: :delete %>
+          <td>
+            <div class="small-6 column">
+              <%= link_to t("shared.edit"), edit_admin_question_path(question), class: "button hollow expanded" %>
+            </div>
+            <div class="small-6 column">
+              <%= link_to t("shared.delete"), admin_question_path(question), class: "button hollow alert expanded", method: :delete %>
+            <div class="small-6 column">
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/poll/questions/_successful_proposals.html.erb
+++ b/app/views/admin/poll/questions/_successful_proposals.html.erb
@@ -1,8 +1,8 @@
 <table class="fixed">
   <thead>
     <tr>
-      <th><%= t('admin.questions.index.table_proposal') %></th>
-      <th class="text-right"><%= t("admin.actions.actions") %></th>
+      <th class="small-9"><%= t("admin.questions.index.table_proposal") %></th>
+      <th><%= t("admin.actions.actions") %></th>
     </tr>
   </thead>
   <tbody>
@@ -15,7 +15,7 @@
             <strong><%= proposal.question %></strong>
           </p>
         </td>
-        <td class="text-right">
+        <td>
           <%= link_to t("admin.questions.index.create_question"),
                 new_admin_question_path(proposal_id: proposal.id),
                 class: "button hollow" %>

--- a/app/views/admin/poll/questions/answers/_form.html.erb
+++ b/app/views/admin/poll/questions/answers/_form.html.erb
@@ -12,8 +12,8 @@
                       ckeditor: { language: I18n.locale } %>
   </div>
 
-  <div class="small-12 medium-6 large-4 margin-top">
-    <%= f.submit(class: "button expanded", value: t("shared.save")) %>
+  <div class="small-12 medium-4 large-2 margin-top">
+    <%= f.submit(class: "button success expanded", value: t("shared.save")) %>
   </div>
 
 <% end %>

--- a/app/views/admin/poll/questions/answers/edit.html.erb
+++ b/app/views/admin/poll/questions/answers/edit.html.erb
@@ -2,7 +2,7 @@
 
 <ul class="breadcrumbs margin-top">
   <li><%= @answer.title %></li>
-  <li><%= t('admin.answers.edit.title') %></li>
+  <li><%= t("admin.answers.edit.title") %></li>
 </ul>
 
 <h2 class="margin-top">

--- a/app/views/admin/poll/questions/answers/new.html.erb
+++ b/app/views/admin/poll/questions/answers/new.html.erb
@@ -2,10 +2,10 @@
 
 <ul class="breadcrumbs margin-top">
   <li><%= @question.title %></li>
-  <li><%= t('admin.answers.new.title') %></li>
+  <li><%= t("admin.answers.new.title") %></li>
 </ul>
 
-<h2><%= t('admin.answers.new.title') %></h2>
+<h2><%= t("admin.answers.new.title") %></h2>
 
 <div class="poll-question-answer-form">
   <%= render "form", form_url: admin_question_answers_path %>

--- a/app/views/admin/poll/questions/index.html.erb
+++ b/app/views/admin/poll/questions/index.html.erb
@@ -1,7 +1,7 @@
-<h2 class="inline-block"><%= t('admin.questions.index.title') %></h2>
+<h2 class="inline-block"><%= t("admin.questions.index.title") %></h2>
 
-<%= link_to t('admin.questions.index.create'), new_admin_question_path,
-            class: "button success float-right" %>
+<%= link_to t("admin.questions.index.create"), new_admin_question_path,
+            class: "button float-right" %>
 
 <div class="small-12 medium-6">
   <%= render 'search' %>

--- a/app/views/admin/poll/questions/show.html.erb
+++ b/app/views/admin/poll/questions/show.html.erb
@@ -29,13 +29,15 @@
   </div>
 </div>
 
+<div class="clear">
+  <%= link_to t("admin.questions.show.add_answer"), new_admin_question_answer_path(@question),
+              class: "button float-right" %>
+</div>
+
 <table class="margin-top">
   <tr>
     <th colspan="5" scope="col" class="with-button">
       <%= t('admin.questions.show.valid_answers') %>
-      <%= link_to t("admin.questions.show.add_answer"),
-                  new_admin_question_answer_path(@question),
-                  class: "button float-right" %>
     </th>
   </tr>
 

--- a/app/views/admin/poll/shifts/_search_officers.html.erb
+++ b/app/views/admin/poll/shifts/_search_officers.html.erb
@@ -1,19 +1,17 @@
-<div class="row">
-  <div class="small-12 medium-6 column">
-    <%= form_tag search_officers_admin_booth_shifts_path,
-                 method: :get, remote: true do |f| %>
-      <div class="input-group">
-        <%= text_field_tag :search,
-                            @search,
-                            placeholder: t("admin.poll_shifts.new.search_officer_placeholder"),
-                            id: "search-officers" %>
-        <div class="input-group-button">
-          <%= submit_tag t("admin.poll_shifts.new.search_officer_button"),
-                         class: "button" %>
-        </div>
+<div class="small-12 medium-6">
+  <%= form_tag search_officers_admin_booth_shifts_path,
+               method: :get, remote: true do |f| %>
+    <div class="input-group">
+      <%= text_field_tag :search,
+                          @search,
+                          placeholder: t("admin.poll_shifts.new.search_officer_placeholder"),
+                          id: "search-officers" %>
+      <div class="input-group-button">
+        <%= submit_tag t("admin.poll_shifts.new.search_officer_button"),
+                       class: "button" %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>
 
 <div id="search-officers-results"></div>

--- a/app/views/admin/poll/shifts/_shifts.html.erb
+++ b/app/views/admin/poll/shifts/_shifts.html.erb
@@ -5,7 +5,7 @@
       <th><%= t("admin.poll_shifts.new.date") %></th>
       <th><%= t("admin.poll_shifts.new.officer") %></th>
       <th><%= t("admin.poll_shifts.new.task") %></th>
-      <th class="text-right"><%= t("admin.poll_shifts.new.shift") %></th>
+      <th class="small-3"><%= t("admin.poll_shifts.new.shift") %></th>
     </tr>
   </thead>
   <tbody>
@@ -14,11 +14,11 @@
         <td><%= l(shift.date.to_date, format: :long) %></td>
         <td><%= shift.officer_name %></td>
         <td><%= t("admin.poll_shifts.#{shift.task}") %></td>
-        <td class="text-right">
+        <td>
           <%= link_to t("admin.poll_shifts.new.remove_shift"),
                       admin_booth_shift_path(@booth, shift),
                       method: :delete,
-                      class: "button hollow alert" %>
+                      class: "button hollow alert expanded" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/settings/_configuration.html.erb
+++ b/app/views/admin/settings/_configuration.html.erb
@@ -1,13 +1,23 @@
 <h2><%= t("admin.settings.index.title") %></h2>
 
 <table>
+  <thead>
+    <tr>
+      <th><%= t("admin.settings.setting_name") %></th>
+      <th><%= t("admin.settings.setting_value") %></th>
+    </tr>
+  </thead>
   <tbody>
     <% @settings.each do |setting| %>
       <tr>
-        <td class="small-12 medium-4">
+        <td class="small-6">
           <strong><%= t("settings.#{setting.key}") %></strong>
+          <br>
+          <span class="small">
+            <%= t("settings.#{setting.key}_description", default: t("admin.settings.no_description")) %>
+          </span>
         </td>
-        <td class="small-12 medium-8">
+        <td class="small-6">
           <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
             <div class="small-12 medium-6 large-9 column">
               <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>

--- a/app/views/admin/settings/_feature_flags.html.erb
+++ b/app/views/admin/settings/_feature_flags.html.erb
@@ -1,15 +1,36 @@
 <h2><%= t("admin.settings.index.feature_flags") %></h2>
 
 <table>
+  <thead>
+    <tr>
+      <th><%= t("admin.settings.setting") %></th>
+      <th><%= t("admin.settings.setting_status") %></th>
+      <th><%= t("admin.settings.setting_actions") %></th>
+    </tr>
+  </thead>
   <tbody>
     <% @feature_flags.each do |feature_flag| %>
       <tr>
-        <td>
+        <td class="small-8">
           <strong><%= t("settings.#{feature_flag.key}") %></strong>
+          <br>
+          <span class="small">
+            <%= t("settings.#{feature_flag.key}_description", default: t("admin.settings.no_description")) %>
+          </span>
         </td>
 
         <td>
-          <%= feature_flag.enabled? ? t("admin.settings.index.features.enabled") : t("admin.settings.index.features.disabled") %>
+          <% if feature_flag.enabled? %>
+            <span class="enabled">
+              <strong>
+                <%= t ("admin.settings.index.features.enabled") %>
+              </strong>
+            </span>
+          <% else %>
+            <span class="disabled">
+              <%= t("admin.settings.index.features.disabled") %>
+            </span>
+          <% end %>
         </td>
 
         <td class="text-right">

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -1,4 +1,10 @@
-<ul class="tabs" data-tabs id="settings-tabs">
+<ul class="tabs"
+    id="settings-tabs"
+    data-deep-link="true"
+    data-update-history="true"
+    data-deep-link-smudge="true"
+    data-deep-link-smudge-delay="500"
+    data-tabs>
   <li class="tabs-title is-active">
     <%= link_to "#tab-configuration" do %>
       <%= t("admin.settings.index.title") %>

--- a/app/views/admin/site_customization/content_blocks/_form.html.erb
+++ b/app/views/admin/site_customization/content_blocks/_form.html.erb
@@ -14,22 +14,20 @@
   </div>
 
   <% end %>
-  <div class="row">
-    <div class="small-12 medium-6 column">
-      <%= f.label :name %>
-      <%= f.select :name, SiteCustomization::ContentBlock::VALID_BLOCKS, label: false %>
-    </div>
-    <div class="small-12 medium-6 column">
-      <%= f.label :locale %>
-      <%= f.select :locale, I18n.available_locales, label: false %>
-    </div>
+  <div class="small-12 medium-6 column">
+    <%= f.label :name %>
+    <%= f.select :name, SiteCustomization::ContentBlock::VALID_BLOCKS, label: false %>
+  </div>
+  <div class="small-12 medium-6 column">
+    <%= f.label :locale %>
+    <%= f.select :locale, I18n.available_locales, label: false %>
+  </div>
 
-    <div class="small-12 column">
-      <%= f.label :body %>
-      <%= f.text_area :body, label: false, rows: 10 %>
-      <div class="small-12 medium-6 large-4">
-        <%= f.submit class: "button success expanded" %>
-      </div>
+  <div class="small-12 column">
+    <%= f.label :body %>
+    <%= f.text_area :body, label: false, rows: 10 %>
+    <div class="small-12 medium-6 large-3">
+      <%= f.submit class: "button success expanded" %>
     </div>
   </div>
 

--- a/app/views/admin/site_customization/content_blocks/edit.html.erb
+++ b/app/views/admin/site_customization/content_blocks/edit.html.erb
@@ -1,14 +1,16 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.site_customization.content_blocks") %> - <%= @content_block.name %> (<%= @content_block.locale %>)
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.content_blocks") %> - <%= @content_block.name %> (<%= @content_block.locale %>)
 <% end %>
 
 <%= back_link_to admin_site_customization_content_blocks_path %>
 
-<%= button_to t("admin.site_customization.content_blocks.index.delete"), admin_site_customization_content_block_path(@content_block), method: :delete, class: "button hollow alert float-right small" %>
+<%= link_to t("admin.site_customization.content_blocks.index.delete"),
+            admin_site_customization_content_block_path(@content_block),
+            method: :delete,
+            class: "delete float-right" %>
 
-<div class="row">
-  <div class="small-12 column">
-    <h2><%= t("admin.site_customization.content_blocks.edit.title") %></h2>
-    <%= render 'form' %>
-  </div>
+<div class="small-12 column">
+  <h2><%= t("admin.site_customization.content_blocks.edit.title") %></h2>
 </div>
+
+<%= render 'form' %>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.site_customization.content_blocks") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.content_blocks") %>
 <% end %>
 
 <%= link_to t("admin.site_customization.content_blocks.index.create"), new_admin_site_customization_content_block_path, class: "button float-right" %>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -32,7 +32,7 @@
         <td><%= link_to "#{content_block.name} (#{content_block.locale})", edit_admin_site_customization_content_block_path(content_block) %></td>
         <td><%= content_block.body.html_safe %></td>
         <td>
-          <%= button_to t("admin.site_customization.content_blocks.index.delete"),
+          <%= link_to t("admin.site_customization.content_blocks.index.delete"),
                         admin_site_customization_content_block_path(content_block),
                         method: :delete, class: "button hollow alert" %>
         </td>

--- a/app/views/admin/site_customization/content_blocks/new.html.erb
+++ b/app/views/admin/site_customization/content_blocks/new.html.erb
@@ -1,12 +1,11 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.site_customization.content_blocks") %> - <%= t("admin.site_customization.content_blocks.new.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.content_blocks") %> - <%= t("admin.site_customization.content_blocks.new.title") %>
 <% end %>
 
 <%= back_link_to admin_site_customization_content_blocks_path %>
 
-<div class="row">
-  <div class="small-12 column">
-    <h2><%= t("admin.site_customization.content_blocks.new.title") %></h2>
-    <%= render 'form' %>
-  </div>
+<div class="small-12 column">
+  <h2><%= t("admin.site_customization.content_blocks.new.title") %></h2>
 </div>
+
+<%= render 'form' %>

--- a/app/views/admin/site_customization/pages/_form.html.erb
+++ b/app/views/admin/site_customization/pages/_form.html.erb
@@ -13,34 +13,32 @@
     </div>
   <% end %>
 
-  <div class="row">
-    <div class="small-12 column">
-      <hr>
-    </div>
-    <div class="small-12 medium-5 column">
-      <h3><%= t("admin.site_customization.pages.form.options") %></h3>
-      <%= f.check_box :more_info_flag, class: "small" %>
-      <%= f.check_box :print_content_flag %>
-    </div>
-    <div class="small-12 medium-3 column">
-      <%= f.label :status %>
-      <% ::SiteCustomization::Page::VALID_STATUSES.each do |status| %>
-        <%= f.radio_button :status, status, label: false %>
-        <%= f.label "status_#{status}", t("admin.site_customization.pages.page.status_#{status}") %>
-        <br>
-      <% end %>
-    </div>
-    <div class="small-12 medium-4 column">
-      <%= f.label :locale %>
-      <%= f.select :locale, I18n.available_locales.map { |l| [name_for_locale(l), l.to_s] }, { include_blank: true, label: false } %>
-    </div>
-    <div class="small-12 medium-4 column">
-      <%= f.label :slug %>
-      <%= f.text_field :slug, label: false, size: 80, maxlength: 80 %>
-    </div>
+  <div class="small-12 column">
+    <hr>
   </div>
 
-  <div class="row">
+  <div class="small-12 medium-5 column">
+    <h3><%= t("admin.site_customization.pages.form.options") %></h3>
+    <%= f.check_box :more_info_flag, class: "small" %>
+    <%= f.check_box :print_content_flag %>
+  </div>
+  <div class="small-12 medium-3 column">
+    <%= f.label :status %>
+    <% ::SiteCustomization::Page::VALID_STATUSES.each do |status| %>
+      <%= f.radio_button :status, status, label: false %>
+      <%= f.label "status_#{status}", t("admin.site_customization.pages.page.status_#{status}") %>
+      <br>
+    <% end %>
+  </div>
+  <div class="small-12 medium-4 column">
+    <%= f.label :locale %>
+    <%= f.select :locale, I18n.available_locales.map { |l| [name_for_locale(l), l.to_s] }, { include_blank: true, label: false } %>
+  </div>
+  <div class="small-12 medium-4 column">
+    <%= f.label :slug %>
+    <%= f.text_field :slug, label: false, size: 80, maxlength: 80 %>
+  </div>
+
     <div class="small-12 column">
       <hr>
 
@@ -55,7 +53,7 @@
         <%= f.cktext_area :content, label: false, cols: 80, rows: 10, ckeditor: { language: I18n.locale } %>
       </div>
 
-      <div class="small-12 medium-6 large-4">
+      <div class="small-12 medium-6 large-3">
         <%= f.submit class: "button success expanded" %>
       </div>
     </div>

--- a/app/views/admin/site_customization/pages/edit.html.erb
+++ b/app/views/admin/site_customization/pages/edit.html.erb
@@ -1,14 +1,13 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.site_customization.pages") %> - <%= @page.title %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.pages") %> - <%= @page.title %>
 <% end %>
 
 <%= back_link_to admin_site_customization_pages_path %>
 
-<%= button_to t("admin.site_customization.pages.index.delete"), admin_site_customization_page_path(@page), method: :delete, class: "button hollow alert small float-right" %>
+<div class="small-12 column">
+  <h2 class="inline-block"><%= t("admin.site_customization.pages.edit.title", page_title: @page.title) %></h2>
 
-<div class="row">
-  <div class="small-12 column">
-    <h2><%= t("admin.site_customization.pages.edit.title", page_title: @page.title) %></h2>
-    <%= render 'form' %>
-  </div>
+  <%= link_to t("admin.site_customization.pages.index.delete"), admin_site_customization_page_path(@page), method: :delete, class: "delete float-right" %>
 </div>
+
+<%= render 'form' %>

--- a/app/views/admin/site_customization/pages/index.html.erb
+++ b/app/views/admin/site_customization/pages/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.site_customization.pages") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.pages") %>
 <% end %>
 
 <%= link_to t("admin.site_customization.pages.index.create"), new_admin_site_customization_page_path, class: "button float-right" %>
@@ -16,7 +16,7 @@
         <th><%= t("admin.site_customization.pages.page.updated_at") %></th>
         <th><%= t("admin.site_customization.pages.page.status") %></th>
         <th><%= t("admin.site_customization.pages.page.locale") %></th>
-        <th colspan="2"><%= t("admin.actions.actions") %></th>
+        <th class="small-4"><%= t("admin.actions.actions") %></th>
       </tr>
     </thead>
     <tbody>
@@ -29,17 +29,21 @@
         <td><%= I18n.l page.created_at, format: :short %></td>
         <td><%= t("admin.site_customization.pages.page.status_#{page.status}") %></td>
         <td><%= name_for_locale(page.locale) %></td>
-        <td class="small">
-          <span class="icon-eye"></span>
-          <% if page.status == "published" %>
-            <%= link_to t("admin.site_customization.pages.index.see_page"), page.url, target: "_blank" %>
-          <% else %>
-            <%= t("admin.site_customization.pages.index.see_page") %>
-          <% end %>
-        </td>
-        <td class="small delete">
-          <span class="icon-x"></span>
-          <%= link_to t("admin.site_customization.pages.index.delete"), admin_site_customization_page_path(page), method: :delete, class: "delete" %>
+        <td>
+          <div class="small-6 column">
+            <% if page.status == "published" %>
+              <%= link_to t("admin.site_customization.pages.index.see_page"),
+                          page.url,
+                          target: "_blank",
+                          class: "button hollow expanded" %>
+            <% end %>
+          </div>
+          <div class="small-6 column end">
+            <%= link_to t("admin.site_customization.pages.index.delete"),
+                        admin_site_customization_page_path(page),
+                        method: :delete,
+                        class: "button hollow alert expanded" %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/site_customization/pages/new.html.erb
+++ b/app/views/admin/site_customization/pages/new.html.erb
@@ -1,12 +1,11 @@
 <% provide :title do %>
-  Admin - <%= t("admin.menu.site_customization.pages") %> - <%= t("admin.site_customization.pages.new.title") %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.site_customization.pages") %> - <%= t("admin.site_customization.pages.new.title") %>
 <% end %>
 
 <%= back_link_to admin_site_customization_pages_path %>
 
-<div class="row">
-  <div class="small-12 column">
-    <h2><%= t("admin.site_customization.pages.new.title") %></h2>
-    <%= render 'form' %>
-  </div>
+<div class="small-12 column">
+  <h2><%= t("admin.site_customization.pages.new.title") %></h2>
 </div>
+
+<%= render 'form' %>

--- a/app/views/admin/system_emails/index.html.erb
+++ b/app/views/admin/system_emails/index.html.erb
@@ -5,7 +5,7 @@
     <tr>
       <th><%= t("admin.shared.title") %></th>
       <th><%= t("admin.shared.description") %></th>
-      <th class="small-7 text-right"><%= t("admin.shared.actions") %></th>
+      <th class="small-7"><%= t("admin.shared.actions") %></th>
     </tr>
   </thead>
   <tbody>
@@ -17,20 +17,26 @@
       <td>
         <%= t("admin.system_emails.#{system_email_title}.description") %>
       </td>
-      <td class="text-right">
+      <td>
         <% if system_email_actions.include?('view') %>
-          <%= link_to t("admin.shared.view"), admin_system_email_view_path(system_email_title),
-                                              class: "button hollow" %>
+          <div class="small-4 column">
+            <%= link_to t("admin.shared.view"), admin_system_email_view_path(system_email_title),
+                                                class: "button hollow expanded" %>
+          </div>
         <% end %>
         <% if system_email_actions.include?('preview_pending') %>
-          <%= link_to t("admin.system_emails.preview_pending.action"),
-                      admin_system_email_preview_pending_path(system_email_title),
-                      class: "button" %>
+          <div class="small-4 column">
+            <%= link_to t("admin.system_emails.preview_pending.action"),
+                        admin_system_email_preview_pending_path(system_email_title),
+                        class: "button expanded" %>
+          </div>
         <% end %>
-        <%= link_to t("admin.system_emails.preview_pending.send_pending"),
-                    admin_system_email_send_pending_path(system_email_title),
-                    class: "button",
-                    method: :put %>
+        <div class="small-4 column">
+          <%= link_to t("admin.system_emails.preview_pending.send_pending"),
+                      admin_system_email_send_pending_path(system_email_title),
+                      class: "button success expanded",
+                      method: :put %>
+        </div>
       </td>
     </tr>
   <% end %>

--- a/app/views/custom/layouts/_admin_header.html.erb
+++ b/app/views/custom/layouts/_admin_header.html.erb
@@ -2,6 +2,10 @@
   <div class="top-links">
     <div class="expanded row">
       <%= render "shared/locale_switcher" %>
+
+      <%= link_to root_path, class: "float-right" do %>
+        <%= t("admin.dashboard.index.back", org: setting['org_name']) %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -2,6 +2,10 @@
   <div class="top-links">
     <div class="expanded row">
       <%= render "shared/locale_switcher" %>
+
+      <%= link_to root_path, class: "float-right" do %>
+        <%= t("admin.dashboard.index.back", org: setting['org_name']) %>
+      <% end %>
     </div>
   </div>
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -670,7 +670,7 @@ en:
         section_title: Edit notification
       show:
         section_title: Notification preview
-        send: Send
+        send: Send notification
         will_get_notified: (%{n} users will be notified)
         got_notified: (%{n} users got notified)
         sent_at: Sent at
@@ -1064,6 +1064,12 @@ en:
             update: Map configuration updated succesfully.
           form:
             submit: Update
+      setting: Feature
+      setting_actions: Actions
+      setting_name: Setting
+      setting_status: Status
+      setting_value: Value
+      no_description: "No description"
     shared:
       booths_search:
         button: Search

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -1,75 +1,134 @@
 en:
   settings:
     comments_body_max_length: "Comments body max length"
+    comments_body_max_length_description: "In number of characters"
     official_level_1_name: "Level 1 public official"
+    official_level_1_name_description: "Tag that will appear on users marked as Level 1 official position"
     official_level_2_name: "Level 2 public official"
+    official_level_2_name_description: "Tag that will appear on users marked as Level 2 official position"
     official_level_3_name: "Level 3 public official"
+    official_level_3_name_description: "Tag that will appear on users marked as Level 3 official position"
     official_level_4_name: "Level 4 public official"
+    official_level_4_name_description: "Tag that will appear on users marked as Level 4 official position"
     official_level_5_name: "Level 5 public official"
+    official_level_5_name_description: "Tag that will appear on users marked as Level 5 official position"
     max_ratio_anon_votes_on_debates: "Maximum ratio of anonymous votes per Debate"
+    max_ratio_anon_votes_on_debates_description: "Anonymous votes are by registered users with an unverified account"
     max_votes_for_proposal_edit: "Number of votes from which a Proposal can no longer be edited"
+    max_votes_for_proposal_edit_description: "From this number of supports the author of a Proposal can no longer edit it"
     max_votes_for_debate_edit: "Number of votes from which a Debate can no longer be edited"
+    max_votes_for_debate_edit_description: "From this number of votes the author of a Debate can no longer edit it"
     proposal_code_prefix: "Prefix for Proposal codes"
+    proposal_code_prefix_description: "This prefix will appear in the Proposals before the creation date and its ID"
     votes_for_proposal_success: "Number of votes necessary for approval of a Proposal"
+    votes_for_proposal_success_description: "When a proposal reaches this number of supports it will no longer be able to receive more supports and is considered successful"
     months_to_archive_proposals: "Months to archive Proposals"
+    months_to_archive_proposals_description: After this number of months the Proposals will be archived and will no longer be able to receive supports"
     email_domain_for_officials: "Email domain for public officials"
+    email_domain_for_officials_description: "All users registered with this domain will have their account verified at registration"
     per_page_code_head: "Code to be included on every page (<head>)"
+    per_page_code_head_description: "This code will appear inside the <head> label. Useful for entering custom scripts, analitycs..."
     per_page_code_body: "Code to be included on every page (<body>)"
-    analytics_url: "Analytics URL"
+    per_page_code_body_description: "This code will appear inside the <body> label. Useful for entering custom scripts, analitycs..."
     twitter_handle: "Twitter handle"
+    twitter_handle_description: "If filled in it will appear in the footer"
     twitter_hashtag: "Twitter hashtag"
+    twitter_hashtag_description: "Hashtag that will appear when sharing content on Twitter"
     facebook_handle: "Facebook handle"
+    facebook_handle_description: "If filled in it will appear in the footer"
     youtube_handle: "Youtube handle"
+    youtube_handle_description: "If filled in it will appear in the footer"
     telegram_handle: "Telegram handle"
+    telegram_handle_description: "If filled in it will appear in the footer"
     instagram_handle: "Instagram handle"
+    instagram_handle_description: "If filled in it will appear in the footer"
+    url: "Main URL"
+    url_description: "Main URL of your website"
+    org_name: "Organization"
+    org_name_description: "Name of your organization"
+    place_name: "Place"
+    place_name_description: "Name of your city"
+    related_content_score_threshold: "Related content score threshold"
+    related_content_score_threshold_description: "Hides content that users mark as unrelated"
+    map_latitude: "Latitude"
+    map_latitude_description: "Latitude to show the map position"
+    map_longitude: "Longitude"
+    map_longitude_description: "Longitude to show the position of the map"
+    map_zoom: "Zoom"
+    map_zoom_description: "Zoom to show the map position"
+    mailer_from_name: "Sender email name"
+    mailer_from_name_description: "This name will appear in emails sent from the application"
+    mailer_from_address: "Sender email address"
+    mailer_from_address_description: "This email address will appear in emails sent from the application"
+    meta_title: "Site title (SEO)"
+    meta_title_description: "Title for the site <title>, used to improve SEO"
+    meta_description: "Site description (SEO)"
+    meta_description_description: 'Site description <meta name="description">, used to improve SEO'
+    meta_keywords: "Keywords (SEO)"
+    meta_keywords_description: 'Keywords <meta name="keywords">, used to improve SEO'
+    min_age_to_participate: Minimum age needed to participate
+    min_age_to_participate_description: "Users over this age can participate in all processes"
+    analytics_url: "Analytics URL"
     blog_url: "Blog URL"
     transparency_url: "Transparency URL"
     opendata_url: "Open Data URL"
-    url: "Main URL"
-    org_name: "Organization"
-    place_name: "Place"
+    verification_offices_url: Verification offices URL
+    proposal_improvement_path: Proposal improvement info internal link
     feature:
-      budgets: Participatory budgeting
-      twitter_login: Twitter login
-      facebook_login: Facebook login
-      google_login: Google login
-      proposals: Proposals
-      debates: Debates
-      polls: Polls
-      signature_sheets: Signature sheets
-      legislation: Legislation
-      spending_proposals: Investment projects
+      budgets: "Participatory budgeting"
+      budgets_description: "With participatory budgets, citizens decide which projects presented by their neighbours will receive a part of the municipal budget"
+      twitter_login: "Twitter login"
+      twitter_login_description: "Allow users to sign up with their Twitter account"
+      facebook_login: "Facebook login"
+      facebook_login_description: "Allow users to sign up with their Facebook account"
+      google_login: "Google login"
+      google_login_description: "Allow users to sign up with their Google Account"
+      proposals: "Proposals"
+      proposals_description: "Citizens' proposals are an opportunity for neighbours and collectives to decide directly how they want their city to be, after getting sufficient support and submitting to a citizens' vote"
+      debates: "Debates"
+      debates_description: "The citizens' debate space is aimed at anyone who can present issues that concern them and about which they want to share their views with others"
+      polls: "Polls"
+      polls_description:  "Citizens' polls are a participatory mechanism by which citizens with voting rights can make direct decisions"
+      signature_sheets: "Signature sheets"
+      signature_sheets_description: "It allows ading from the Administration panel signatures collected on-site to Proposals and investment projects of the Participative Budgets"
+      legislation: "Legislation"
+      legislation_description: "In participatory processes, citizens are offered the opportunity to participate in the drafting and modification of regulations that affect the city and to give their opinion on certain actions that are planned to be carried out"
+      spending_proposals: "Spending proposals"
+      spending_proposals_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
       spending_proposal_features:
         phase1: "Participatory budget: Phase 1 - Accept proposals"
+        phase1_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
         phase2: "Participatory budget: Phase 2 - Preselect proposals"
+        phase2_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
         phase3: "Participatory budget: Phase 3 - Invest"
+        phase3_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
         open_results_page: "Participatory budget: Make results page public"
+        open_results_page_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
         voting_allowed: Voting on investment projects - Preselection phase
+        voting_allowed_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
         final_voting_allowed: Voting on investment projects - Final phase
+        final_voting_allowed_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
+      user:
+        recommendations: "Recommendations"
+        recommendations_description: "Shows users recommendations on the homepage based on the tags of the following items"
+        skip_verification: "Skip user verification"
+        skip_verification_description: "This will disable user verification and all registered users will be able to participate in all processes"
+        recommendations_on_debates: "Recommendations on debates"
+        recommendations_on_debates_description: "Shows users recommendations to users on the debates page based on the tags of the items followed"
+        recommendations_on_proposals: "Recommendations on proposals"
+        recommendations_on_proposals_description: "Displays recommendations to users on the proposals page based on the tags of the items followed"
+      community: "Community on proposals and investments"
+      community_description: "Enables the community section in the proposals and investment projects of the Participatory Budgets"
+      map: "Proposals and budget investments geolocation"
+      map_description: "Enables geolocation of proposals and investment projects"
+      allow_images: "Allow upload and show images"
+      allow_images_description: "Allows users to upload images when creating proposals and investment projects from Participatory Budgets"
+      allow_attached_documents: "Allow upload and show of attached documents"
+      allow_attached_documents_description: "Allows users to upload documents when creating proposals and investment projects from Participatory Budgets"
+      guides: "Guides to create proposals or investment projects"
+      guides_description: "Displays a guide to differences between proposals and investment projects if there is an active participatory budget"
+      public_stats: "Public stats"
+      public_stats_description: "Display public stats in the Administration panel"
       probe:
         plaza: "Plaza España Probe"
         voting_allowed: Voting on investment projects
-      legislation: Legislation
-      user:
-        recommendations: Recommendations
-        skip_verification: Skip user verification
-        recommendations_on_debates: Recommendations on debates
-        recommendations_on_proposals: Recommendations on proposals
-      community: Community on proposals and investments
-      map: Proposals and budget investments geolocation
-      allow_images: Allow upload and show images
-      allow_attached_documents: Allow upload and show of attached documents
-      guides: Guides to create proposals or investment projects
-      public_stats: Public stats
-    related_content_score_threshold: Related content score threshold
-    map_latitude: Latitude
-    map_longitude: Longitude
-    map_zoom: Zoom
-    mailer_from_name: Origin email name
-    mailer_from_address: Origin email address
-    meta_title: "Site title (SEO)"
-    meta_description: "Site description (SEO)"
-    meta_keywords: "Keywords (SEO)"
-    verification_offices_url: Verification offices URL
-    min_age_to_participate: Minimum age needed to participate
-    proposal_improvement_path: Proposal improvement info internal link

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -499,7 +499,7 @@ es:
           form:
             error: Error
         form:
-          add_option: +Añadir respuesta cerrada
+          add_option: Añadir respuesta cerrada
           title: Pregunta
           title_placeholder: Escribe un título a la pregunta
           value_placeholder: Escribe una respuesta cerrada
@@ -670,7 +670,7 @@ es:
         section_title: Editar notificación
       show:
         section_title: Vista previa de notificación
-        send: Enviar
+        send: Enviar notificación
         will_get_notified: (%{n} usuarios serán notificados)
         got_notified: (%{n} usuarios fueron notificados)
         sent_at: Enviado
@@ -1064,6 +1064,12 @@ es:
             update: La configuración del mapa se ha guardado correctamente.
           form:
             submit: Actualizar
+      setting: Funcionalidad
+      setting_actions: Acciones
+      setting_name: Configuración
+      setting_status: Estado
+      setting_value: Valor
+      no_description: Sin descripción
     shared:
       booths_search:
         button: Buscar

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -1,75 +1,134 @@
 es:
   settings:
     comments_body_max_length: "Longitud máxima de los comentarios"
+    comments_body_max_length_description: "En número de caracteres"
     official_level_1_name: "Cargos públicos de nivel 1"
+    official_level_1_name_description: "Etiqueta que aparecerá en los usuarios marcados como Nivel 1 de cargo público"
     official_level_2_name: "Cargos públicos de nivel 2"
+    official_level_2_name_description: "Etiqueta que aparecerá en los usuarios marcados como Nivel 2 de cargo público"
     official_level_3_name: "Cargos públicos de nivel 3"
+    official_level_3_name_description: "Etiqueta que aparecerá en los usuarios marcados como Nivel 3 de cargo público"
     official_level_4_name: "Cargos públicos de nivel 4"
+    official_level_4_name_description: "Etiqueta que aparecerá en los usuarios marcados como Nivel 4 de cargo público"
     official_level_5_name: "Cargos públicos de nivel 5"
+    official_level_5_name_description: "Etiqueta que aparecerá en los usuarios marcados como Nivel 5 de cargo público"
     max_ratio_anon_votes_on_debates: "Porcentaje máximo de votos anónimos por Debate"
-    max_votes_for_proposal_edit: "Número de votos en que una Propuesta deja de poderse editar"
+    max_ratio_anon_votes_on_debates_description: "Se consideran votos anónimos los realizados por usuarios registrados con una cuenta sin verificar"
+    max_votes_for_proposal_edit: "Número de apoyos en que una Propuesta deja de poderse editar"
+    max_votes_for_proposal_edit_description: "A partir de este número de apoyos el autor de una Propuesta ya no podrá editarla"
     max_votes_for_debate_edit: "Número de votos en que un Debate deja de poderse editar"
+    max_votes_for_debate_edit_description: "A partir de este número de votos el autor de un Debate ya no podrá editarlo"
     proposal_code_prefix: "Prefijo para los códigos de Propuestas"
-    votes_for_proposal_success: "Número de votos necesarios para aprobar una Propuesta"
+    proposal_code_prefix_description: "Este prefijo aparecerá en las Propuestas delante de la fecha de creación y su ID"
+    votes_for_proposal_success: "Número de apoyos necesarios para aprobar una Propuesta"
+    votes_for_proposal_success_description: "Cuando una propuesta alcance este número de apoyos ya no podrá recibir más y se considera exitosa"
     months_to_archive_proposals: "Meses para archivar las Propuestas"
+    months_to_archive_proposals_description: "Pasado este número de meses las Propuestas se archivarán y ya no podrán recoger apoyos"
     email_domain_for_officials: "Dominio de email para cargos públicos"
+    email_domain_for_officials_description: "Todos los usuarios registrados con este dominio tendrán su cuenta verificada al registrarse"
     per_page_code_head: "Código a incluir en cada página (<head>)"
+    per_page_code_head_description: "Esté código aparecerá dentro de la etiqueta <head>. Útil para introducir scripts personalizados, analitycs..."
     per_page_code_body: "Código a incluir en cada página (<body>)"
-    analytics_url: "URL de estadísticas externas"
+    per_page_code_body_description: "Esté código aparecerá dentro de la etiqueta <body>. Útil para introducir scripts personalizados, analitycs..."
     twitter_handle: "Usuario de Twitter"
+    twitter_handle_description: "Si está rellenado aparecerá en el pie de página"
     twitter_hashtag: "Hashtag para Twitter"
+    twitter_hashtag_description: "Hashtag que aparecerá al compartir contenido por Twitter"
     facebook_handle: "Identificador de Facebook"
+    facebook_handle_description: "Si está rellenado aparecerá en el pie de página"
     youtube_handle: "Usuario de Youtube"
+    youtube_handle_description: "Si está rellenado aparecerá en el pie de página"
     telegram_handle: "Usuario de Telegram"
+    telegram_handle_description: "Si está rellenado aparecerá en el pie de página"
     instagram_handle: "Usuario de Instagram"
+    instagram_handle_description: "Si está rellenado aparecerá en el pie de página"
+    url: "URL general de la web"
+    url_description: "URL principal de tu web"
+    org_name: "Nombre de la organización"
+    org_name_description: "Nombre de tu organización"
+    place_name: "Nombre del lugar"
+    place_name_description: "Nombre de tu ciudad"
+    related_content_score_threshold: Umbral de puntuación de contenido relacionado
+    related_content_score_threshold_description: Oculta el contenido que los usuarios marquen como no relacionado
+    map_latitude: "Latitud"
+    map_latitude_description: "Latitud para mostrar la posición del mapa"
+    map_longitude: "Longitud"
+    map_longitude_description: "Longitud para mostrar la posición del mapa"
+    map_zoom: "Zoom"
+    map_zoom_description: "Zoom para mostrar la posición del mapa"
+    mailer_from_name: "Nombre email remitente"
+    mailer_from_name_description: "Este nombre aparecerá en los emails enviados desde la aplicación"
+    mailer_from_address: "Dirección email remitente"
+    mailer_from_address_description: "Esta dirección de email aparecerá en los emails enviados desde la aplicación"
+    meta_title: "Título del sitio"
+    meta_title_description: "Título para el sitio <title>, utilizado para mejorar el SEO"
+    meta_description: "Descripción del sitio"
+    meta_description_description: 'Descripción del sitio <meta name="description">, utilizada para mejorar el SEO'
+    meta_keywords: "Palabras clave"
+    meta_keywords_description: 'Palabras clave <meta name="keywords">, utilizadas para mejorar el SEO'
+    min_age_to_participate: "Edad mínima para participar"
+    min_age_to_participate_description: "Los usuarios mayores de esta edad podrán participar en todos los procesos"
+    analytics_url: "URL de estadísticas externas"
     blog_url: "URL del blog"
     transparency_url: "URL de transparencia"
     opendata_url: "URL de open data"
-    url: "URL general de la web"
-    org_name: "Nombre de la organización"
-    place_name: "Nombre del lugar"
+    verification_offices_url: URL oficinas verificación
+    proposal_improvement_path: Link a información para mejorar propuestas
     feature:
-      budgets: Presupuestos participativos
-      twitter_login: Registro con Twitter
-      facebook_login: Registro con Facebook
-      google_login: Registro con Google
-      proposals: Propuestas
-      debates: Debates
-      polls: Votaciones
-      signature_sheets: Hojas de firmas
-      legislation: Legislación
-      spending_proposals: Propuestas de inversión
+      budgets: "Presupuestos participativos"
+      budgets_description: "Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto municipal"
+      twitter_login: "Registro con Twitter"
+      twitter_login_description: "Permitir que los usuarios se registren con su cuenta de Twitter"
+      facebook_login: "Registro con Facebook"
+      facebook_login_description: "Permitir que los usuarios se registren con su cuenta de Facebook"
+      google_login: "Registro con Google"
+      google_login_description: "Permitir que los usuarios se registren con su cuenta de Google"
+      proposals: "Propuestas"
+      proposals_description: "Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su ciudad, después de conseguir los apoyos suficientes y de someterse a votación ciudadana"
+      debates: "Debates"
+      debates_description: "El espacio de debates ciudadanos está dirigido a que cualquier persona pueda exponer temas que le preocupan y sobre los que quiera compartir puntos de vista con otras personas"
+      polls: "Votaciones"
+      polls_description: "Las votaciones ciudadanas son un mecanismo de participación por el que la ciudadanía con derecho a voto puede tomar decisiones de forma directa"
+      signature_sheets: "Hojas de firmas"
+      signature_sheets_description: "Permite añadir desde el panel de Administración firmas recogidas de forma presencial a Propuestas y proyectos de gasto de los Presupuestos participativos"
+      legislation: "Legislación colaborativa"
+      legislation_description: "En los procesos participativos se ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la ciudad y de dar su opinión sobre ciertas actuaciones que se tiene previsto llevar a cabo"
+      spending_proposals: "Propuestas de inversión"
+      spending_proposals_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
       spending_proposal_features:
         phase1: "Prespuestos participativos: Fase 1 - Aceptar propuestas"
+        phase1_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
         phase2: "Prespuestos participativos: Fase 2 - Preselección de propuestas"
+        phase2_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
         phase3: "Prespuestos participativos: Fase 3 - Votación final"
-        open_results_page:  "Prespuestos participativos: Hacer públicos los resultados"
-        voting_allowed: Votaciones de preselección sobre propuestas de inversión.
-        final_voting_allowed: Votaciones finales en propuestas de inversión.
+        phase3_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
+        open_results_page: "Prespuestos participativos: Hacer públicos los resultados"
+        open_results_page_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
+        voting_allowed: "Votaciones de preselección sobre propuestas de inversión."
+        voting_allowed_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
+        final_voting_allowed: "Votaciones finales en propuestas de inversión."
+        final_voting_allowed_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
+      user:
+        recommendations: "Recomendaciones"
+        recommendations_description: "Muestra a los usuarios recomendaciones en la homepage basado en las etiquetas de los elementos que sigue"
+        skip_verification: "Omitir verificación de usuarios"
+        skip_verification_description: "Esto deshabilitará la verificación de usuarios y todos los usuarios registrados podrán participar en todos los procesos"
+        recommendations_on_debates: "Recomendaciones en debates"
+        recommendations_on_debates_description: "Muestra a los usuarios recomendaciones en la página de debates basado en las etiquetas de los elementos que sigue"
+        recommendations_on_proposals: "Recomendaciones en propuestas"
+        recommendations_on_proposals_description: "Muestra a los usuarios recomendaciones en la página de propuestas basado en las etiquetas de los elementos que sigue"
+      community: "Comunidad en propuestas y proyectos de gasto"
+      community_description: "Activa la sección de comunidad en las propuestas y en los proyectos de gasto de los Presupuestos participativos"
+      map: "Geolocalización de propuestas y proyectos de gasto"
+      map_description: "Activa la geolocalización de propuestas y proyectos de gasto"
+      allow_images: "Permitir subir y mostrar imágenes"
+      allow_images_description: "Permite que los usuarios suban imágenes al crear propuestas y proyectos de gasto de los Presupuestos participativos"
+      allow_attached_documents: "Permitir creación de documentos adjuntos"
+      allow_attached_documents_description: "Permite que los usuarios suban documentos al crear propuestas y proyectos de gasto de los Presupuestos participativos"
+      guides: "Guías para crear propuestas o proyectos de gasto"
+      guides_description: "Muestra una guía de diferencias entre las propuestas y los proyectos de gasto si hay un presupuesto participativo activo"
+      public_stats: "Estadísticas públicas"
+      public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       probe:
         plaza: "Sondeo Plaza España"
         voting_allowed: Votaciones sobre propuestas de inversión
-      legislation: Legislación
-      user:
-        recommendations: Recomendaciones
-        skip_verification: Omitir verificación de usuarios
-        recommendations_on_debates: Recomendaciones en debates
-        recommendations_on_proposals: Recomendaciones en propuestas
-      community: Comunidad en propuestas y proyectos de gasto
-      map: Geolocalización de propuestas y proyectos de gasto
-      allow_images: Permitir subir y mostrar imágenes
-      allow_attached_documents: Permitir creación de documentos adjuntos
-      guides: Guías para crear propuestas o proyectos de inversión
-      public_stats: Estadísticas públicas
-    related_content_score_threshold: Umbral de puntuación de contenido relacionado
-    map_latitude: Latitud
-    map_longitude: Longitud
-    map_zoom: Zoom
-    mailer_from_name: Nombre email remitente
-    mailer_from_address: Dirección email remitente
-    meta_title: "Título del sitio (SEO)"
-    meta_description: "Descripción del sitio (SEO)"
-    meta_keywords: "Palabras clave (SEO)"
-    verification_offices_url: URL oficinas verificación
-    min_age_to_participate: Edad mínima para participar
-    proposal_improvement_path: Link a información para mejorar propuestas

--- a/spec/features/admin/admin_notifications_spec.rb
+++ b/spec/features/admin/admin_notifications_spec.rb
@@ -195,7 +195,7 @@ feature "Admin Notifications" do
 
       visit admin_admin_notification_path(notification)
 
-      accept_confirm { click_link "Send" }
+      accept_confirm { click_link "Send notification" }
 
       expect(page).to have_content "Notification sent successfully"
 

--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -57,7 +57,7 @@ feature 'Admin legislation draft versions' do
       fill_in 'legislation_draft_version_changelog', with: 'Version 3 changes'
       fill_in 'legislation_draft_version_body', with: 'Version 3 body'
 
-      within('.primary-buttons') do
+      within('.end') do
         click_button 'Create version'
       end
 

--- a/spec/features/admin/site_customization/content_blocks_spec.rb
+++ b/spec/features/admin/site_customization/content_blocks_spec.rb
@@ -88,7 +88,7 @@ feature "Admin custom content blocks" do
       expect(page).to have_content("#{block.name} (#{block.locale})")
       expect(page).to have_content(block.body)
 
-      click_button "Delete block"
+      click_link "Delete block"
 
       expect(page).not_to have_content("#{block.name} (#{block.locale})")
       expect(page).not_to have_content(block.body)
@@ -98,7 +98,7 @@ feature "Admin custom content blocks" do
       block = create(:site_customization_content_block)
       visit edit_admin_site_customization_content_block_path(block)
 
-      click_button "Delete block"
+      click_link "Delete block"
 
       expect(page).not_to have_content("#{block.name} (#{block.locale})")
       expect(page).not_to have_content(block.body)

--- a/spec/features/admin/site_customization/pages_spec.rb
+++ b/spec/features/admin/site_customization/pages_spec.rb
@@ -63,7 +63,7 @@ feature "Admin custom pages" do
     custom_page = create(:site_customization_page, title: "An example custom page")
     visit edit_admin_site_customization_page_path(custom_page)
 
-    click_button "Delete page"
+    click_link "Delete page"
 
     expect(page).not_to have_content("An example custom page")
   end


### PR DESCRIPTION
References
===================
This close https://github.com/AyuntamientoMadrid/consul/issues/1416

Objectives
===================

Unifies styles and layout for all admin views. 

Basically this PR removes a lot of redundant `<div class="row">` to improve layout sizing. 

Also unifies sizes and colors for titles, tables and buttons (resolving https://github.com/AyuntamientoMadrid/consul/issues/1416).

Visual Changes
===================
![features](https://user-images.githubusercontent.com/631897/43094846-54ed9438-8eb4-11e8-9dc0-d6ffd600a35f.png)

![settings](https://user-images.githubusercontent.com/631897/43094847-550d5908-8eb4-11e8-8a8d-539dbf2517b4.png)

![polls](https://user-images.githubusercontent.com/631897/43094848-55408e54-8eb4-11e8-9cb7-f3a8a30337c2.png)

![process](https://user-images.githubusercontent.com/631897/43094849-555bea64-8eb4-11e8-8165-8884f2db4f57.png)

![processes](https://user-images.githubusercontent.com/631897/43094850-5575b82c-8eb4-11e8-83ac-afc541e5ff6e.png)

Notes
===================
Backport this to CONSUL repo.