### PR TITLE
Change Translatable implementation to accommodate new requirements

### DIFF
--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -1,6 +1,7 @@
 App.Globalize =
 
   display_locale: (locale) ->
+    App.Globalize.enable_locale(locale)
     $(".js-globalize-locale-link").each ->
       if $(this).data("locale") == locale
         $(this).show()
@@ -27,7 +28,13 @@ App.Globalize =
     next = $(".js-globalize-locale-link:visible").first()
     App.Globalize.highlight_locale(next)
     App.Globalize.display_translations(next.data("locale"))
-    $("#delete_translations_" + locale).val(1)
+    App.Globalize.disable_locale(locale)
+
+  enable_locale: (locale) ->
+    $("#enabled_translations_" + locale).val(1)
+
+  disable_locale: (locale) ->
+    $("#enabled_translations_" + locale).val(0)
 
   initialize: ->
     $('.js-globalize-locale').on 'change', ->

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -41,8 +41,9 @@ class Admin::BannersController < Admin::BaseController
       attributes = [:title, :description, :target_url,
                     :post_started_at, :post_ended_at,
                     :background_color, :font_color,
+                    *translation_params(Banner),
                     web_section_ids: []]
-      params.require(:banner).permit(*attributes, *translation_params(params[:banner]))
+      params.require(:banner).permit(*attributes)
     end
 
     def banner_styles
@@ -64,9 +65,5 @@ class Admin::BannersController < Admin::BaseController
     def resource
       @banner = Banner.find(params[:id]) unless @banner
       @banner
-    end
-
-    def resource_model
-      Banner
     end
 end

--- a/app/controllers/admin/budget_investment_milestones_controller.rb
+++ b/app/controllers/admin/budget_investment_milestones_controller.rb
@@ -48,9 +48,10 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
     image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
     documents_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
     attributes = [:title, :description, :publication_date, :budget_investment_id, :status_id,
+                  *translation_params(Budget::Investment::Milestone),
                   image_attributes: image_attributes, documents_attributes: documents_attributes]
 
-    params.require(:budget_investment_milestone).permit(*attributes, translation_params(params[:budget_investment_milestone]))
+    params.require(:budget_investment_milestone).permit(*attributes)
   end
 
   def load_budget_investment
@@ -67,10 +68,6 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
 
   def load_statuses
     @statuses = Budget::Investment::Status.all
-  end
-
-  def resource_model
-    Budget::Investment::Milestone
   end
 
   def resource

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -9,7 +9,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
 
   def update
     content_params.each do |content|
-      values = content[:values].slice(*translation_params(content[:values]))
+      values = content[:values].slice(*translation_params(I18nContent))
 
       unless values.empty?
         values.each do |key, value|
@@ -43,7 +43,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
     end
 
     def resource
-      resource_model.find(content_params[:id])
+      I18nContent.find(content_params[:id])
     end
 
     def content_params

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -51,7 +51,8 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
     end
 
     def delete_translations
-      languages_to_delete = params[:delete_translations].select { |k, v| params[:delete_translations][k] == '1' }.keys
+      languages_to_delete = params[:enabled_translations].select { |_, v| v == '0' }
+                                                         .keys
       languages_to_delete.each do |locale|
         I18nContentTranslation.destroy_all(locale: locale)
       end

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -33,15 +33,6 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
 
   private
 
-    def i18n_content_params
-      attributes = [:key, :value]
-      params.require(:information_texts).permit(*attributes, translation_params(params[:information_texts]))
-    end
-
-    def resource_model
-      I18nContent
-    end
-
     def resource
       I18nContent.find(content_params[:id])
     end

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -7,19 +7,18 @@ module Translatable
 
   private
 
-    # TODO change method interface to remove unnecessary argument
-    def translation_params(_)
-      enabled_translations.flat_map do |locale|
+    def translation_params(resource_model)
+      enabled_translations.flat_map do |loc|
         resource_model.translated_attribute_names.map do |attr_name|
-          resource_model.localized_attr_name_for(attr_name, locale)
+          resource_model.localized_attr_name_for(attr_name, loc)
         end
-      end.tap { |x| Rails.logger.debug "permitted translation params:"; p x}
+      end
     end
 
-    # TODO change to resource
     def delete_translations
-      locales = resource_model.translated_locales
-                              .select { |l| params.dig(:enabled_translations, l) == "0" }
+      locales = resource.translated_locales
+                        .select { |l| params.dig(:enabled_translations, l) == "0" }
+
       locales.each do |l|
         Globalize.with_locale(l) do
           resource.translation.destroy

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -8,10 +8,8 @@ module Translatable
   private
 
     def translation_params(resource_model)
-      enabled_translations.flat_map do |loc|
-        resource_model.translated_attribute_names.map do |attr_name|
-          resource_model.localized_attr_name_for(attr_name, loc)
-        end
+      resource_model.translated_attribute_names.product(enabled_translations).map do |attr_name, loc|
+        resource_model.localized_attr_name_for(attr_name, loc)
       end
     end
 

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -27,7 +27,11 @@ module GlobalizeHelper
   end
 
   def css_to_display_translation?(resource, locale)
-    resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale ? "" : "display: none"
+    enable_locale?(resource, locale) ? "" : "display: none"
+  end
+
+  def enable_locale?(resource, locale)
+    resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale
   end
 
   def highlight_current?(locale)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -14,6 +14,18 @@ module GlobalizeHelper
     same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none"
   end
 
+  def render_translations_to_delete(resource)
+    capture do
+      resource.globalize_locales.each do |locale|
+        concat translation_enabled_tag(locale, enable_locale?(resource, locale))
+      end
+    end
+  end
+
+  def translation_enabled_tag(locale, enabled)
+    hidden_field_tag("enabled_translations[#{locale}]", (enabled ? 1 : 0))
+  end
+
   def css_to_display_translation?(resource, locale)
     resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale ? "" : "display: none"
   end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -1,5 +1,9 @@
 module SiteCustomizationHelper
+  def site_customization_enable_translation?(locale)
+    I18nContentTranslation.existing_languages.include?(neutral_locale(locale)) || locale == I18n.locale
+  end
+
   def site_customization_display_translation?(locale)
-    I18nContentTranslation.existing_languages.include?(neutral_locale(locale)) || locale == I18n.locale ? "" : "display: none"
+    site_customization_enable_translation?(locale) ? "" : "display: none"
   end
 end

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -4,9 +4,7 @@
 
   <%= render 'errors' %>
 
-  <% @banner.globalize_locales.each do |locale| %>
-    <%= hidden_field_tag "delete_translations[#{locale}]", 0 %>
-  <% end %>
+  <%= render_translations_to_delete(@banner) %>
 
   <div class="row">
     <% date_started_at = @banner.post_started_at.present? ? I18n.localize(@banner.post_started_at) : "" %>

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -2,6 +2,8 @@
 
 <%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
 
+  <%= render_translations_to_delete(@milestone) %>
+
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime),
                              maxlength: Budget::Investment::Milestone.title_max_length %>
 
@@ -16,7 +18,6 @@
 
   <%= f.label :description, t("admin.milestones.new.description") %>
   <% @milestone.globalize_locales.each do |locale| %>
-    <%= hidden_field_tag "delete_translations[#{locale}]", 0 %>
     <% globalize(locale) do %>
       <%= f.text_area "description_#{locale}", rows: 5,
                       class: "js-globalize-attribute",

--- a/app/views/admin/site_customization/information_texts/_form.html.erb
+++ b/app/views/admin/site_customization/information_texts/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_tag admin_site_customization_information_texts_path do %>
   <% I18n.available_locales.each do |l| %>
-    <%= hidden_field_tag "delete_translations[#{l}]", 0 %>
+    <%= translation_enabled_tag l, site_customization_enable_translation?(l) %>
   <% end %>
   <% contents.each do |group| %>
     <% group.each do |content| %>

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -71,6 +71,18 @@ feature "Translations" do
       expect(page).not_to have_link "Español"
     end
 
+    scenario 'Change value of a translated field to blank' do
+      milestone.update_attributes!(status: create(:budget_investment_status))
+      visit @edit_milestone_url
+
+      fill_in 'budget_investment_milestone_description_en', with: ''
+
+      click_button "Update milestone"
+      expect(page).to have_content "Milestone updated successfully"
+
+      expect(milestone.reload.description).to be_blank
+    end
+
     context "Globalize javascript interface" do
 
       scenario "Highlight current locale", :js do

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -72,7 +72,6 @@ feature "Translations" do
     end
 
     scenario 'Change value of a translated field to blank' do
-      milestone.update_attributes!(status: create(:budget_investment_status))
       visit @edit_milestone_url
 
       fill_in 'budget_investment_milestone_description_en', with: ''
@@ -80,7 +79,8 @@ feature "Translations" do
       click_button "Update milestone"
       expect(page).to have_content "Milestone updated successfully"
 
-      expect(milestone.reload.description).to be_blank
+      expect(page).to have_content "Milestone updated successfully"
+      expect(page).not_to have_content "Description in English"
     end
 
     context "Globalize javascript interface" do


### PR DESCRIPTION
References
===================
 - Changes initial implementation from PR https://github.com/AyuntamientoMadrid/consul/pull/1435

Objectives
===================
2 reasons for this change:
1. Accommodate forms with nested resources. This is necessary for Collaborative Legislation (https://github.com/consul/consul/issues/2736), e.g. `/admin/legislation/processes/5/questions/1/edit`
2. Allow for a cleaner, regex-less implementation of this bug fix: https://github.com/AyuntamientoMadrid/consul/commit/25b5526e0412b63e0c46981891a66a7f1f5e89b2

I also think this represents a better separation of concerns. I see this as the client telling the server which translations the user wants to have, and the server can decide which attributes need to be updated *and* which translation records need to be deleted.

Visual Changes
===================
None

Notes
===================
If merged, the following open PRs will need to incorporate these changes (should be easy):
 - #1596 
 - #1588 
 - https://github.com/consul/consul/pull/2833