### PR TITLE
Add geozone segments for newsletters

### DIFF
--- a/app/helpers/user_segments_helper.rb
+++ b/app/helpers/user_segments_helper.rb
@@ -1,6 +1,6 @@
 module UserSegmentsHelper
   def user_segments_options
-    UserSegments::SEGMENTS.collect do |user_segment_name|
+    UserSegments.segments.collect do |user_segment_name|
       [t("admin.segment_recipient.#{user_segment_name}"), user_segment_name]
     end
   end

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -612,6 +612,27 @@ en:
       winner_investment_authors: Authors of winner investments in the current budget
       not_supported_on_current_budget: Users that haven't supported investments on current budget
       invalid_recipients_segment: "Recipients user segment is invalid"
+      arganzuela: Arganzuela
+      barajas: Barajas
+      carabanchel: Carabanchel
+      centro: Centro
+      chamartin: Chamartín
+      chamberi: Chamberí
+      ciudad_lineal: Ciudad Lineal
+      fuencarral_el_pardo: Fuencarral-El Pardo
+      hortaleza: Hortaleza
+      latina: Latina
+      moncloa_aravaca: Moncloa-Aravaca
+      moratalaz: Moratalaz
+      puente_de_vallecas: Puente de Vallecas
+      retiro: Retiro
+      salamanca: Salamanca
+      san_blas_canillejas: San Blas-Canillejas
+      tetuan: Tetuán
+      usera: Usera
+      vicalvaro: Vicálvaro
+      villa_de_vallecas: Villa de Vallecas
+      villaverde: Villaverde
     newsletters:
       create_success: Newsletter created successfully
       update_success: Newsletter updated successfully

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -612,6 +612,27 @@ es:
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
       not_supported_on_current_budget: Usuarios que no han apoyado proyectos de los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"
+      arganzuela: Arganzuela
+      barajas: Barajas
+      carabanchel: Carabanchel
+      centro: Centro
+      chamartin: Chamartín
+      chamberi: Chamberí
+      ciudad_lineal: Ciudad Lineal
+      fuencarral_el_pardo: Fuencarral-El Pardo
+      hortaleza: Hortaleza
+      latina: Latina
+      moncloa_aravaca: Moncloa-Aravaca
+      moratalaz: Moratalaz
+      puente_de_vallecas: Puente de Vallecas
+      retiro: Retiro
+      salamanca: Salamanca
+      san_blas_canillejas: San Blas-Canillejas
+      tetuan: Tetuán
+      usera: Usera
+      vicalvaro: Vicálvaro
+      villa_de_vallecas: Villa de Vallecas
+      villaverde: Villaverde
     newsletters:
       create_success: Newsletter creada correctamente
       update_success: Newsletter actualizada correctamente

--- a/db/dev_seeds/newsletters.rb
+++ b/db/dev_seeds/newsletters.rb
@@ -14,7 +14,7 @@ section "Creating Newsletters" do
   5.times do |n|
     Newsletter.create!(
       subject: "Newsletter subject #{n}",
-      segment_recipient: UserSegments::SEGMENTS.sample,
+      segment_recipient: UserSegments.segments.sample,
       from: 'no-reply@consul.dev',
       body: newsletter_body.sample,
       sent_at: [Time.now, nil].sample

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -1,13 +1,16 @@
 class UserSegments
-  SEGMENTS = %w(all_users
-                administrators
-                proposal_authors
-                investment_authors
-                feasible_and_undecided_investment_authors
-                selected_investment_authors
-                winner_investment_authors
-                not_supported_on_current_budget
-                beta_testers) + Geozone.all.map(&:name).map(&:parameterize).map(&:underscore).sort - ["city"]
+
+  def self.segments
+    %w(all_users
+       administrators
+       proposal_authors
+       investment_authors
+       feasible_and_undecided_investment_authors
+       selected_investment_authors
+       winner_investment_authors
+       not_supported_on_current_budget
+       beta_testers) + geozones
+  end
 
   def self.all_users
     User.active
@@ -58,6 +61,10 @@ class UserSegments
                  voodoorai2000@gmail.com)
 
     User.where(email: testers)
+  end
+
+  def self.geozones
+    Geozone.pluck(:name).map(&:parameterize).map(&:underscore).sort - ["city"]
   end
 
   Geozone.all.each do |geozone|

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -7,7 +7,7 @@ class UserSegments
                 selected_investment_authors
                 winner_investment_authors
                 not_supported_on_current_budget
-                beta_testers)
+                beta_testers) + Geozone.all.map(&:name).map(&:parameterize).map(&:underscore).sort - ["city"]
 
   def self.all_users
     User.active
@@ -60,6 +60,13 @@ class UserSegments
     User.where(email: testers)
   end
 
+  Geozone.all.each do |geozone|
+    method_name = geozone.name.parameterize.underscore
+    self.define_singleton_method(:"#{method_name}") do
+      all_users.where(geozone: geozone)
+    end
+  end
+
   def self.user_segment_emails(users_segment)
     UserSegments.send(users_segment).newsletter.pluck(:email).compact
   end
@@ -73,4 +80,5 @@ class UserSegments
   def self.author_ids(author_ids)
     all_users.where(id: author_ids)
   end
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1124,7 +1124,7 @@ LOREM_IPSUM
 
   factory :newsletter do
     sequence(:subject) { |n| "Subject #{n}" }
-    segment_recipient  UserSegments::SEGMENTS.sample
+    segment_recipient  UserSegments.segments.sample
     sequence(:from)    { |n| "noreply#{n}@consul.dev" }
     sequence(:body)    { |n| "Body #{n}" }
   end
@@ -1133,7 +1133,7 @@ LOREM_IPSUM
     title             { |n| "Admin Notification title #{n}" }
     body              { |n| "Admin Notification body #{n}" }
     link              nil
-    segment_recipient UserSegments::SEGMENTS.sample
+    segment_recipient UserSegments.segments.sample
     recipients_count  nil
     sent_at           nil
 

--- a/spec/features/admin/admin_notifications_spec.rb
+++ b/spec/features/admin/admin_notifications_spec.rb
@@ -222,7 +222,7 @@ feature "Admin Notifications" do
   end
 
   scenario "Select list of users to send notification" do
-    UserSegments::SEGMENTS.each do |user_segment|
+    UserSegments.segments.each do |user_segment|
       segment_recipient = I18n.t("admin.segment_recipient.#{user_segment}")
 
       visit new_admin_admin_notification_path

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -146,14 +146,33 @@ feature "Admin newsletter emails" do
     end
   end
 
-  scenario "Select list of users to send newsletter" do
-    UserSegments::SEGMENTS.each do |user_segment|
-      visit new_admin_newsletter_path
+  context "Select list of users to send newsletter" do
 
-      fill_in_newsletter_form(segment_recipient: I18n.t("admin.segment_recipient.#{user_segment}"))
-      click_button "Create Newsletter"
+    scenario "Custom user segments" do
+      UserSegments.segments.each do |user_segment|
+        visit new_admin_newsletter_path
 
-      expect(page).to have_content(I18n.t("admin.segment_recipient.#{user_segment}"))
+        fill_in_newsletter_form(segment_recipient: I18n.t("admin.segment_recipient.#{user_segment}"))
+        click_button "Create Newsletter"
+
+        expect(page).to have_content(I18n.t("admin.segment_recipient.#{user_segment}"))
+      end
     end
+
+    scenario "Geozone segments" do
+      create(:geozone, name: "Arganzuela")
+      create(:geozone, name: "Barajas")
+      create(:geozone, name: "Centro")
+
+      Geozone.pluck(:name).each do |geozone|
+        visit new_admin_newsletter_path
+
+        fill_in_newsletter_form(segment_recipient: I18n.t("admin.segment_recipient.#{geozone.parameterize.underscore}"))
+        click_button "Create Newsletter"
+
+        expect(page).to have_content(I18n.t("admin.segment_recipient.#{geozone.parameterize.underscore}"))
+      end
+    end
+
   end
 end

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -206,4 +206,42 @@ describe UserSegments do
     end
   end
 
+  context "Geozones" do
+
+    let!(:new_york) { create(:geozone, name: "New York") }
+    let!(:california) { create(:geozone, name: "California") }
+    let!(:mars) { create(:geozone, name: "Mars") }
+
+    let(:user1) { create(:user, geozone: new_york) }
+    let(:user2) { create(:user, geozone: new_york) }
+    let(:user3) { create(:user, geozone: california) }
+    let(:user4) { create(:user, geozone: mars) }
+
+    before do
+      load 'lib/user_segments.rb'
+    end
+
+    it "dynamically generates user segments for all geozones" do
+      expect(described_class).to respond_to("new_york")
+      expect(described_class).to respond_to("california")
+      expect(described_class).to respond_to("mars")
+      expect(described_class).to_not respond_to("jupiter")
+    end
+
+    it "returns users of a geozone" do
+      expect(described_class.new_york).to include(user1)
+      expect(described_class.new_york).to include(user2)
+      expect(described_class.new_york).to_not include(user3)
+      expect(described_class.new_york).to_not include(user4)
+    end
+
+    it "only returns active users of a geozone" do
+      user2.update(erased_at: Time.current)
+
+      expect(described_class.new_york).to include(user1)
+      expect(described_class.new_york).to_not include(user2)
+    end
+
+  end
+
 end

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -228,6 +228,17 @@ describe UserSegments do
       expect(described_class).to_not respond_to("jupiter")
     end
 
+    it "includes geozones in available segments" do
+      expect(described_class.segments).to include("new_york")
+      expect(described_class.segments).to include("california")
+      expect(described_class.segments).to include("mars")
+      expect(described_class.segments).to_not include("jupiter")
+    end
+
+    it "does not include the generic city as a segment" do
+      expect(described_class.segments).to_not include("city")
+    end
+
     it "returns users of a geozone" do
       expect(described_class.new_york).to include(user1)
       expect(described_class.new_york).to include(user2)


### PR DESCRIPTION
Objectives
===================
Allow sending newsletters to users of a specific geozone

Visual Changes
===================
Added geozone segments
![geozone segments](https://user-images.githubusercontent.com/4169/43160160-b5d8e920-8f84-11e8-9cf1-982a86fa95b4.png)

Notes
===================
When backporting, think about a solution that does not require translating geozone names, as it's hard to [test](https://github.com/AyuntamientoMadrid/consul/compare/master...AyuntamientoMadrid:user_segments_for_geozones?expand=1#diff-e2806d59b4ed9091bc09a0652196a30dR163) for geozones that are not present in translations. And each fork would have to add this custom translations. It should be possible to reproduce this funcionality using the Geozones themselves instead of custom translations 😌