### PR TITLE
Fix flaky spec: Admin legislation questions Update Valid legislation question 

### DIFF
--- a/spec/features/admin/legislation/questions_spec.rb
+++ b/spec/features/admin/legislation/questions_spec.rb
@@ -85,7 +85,7 @@ feature 'Admin legislation questions' do
 
       click_link "All"
 
-      expect(page).to have_content 'An example legislation process'
+      expect(page).not_to have_link "All"
 
       click_link 'An example legislation process'
       click_link 'Debate'


### PR DESCRIPTION
Fix flaky legislation question spec

# References

* Issue #1603

# Objectives

Fix the flaky spec that appeared in `spec/features/admin/legislation/questions_spec.rb:86`   ("Admin legislation questions Update Valid legislation question").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

As mentioned in the commit message:

> Right after clicking the "Collaborative Legislation" link, the link 'An example legislation process' is already available. So sometimes Capybara might click the links "All" and 'An example legislation process' at more or less the same time, causing the second link not to be correctly
clicked.

## Explain why your PR fixes it

Making sure the "All" link doesn't exist anymore we guarantee Capybara will wait for the previous AJAX request to finish before clicking the next link.

# Notes

* The test to "Create Valid legislation question" is almost identical but it doesn't fail because it doesn't use Capybara's JavaScript driver.