### PR TITLE
Change Muros polls texts

### DIFF
--- a/app/views/custom/polls/index.html.erb
+++ b/app/views/custom/polls/index.html.erb
@@ -18,10 +18,6 @@
   <div class="small-12 column">
     <%= render 'shared/filter_subnav', i18n_namespace: "polls.index" %>
 
-    <h3 class="margin-top"><%= t("polls.index.muros_title") %></h3>
-    <p><%= t("polls.index.muros_1_html") %></p>
-    <p><%= t("polls.index.muros_2") %>&nbsp;<%= t("polls.index.muros_3_html") %></p>
-
     <% if @polls.any? %>
       <% polls_by_geozone_restriction = @polls.group_by(&:geozone_restricted) %>
 

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -298,12 +298,8 @@ en:
         gender: "Participation by gender"
         district: "Participation by district"
     index:
-      title: "Vota un diseño de mural para cada distrito"
-      description: "Entra en Decide Madrid y vota el diseño de mural que embellecerá tu distrito."
-      muros_title: "Compartiendo muros"
-      muros_1_html: 'La iniciativa <strong>"Compartiendo Muros"</strong>, promovida por la Dirección General de Intervención en el Paisaje Urbano y el Patrimonio Cultural, tiene como objetivo principal que la ciudadanía identifique el espacio público como algo suyo, participe en su embellecimiento y se responsabilice de su conservación y mantenimiento a través de acciones artísticas abiertas a la participación del tejido creativo radicado en el distrito.'
-      muros_2: "Los murales son fruto de la colaboración entre el vecindario de los distritos y el o la artista que se ha elegido por convocatoria abierta para llevar a cabo este proyecto en cada uno de los distritos."
-      muros_3_html: "Elige el diseño que prefieres para embellecer tu distrito. <strong>Puedes votar desde el viernes 20 de julio hasta el martes 31 de julio</strong>. Las intervenciones artísticas cuyos diseños resulten elegidos se realizarán entre el 3 de septiembre y el 9 de octubre."
+      title: "Crea una propuesta que quieras que el Ayuntamiento de Madrid lleve a cabo"
+      description: "Entra en Decide Madrid y crea una propuesta"
   first_2017_poll:
     title: FIRST CITIZEN POLL
     date: FEBRUARY 13th-19th, 2017

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -298,12 +298,8 @@ es:
         age: "Participación por grupos de edad"
         district: "Participación por distrito"
     index:
-      title: "Vota un diseño de mural para cada distrito"
-      description: "Entra en Decide Madrid y vota el diseño de mural que embellecerá tu distrito."
-      muros_title: "Compartiendo muros"
-      muros_1_html: 'La iniciativa <strong>"Compartiendo Muros"</strong>, promovida por la Dirección General de Intervención en el Paisaje Urbano y el Patrimonio Cultural, tiene como objetivo principal que la ciudadanía identifique el espacio público como algo suyo, participe en su embellecimiento y se responsabilice de su conservación y mantenimiento a través de acciones artísticas abiertas a la participación del tejido creativo radicado en el distrito.'
-      muros_2: "Los murales son fruto de la colaboración entre el vecindario de los distritos y el o la artista que se ha elegido por convocatoria abierta para llevar a cabo este proyecto en cada uno de los distritos."
-      muros_3_html: "Elige el diseño que prefieres para embellecer tu distrito. <strong>Puedes votar desde el viernes 20 de julio hasta el martes 31 de julio</strong>. Las intervenciones artísticas cuyos diseños resulten elegidos se realizarán entre el 3 de septiembre y el 9 de octubre."
+      title: "Crea una propuesta que quieras que el Ayuntamiento de Madrid lleve a cabo"
+      description: "Entra en Decide Madrid y crea una propuesta"
   first_2017_poll:
     title: PRIMERA VOTACIÓN CIUDADANA
     date: 13-19 DE FEBRERO 2017


### PR DESCRIPTION
Objectives
============
- Remove explicative content from the polls index page about the Muros polls.

Notes
============
There's no need to backport these changes to CONSUL.