### PR TITLE
Hides token message temporally

### DIFF
--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -37,11 +37,13 @@
         <%= render 'polls/questions/question', question: question, token: @token %>
       <% end %>
 
-      <% if poll_voter_token(@poll, current_user).empty? %>
-        <div class="callout token-message js-token-message" style="display: none">
-          <%= t('poll_questions.show.voted_token') %>
-        </div>
-      <% end %>
+      <!-- Hides token temporally -->
+      <%# if poll_voter_token(@poll, current_user).empty? %>
+        <!-- <div class="callout token-message js-token-message" style="display: none">
+          <%#= t("poll_questions.show.voted_token") %>
+        </div> -->
+      <%# end %>
+      <!-- /.  Hides token temporally -->
     </div>
   </div>
 

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -533,7 +533,7 @@ en:
     show:
       vote_answer: "Vote %{answer}"
       voted: "You have voted %{answer}"
-      voted_token: "You can write down this vote identifier, to check your vote on the final results:"
+      #voted_token: "You can write down this vote identifier, to check your vote on the final results:"
   proposal_notifications:
     new:
       title: "Send message"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -523,7 +523,7 @@ es:
     show:
       vote_answer: "Votar %{answer}"
       voted: "Has votado %{answer}"
-      voted_token: "Puedes apuntar este identificador de voto, para comprobar tu votación en el resultado final:"
+      #voted_token: "Puedes apuntar este identificador de voto, para comprobar tu votación en el resultado final:"
   proposal_notifications:
     new:
       title: "Enviar mensaje"

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -36,10 +36,11 @@ feature "Voter" do
         expect(page).not_to have_link(answer_yes.title)
       end
 
-      expect(page).to have_css(".js-token-message", visible: true)
-      token = find(:css, ".js-question-answer")[:href].gsub(/.+?(?=token)/, '').gsub('token=', '')
+      # Hides token temporally
+      #expect(page).to have_css(".js-token-message", visible: true)
+      #token = find(:css, ".js-question-answer")[:href].gsub(/.+?(?=token)/, '').gsub('token=', '')
 
-      expect(page).to have_content "You can write down this vote identifier, to check your vote on the final results: #{token}"
+      #expect(page).to have_content "You can write down this vote identifier, to check your vote on the final results: #{token}"
 
       expect(Poll::Voter.count).to eq(1)
       expect(Poll::Voter.first.origin).to eq("web")


### PR DESCRIPTION
Objectives
===================
Hides token message temporally when a user select an answer on `polls/show`

Visual Changes
===================
**Hides this message**
![token_message](https://user-images.githubusercontent.com/631897/43014633-1cd0fcf2-8c4d-11e8-8cc3-7d234641f65d.png)

Notes
===================
This is temporal doesn't need to backport.