### PR TITLE
[Refactor] Basic content for I18n on Admin panel

### DIFF
--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -66,10 +66,9 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
       locale = params[:locale] || I18n.locale
       translations = I18n.backend.send(:translations)[locale.to_sym]
 
-      translations.each do |k, v|
-        @content[k.to_s] = I18nContent.flat_hash(v).keys.map { |s|
-          @existing_keys["#{k.to_s}.#{s}"].nil? ? I18nContent.new(key: "#{k.to_s}.#{s}") :
-                                                  @existing_keys["#{k.to_s}.#{s}"]
+      translations.each do |key, value|
+        @content[key.to_s] = I18nContent.flat_hash(value).keys.map { |string|
+          @existing_keys["#{key.to_s}.#{string}"] || I18nContent.new(key: "#{key.to_s}.#{string}")
         }
       end
     end

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -13,7 +13,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
 
       unless values.empty?
         values.each do |key, value|
-          locale = key.split("_").last
+          locale = key.split('_').last
 
           if value == t(content[:id], locale: locale) || value.match(/translation missing/)
             next
@@ -44,6 +44,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
     def delete_translations
       languages_to_delete = params[:enabled_translations].select { |_, v| v == '0' }
                                                          .keys
+
       languages_to_delete.each do |locale|
         I18nContentTranslation.destroy_all(locale: locale)
       end
@@ -53,9 +54,9 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
       @existing_keys = {}
       @tab = params[:tab] || :debates
 
-      I18nContent.begins_with_key(@tab)
-                 .all
-                 .map{ |content| @existing_keys[content.key] = content }
+      I18nContent.begins_with_key(@tab).map { |content|
+        @existing_keys[content.key] = content
+      }
     end
 
     def append_or_create_keys
@@ -66,10 +67,10 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
       translations = I18n.backend.send(:translations)[locale.to_sym]
 
       translations.each do |k, v|
-        @content[k.to_s] = I18nContent.flat_hash(v).keys
-                                      .map { |s| @existing_keys["#{k.to_s}.#{s}"].nil? ?
-                                                 I18nContent.new(key: "#{k.to_s}.#{s}") :
-                                                 @existing_keys["#{k.to_s}.#{s}"] }
+        @content[k.to_s] = I18nContent.flat_hash(v).keys.map { |s|
+          @existing_keys["#{k.to_s}.#{s}"].nil? ? I18nContent.new(key: "#{k.to_s}.#{s}") :
+                                                  @existing_keys["#{k.to_s}.#{s}"]
+        }
       end
     end
 

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -66,17 +66,11 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
       translations = I18n.backend.send(:translations)[locale.to_sym]
 
       translations.each do |k, v|
-        @content[k.to_s] = flat_hash(v).keys
-                                       .map { |s| @existing_keys["#{k.to_s}.#{s}"].nil? ?
-                                              I18nContent.new(key: "#{k.to_s}.#{s}") :
-                                              @existing_keys["#{k.to_s}.#{s}"] }
+        @content[k.to_s] = I18nContent.flat_hash(v).keys
+                                      .map { |s| @existing_keys["#{k.to_s}.#{s}"].nil? ?
+                                                 I18nContent.new(key: "#{k.to_s}.#{s}") :
+                                                 @existing_keys["#{k.to_s}.#{s}"] }
       end
-    end
-
-    def flat_hash(h, f = nil, g = {})
-      return g.update({ f => h }) unless h.is_a? Hash
-      h.each { |k, r| flat_hash(r, [f,k].compact.join('.'), g) }
-      return g
     end
 
 end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -12,15 +12,13 @@ module SiteCustomizationHelper
     i18n_content = I18nContent.where(key: content.key).first
 
     if i18n_content.present?
-      translation = I18nContentTranslation.where(
+      I18nContentTranslation.where(
         i18n_content_id: i18n_content.id,
         locale: locale
       ).first.try(:value)
     else
-      translation = false
+      false
     end
-
-    return translation
   end
 
 end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -1,4 +1,5 @@
 module SiteCustomizationHelper
+
   def site_customization_enable_translation?(locale)
     I18nContentTranslation.existing_languages.include?(locale) || locale == I18n.locale
   end
@@ -6,4 +7,20 @@ module SiteCustomizationHelper
   def site_customization_display_translation?(locale)
     site_customization_enable_translation?(locale) ? "" : "display: none;"
   end
+
+  def translation_for_locale(content, locale)
+    i18n_content = I18nContent.where(key: content.key).first
+
+    if i18n_content.present?
+      translation = I18nContentTranslation.where(
+        i18n_content_id: i18n_content.id,
+        locale: locale
+      ).first.try(:value)
+    else
+      translation = false
+    end
+
+    return translation
+  end
+
 end

--- a/app/models/i18n_content.rb
+++ b/app/models/i18n_content.rb
@@ -1,7 +1,6 @@
 class I18nContent < ActiveRecord::Base
-
-  scope :by_key, -> (key){ where(key: key) }
-  scope :begins_with_key, -> (key){ where("key ILIKE ?", "#{key}?%") }
+  scope :by_key,          ->(key) { where(key: key) }
+  scope :begins_with_key, ->(key) { where("key ILIKE ?", "#{key}%") }
 
   validates :key, uniqueness: true
 

--- a/app/models/i18n_content.rb
+++ b/app/models/i18n_content.rb
@@ -40,10 +40,10 @@ class I18nContent < ActiveRecord::Base
   #   'string.key2.key4.key5' => 'value3'
   # }
 
-  def self.flat_hash(h, f = nil, g = {})
-    return g.update({ f => h }) unless h.is_a? Hash
-    h.map { |k, r| flat_hash(r, [f, k].compact.join('.'), g) }
-    return g
+  def self.flat_hash(input, path = nil, output = {})
+    return output.update({ path => input }) unless input.is_a? Hash
+    input.map { |key, value| flat_hash(value, [path, key].compact.join('.'), output) }
+    return output
   end
 
 end

--- a/app/models/i18n_content.rb
+++ b/app/models/i18n_content.rb
@@ -1,4 +1,5 @@
 class I18nContent < ActiveRecord::Base
+
   scope :by_key,          ->(key) { where(key: key) }
   scope :begins_with_key, ->(key) { where("key ILIKE ?", "#{key}%") }
 
@@ -7,35 +8,41 @@ class I18nContent < ActiveRecord::Base
   translates :value, touch: true
   globalize_accessors locales: [:en, :es, :fr, :nl, :val]
 
-
-  # flat_hash function returns a flattened hash, a hash of a single
-  # level of profundity in which each key is composed from the
-  # keys of the original hash (whose value is not a hash) by
-  # typing in the key the route from the first level of the
-  # original hash
+  # flat_hash returns a flattened hash, a hash with a single level of
+  # depth in which each key is composed from the keys of the original
+  # hash (whose value is not a hash) by typing in the key of the route
+  # from the first level of the original hash
   #
-  # examples
-  # hash = {'key1' => 'value1',
-  #         'key2' => {'key3' => 'value2',
-  #                    'key4' => {'key5' => 'value3'}}}
+  # Examples:
   #
-  # I18nContent.flat_hash(hash) = {"key1"=>"value1",
-  #                                "key2.key3"=>"value2",
-  #                                "key2.key4.key5"=>"value3"}
+  # hash = {
+  #   'key1' => 'value1',
+  #   'key2' => { 'key3' => 'value2',
+  #               'key4' => { 'key5' => 'value3' } }
+  # }
   #
-  # I18nContent.flat_hash(hash, 'string') = {"string.key1"=>"value1",
-  #                                          "string.key2.key3"=>"value2",
-  #                                          "string.key2.key4.key5"=>"value3"}
+  # I18nContent.flat_hash(hash) = {
+  #   'key1' => 'value1',
+  #   'key2.key3' => 'value2',
+  #   'key2.key4.key5' => 'value3'
+  # }
   #
-  # I18nContent.flat_hash(hash, 'string', {'key6' => "value4"}) =
-  #                                         {'key6' => "value4",
-  #                                          "string.key1"=>"value1",
-  #                                          "string.key2.key3"=>"value2",
-  #                                          "string.key2.key4.key5"=>"value3"}
+  # I18nContent.flat_hash(hash, 'string') = {
+  #   'string.key1' => 'value1',
+  #   'string.key2.key3' => 'value2',
+  #   'string.key2.key4.key5' => 'value3'
+  # }
+  #
+  # I18nContent.flat_hash(hash, 'string', { 'key6' => 'value4' }) = {
+  #   'key6' => 'value4',
+  #   'string.key1' => 'value1',
+  #   'string.key2.key3' => 'value2',
+  #   'string.key2.key4.key5' => 'value3'
+  # }
 
   def self.flat_hash(h, f = nil, g = {})
     return g.update({ f => h }) unless h.is_a? Hash
-    h.each { |k, r| flat_hash(r, [f,k].compact.join('.'), g) }
+    h.map { |k, r| flat_hash(r, [f, k].compact.join('.'), g) }
     return g
   end
 

--- a/app/models/i18n_content.rb
+++ b/app/models/i18n_content.rb
@@ -6,4 +6,37 @@ class I18nContent < ActiveRecord::Base
 
   translates :value, touch: true
   globalize_accessors locales: [:en, :es, :fr, :nl, :val]
+
+
+  # flat_hash function returns a flattened hash, a hash of a single
+  # level of profundity in which each key is composed from the
+  # keys of the original hash (whose value is not a hash) by
+  # typing in the key the route from the first level of the
+  # original hash
+  #
+  # examples
+  # hash = {'key1' => 'value1',
+  #         'key2' => {'key3' => 'value2',
+  #                    'key4' => {'key5' => 'value3'}}}
+  #
+  # I18nContent.flat_hash(hash) = {"key1"=>"value1",
+  #                                "key2.key3"=>"value2",
+  #                                "key2.key4.key5"=>"value3"}
+  #
+  # I18nContent.flat_hash(hash, 'string') = {"string.key1"=>"value1",
+  #                                          "string.key2.key3"=>"value2",
+  #                                          "string.key2.key4.key5"=>"value3"}
+  #
+  # I18nContent.flat_hash(hash, 'string', {'key6' => "value4"}) =
+  #                                         {'key6' => "value4",
+  #                                          "string.key1"=>"value1",
+  #                                          "string.key2.key3"=>"value2",
+  #                                          "string.key2.key4.key5"=>"value3"}
+
+  def self.flat_hash(h, f = nil, g = {})
+    return g.update({ f => h }) unless h.is_a? Hash
+    h.each { |k, r| flat_hash(r, [f,k].compact.join('.'), g) }
+    return g
+  end
+
 end

--- a/app/views/admin/shared/_common_globalize_locales.html.erb
+++ b/app/views/admin/shared/_common_globalize_locales.html.erb
@@ -1,0 +1,27 @@
+<% I18n.available_locales.each do |locale| %>
+  <%= link_to t("admin.translations.remove_language"), "#",
+              id: "delete-#{locale}",
+              style: show_delete?(locale),
+              class: 'float-right delete js-delete-language',
+              data: { locale: locale } %>
+
+<% end %>
+
+<ul class="tabs" data-tabs id="globalize_locale">
+  <% I18n.available_locales.each do |locale| %>
+    <li class="tabs-title">
+      <%= link_to name_for_locale(locale), "#",
+                  style: display_locale_condition.call(locale) ? "" : "display: none",
+                  class: "js-globalize-locale-link #{highlight_current?(locale)}",
+                  data: { locale: locale },
+                  remote: true %>
+    </li>
+  <% end %>
+</ul>
+
+<div class="small-12 medium-6">
+  <%= select_tag :translation_locale,
+                 options_for_locale_select,
+                 prompt: t("admin.translations.add_language"),
+                 class: "js-globalize-locale" %>
+</div>

--- a/app/views/admin/shared/_globalize_locales.html.erb
+++ b/app/views/admin/shared/_globalize_locales.html.erb
@@ -1,27 +1,3 @@
-<% I18n.available_locales.each do |locale| %>
-  <%= link_to t("admin.translations.remove_language"), "#",
-              id: "delete-#{locale}",
-              style: show_delete?(locale),
-              class: 'float-right delete js-delete-language',
-              data: { locale: locale } %>
-
-<% end %>
-
-<ul class="tabs" data-tabs id="globalize_locale">
-  <% I18n.available_locales.each do |locale| %>
-    <li class="tabs-title">
-      <%= link_to name_for_locale(locale), "#",
-                  style: css_to_display_translation?(resource, locale),
-                  class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                  data: { locale: locale },
-                  remote: true %>
-    </li>
-  <% end %>
-</ul>
-
-<div class="small-12 medium-6">
-  <%= select_tag :translation_locale,
-                 options_for_locale_select,
-                 prompt: t("admin.translations.add_language"),
-                 class: "js-globalize-locale" %>
-</div>
+<%= render "admin/shared/common_globalize_locales", display_locale_condition: lambda { |locale|
+  css_to_display_translation?(resource, locale)
+} %>

--- a/app/views/admin/site_customization/information_texts/_form_field.html.erb
+++ b/app/views/admin/site_customization/information_texts/_form_field.html.erb
@@ -1,15 +1,6 @@
 <% globalize(locale) do %>
-  
-  <% i18n_content = I18nContent.where(key: content.key).first %>
-  <% if i18n_content.present? %>
-    <% i18n_content_translation = I18nContentTranslation.where(i18n_content_id: i18n_content.id, locale: locale).first.try(:value) %>
-  <% else %>
-    <% i18n_content_translation = false %>
-  <% end %>
-
   <%= hidden_field_tag "contents[content_#{content.key}][id]", content.key %>
   <%= text_area_tag "contents[content_#{content.key}]values[value_#{locale}]",
-                    i18n_content_translation ||
-                    t(content.key, locale: locale),
+                    translation_for_locale(content, locale) || t(content.key, locale: locale),
                     merge_translatable_field_options({rows: 5}, locale) %>
 <% end %>

--- a/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
+++ b/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
@@ -1,27 +1,3 @@
-<% I18n.available_locales.each do |locale| %>
-  <%= link_to t("admin.translations.remove_language"), "#",
-              id: "delete-#{locale}",
-              style: show_delete?(locale),
-              class: 'float-right delete js-delete-language',
-              data: { locale: locale } %>
-
-<% end %>
-
-<ul class="tabs" data-tabs id="globalize_locale">
-  <% I18n.available_locales.each do |locale| %>
-    <li class="tabs-title">
-      <%= link_to name_for_locale(locale), "#",
-                  style: site_customization_display_translation?(locale),
-                  class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                  data: { locale: locale },
-                  remote: true %>
-    </li>
-  <% end %>
-</ul>
-
-<div class="small-12 medium-6">
-  <%= select_tag :translation_locale,
-                 options_for_locale_select,
-                 prompt: t("admin.translations.add_language"),
-                 class: "js-globalize-locale" %>
-</div>
+<%= render "admin/shared/common_globalize_locales", display_locale_condition: lambda { |locale|
+  site_customization_display_translation?(locale)
+} %>

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -73,4 +73,36 @@ RSpec.describe I18nContent, type: :model do
       expect(i18n_content.value).to eq('Texto en español')
     end
   end
+
+  context 'flat_hash' do
+
+    it 'using one parameter' do
+      expect(I18nContent.flat_hash(nil)).to eq({nil=>nil})
+      expect(I18nContent.flat_hash('string')).to eq({nil=>'string'})
+      expect(I18nContent.flat_hash({w: 'string'})).to eq({"w" => 'string'})
+      expect(I18nContent.flat_hash({w: {p: 'string'}})).to eq({"w.p" => 'string'})
+    end
+
+    it 'using the two first parameters' do
+      expect(I18nContent.flat_hash('string', 'f')).to eq({'f'=>'string'})
+      expect(I18nContent.flat_hash(nil, 'f')).to eq({"f" => nil})
+      expect(I18nContent.flat_hash({w: 'string'}, 'f')).to eq({"f.w" => 'string'})
+      expect(I18nContent.flat_hash({w: {p: 'string'}}, 'f')).to eq({"f.w.p" => 'string'})
+    end
+
+    it 'using the first and last parameters' do
+      expect {I18nContent.flat_hash('string', nil, 'not hash')}.to raise_error NoMethodError
+      expect(I18nContent.flat_hash(nil, nil, {q: 'other string'})).to eq({q: 'other string', nil => nil})
+      expect(I18nContent.flat_hash({w: 'string'}, nil, {q: 'other string'})).to eq({q: 'other string', "w" => 'string'})
+      expect(I18nContent.flat_hash({w: {p: 'string'}}, nil, {q: 'other string'})).to eq({q: 'other string', "w.p" => 'string'})
+    end
+
+    it 'using all parameters' do
+      expect {I18nContent.flat_hash('string', 'f', 'not hash')}.to raise_error NoMethodError
+      expect(I18nContent.flat_hash(nil, 'f', {q: 'other string'})).to eq({q: 'other string', "f" => nil})
+      expect(I18nContent.flat_hash({w: 'string'}, 'f', {q: 'other string'})).to eq({q: 'other string', "f.w" => 'string'})
+      expect(I18nContent.flat_hash({w: {p: 'string'}}, 'f', {q: 'other string'})).to eq({q: 'other string', "f.w.p" => 'string'})
+    end
+
+  end
 end

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe I18nContent, type: :model do
     end
 
     it 'return all matching records when #begins_with_key is used' do
-      debate_translation = create(:i18n_content)
-      debate_title       = create(:i18n_content, key: 'debates.form.debate_title')
-      proposal_title     = create(:i18n_content, key: 'proposals.form.proposal_title')
+      debate_text    = create(:i18n_content, key: 'debates.form.debate_text')
+      debate_title   = create(:i18n_content, key: 'debates.form.debate_title')
+      proposal_title = create(:i18n_content, key: 'proposals.form.proposal_title')
 
       expect(I18nContent.all.size).to eq(3)
 
       query = I18nContent.begins_with_key('debates')
 
       expect(query.size).to eq(2)
-      expect(query).to eq([debate_translation, debate_title])
+      expect(query).to eq([debate_text, debate_title])
       expect(query).not_to include(proposal_title)
     end
   end

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -74,35 +74,83 @@ RSpec.describe I18nContent, type: :model do
     end
   end
 
-  context 'flat_hash' do
+  describe '#flat_hash' do
+    it 'uses one parameter' do
+      expect(I18nContent.flat_hash(nil)).to eq({
+        nil => nil
+      })
 
-    it 'using one parameter' do
-      expect(I18nContent.flat_hash(nil)).to eq({nil=>nil})
-      expect(I18nContent.flat_hash('string')).to eq({nil=>'string'})
-      expect(I18nContent.flat_hash({w: 'string'})).to eq({"w" => 'string'})
-      expect(I18nContent.flat_hash({w: {p: 'string'}})).to eq({"w.p" => 'string'})
+      expect(I18nContent.flat_hash('string')).to eq({
+        nil => 'string'
+      })
+
+      expect(I18nContent.flat_hash({ w: 'string' })).to eq({
+        'w' => 'string'
+      })
+
+      expect(I18nContent.flat_hash({ w: { p: 'string' } })).to eq({
+        'w.p' => 'string'
+      })
     end
 
-    it 'using the two first parameters' do
-      expect(I18nContent.flat_hash('string', 'f')).to eq({'f'=>'string'})
-      expect(I18nContent.flat_hash(nil, 'f')).to eq({"f" => nil})
-      expect(I18nContent.flat_hash({w: 'string'}, 'f')).to eq({"f.w" => 'string'})
-      expect(I18nContent.flat_hash({w: {p: 'string'}}, 'f')).to eq({"f.w.p" => 'string'})
+    it 'uses the first two parameters' do
+      expect(I18nContent.flat_hash('string', 'f')).to eq({
+        'f' => 'string'
+      })
+
+      expect(I18nContent.flat_hash(nil, 'f')).to eq({
+        'f' => nil
+      })
+
+      expect(I18nContent.flat_hash({ w: 'string' }, 'f')).to eq({
+        'f.w' => 'string'
+      })
+
+      expect(I18nContent.flat_hash({ w: { p: 'string' } }, 'f')).to eq({
+        'f.w.p' => 'string'
+      })
     end
 
-    it 'using the first and last parameters' do
-      expect {I18nContent.flat_hash('string', nil, 'not hash')}.to raise_error NoMethodError
-      expect(I18nContent.flat_hash(nil, nil, {q: 'other string'})).to eq({q: 'other string', nil => nil})
-      expect(I18nContent.flat_hash({w: 'string'}, nil, {q: 'other string'})).to eq({q: 'other string', "w" => 'string'})
-      expect(I18nContent.flat_hash({w: {p: 'string'}}, nil, {q: 'other string'})).to eq({q: 'other string', "w.p" => 'string'})
+    it 'uses the first and last parameters' do
+      expect {
+        I18nContent.flat_hash('string', nil, 'not hash')
+      }.to raise_error(NoMethodError)
+
+      expect(I18nContent.flat_hash(nil, nil, { q: 'other string' })).to eq({
+        q: 'other string',
+        nil => nil
+      })
+
+      expect(I18nContent.flat_hash({ w: 'string' }, nil, { q: 'other string' })).to eq({
+        q: 'other string',
+        'w' => 'string'
+      })
+
+      expect(I18nContent.flat_hash({w: { p: 'string' } }, nil, { q: 'other string' })).to eq({
+        q: 'other string',
+        'w.p' => 'string'
+      })
     end
 
-    it 'using all parameters' do
-      expect {I18nContent.flat_hash('string', 'f', 'not hash')}.to raise_error NoMethodError
-      expect(I18nContent.flat_hash(nil, 'f', {q: 'other string'})).to eq({q: 'other string', "f" => nil})
-      expect(I18nContent.flat_hash({w: 'string'}, 'f', {q: 'other string'})).to eq({q: 'other string', "f.w" => 'string'})
-      expect(I18nContent.flat_hash({w: {p: 'string'}}, 'f', {q: 'other string'})).to eq({q: 'other string', "f.w.p" => 'string'})
-    end
+    it 'uses all parameters' do
+      expect {
+        I18nContent.flat_hash('string', 'f', 'not hash')
+      }.to raise_error NoMethodError
 
+      expect(I18nContent.flat_hash(nil, 'f', { q: 'other string' })).to eq({
+        q: 'other string',
+        'f' => nil
+      })
+
+      expect(I18nContent.flat_hash({ w: 'string' }, 'f', { q: 'other string' })).to eq({
+        q: 'other string',
+        'f.w' => 'string'
+      })
+
+      expect(I18nContent.flat_hash({ w: { p: 'string' } }, 'f', { q: 'other string' })).to eq({
+        q: 'other string',
+        'f.w.p' => 'string'
+      })
+    end
   end
 end

--- a/spec/models/i18n_content_spec.rb
+++ b/spec/models/i18n_content_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe I18nContent, type: :model do
+  let(:i18n_content) { build(:i18n_content) }
+
+  it 'is valid' do
+    expect(i18n_content).to be_valid
+  end
+
+  it 'is not valid if key is not unique' do
+    new_content = create(:i18n_content)
+
+    expect(i18n_content).not_to be_valid
+    expect(i18n_content.errors.size).to eq(1)
+  end
+
+  context 'Scopes' do
+    it 'return one record when #by_key is used' do
+      content      = create(:i18n_content)
+      key          = 'debates.form.debate_title'
+      debate_title = create(:i18n_content, key: key)
+
+      expect(I18nContent.all.size).to eq(2)
+
+      query = I18nContent.by_key(key)
+
+      expect(query.size).to eq(1)
+      expect(query).to eq([debate_title])
+    end
+
+    it 'return all matching records when #begins_with_key is used' do
+      debate_translation = create(:i18n_content)
+      debate_title       = create(:i18n_content, key: 'debates.form.debate_title')
+      proposal_title     = create(:i18n_content, key: 'proposals.form.proposal_title')
+
+      expect(I18nContent.all.size).to eq(3)
+
+      query = I18nContent.begins_with_key('debates')
+
+      expect(query.size).to eq(2)
+      expect(query).to eq([debate_translation, debate_title])
+      expect(query).not_to include(proposal_title)
+    end
+  end
+
+  context 'Globalize' do
+    it 'translates key into multiple languages' do
+      key = 'devise_views.mailer.confirmation_instructions.welcome'
+      welcome = build(:i18n_content, key: key, value_en: 'Welcome', value_es: 'Bienvenido')
+
+      expect(welcome.value_en).to eq('Welcome')
+      expect(welcome.value_es).to eq('Bienvenido')
+    end
+
+    it 'responds to locales defined on model' do
+      expect(i18n_content).to respond_to(:value_en)
+      expect(i18n_content).to respond_to(:value_es)
+      expect(i18n_content).not_to respond_to(:value_de)
+    end
+
+    it 'returns nil if translations are not available' do
+      expect(i18n_content.value_en).to eq('Text in english')
+      expect(i18n_content.value_es).to eq('Texto en español')
+      expect(i18n_content.value_nl).to be(nil)
+      expect(i18n_content.value_fr).to be(nil)
+    end
+
+    it 'responds accordingly to the current locale' do
+      expect(i18n_content.value).to eq('Text in english')
+
+      Globalize.locale = :es
+
+      expect(i18n_content.value).to eq('Texto en español')
+    end
+  end
+end


### PR DESCRIPTION
References
===================
* **Related PR**: #1580

Objectives
===================
## Added
* `I18nContent` model specs
* Tests and examples for `flat_hash` function (by @raul-fuentes)

## Fixes
* Fixed a bug where all matching I18n keys wouldn't appear when the `#begins_with_key` scope was used because of a trailing question mark (`?`)

## Refactoring (for DRYness/readability)
* `globalize_locales` partials to use lambdas and extracted shared markup into a partial (by @javierm)
* Extracted variable assignment from `information_texts/_form_field` partial into helper method
* Avoid using ternary operator when appending/creating I18n keys
* Concise variable names for `I18nContent#flat_hash` method

Visual Changes
===================
* None, all stays the same

Notes
===================
* Re: `InformationTexts` controller:
  * Refactor still pending considering its complexity (if possible)
  * Unit tests must be written

* Backport to CONSUL once approved and merged into `master`