### PR TITLE
Fixes budget investments specs

### DIFF
--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -881,6 +881,10 @@ feature 'Budget Investments' do
           expect(page).to have_content(investment.formatted_price)
           expect(page).to have_content(investment.price_explanation)
 
+          if budget.finished?
+            investment.update(winner: true)
+          end
+
           visit budget_investments_path(budget)
 
           expect(page).to have_content(investment.formatted_price)

--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -311,6 +311,12 @@ feature 'Tags' do
           investment.update(selected: true, feasibility: "feasible")
         end
 
+        if budget.finished?
+          [investment1, investment2, investment3].each do |investment|
+            investment.update(selected: true, feasibility: "feasible", winner: true)
+          end
+        end
+
         login_as(admin) if budget.drafting?
         visit budget_path(budget)
         click_link group.name


### PR DESCRIPTION
Objectives
===================
Fixes budget investments specs:
- **Tags Categories Filter by category tags**
`spec/features/tags/budget_investments_spec.rb:306` 

- **Budget Investments Show Investment's price & cost explanation When investment with price is selected Price & explanation is shown when Budget is on published prices phase**
`/spec/features/budgets/investments_spec.rb:876`

These specs was failing in the **finished phase** because now we are only displaying winner projects in this phase. With this commits, all investments are marked as winners if budget finished so that they appear correctly.

🎉 

Notes
===================
Backport this to CONSUL repo.