### PR TITLE
Fix flaky specs: proposals, legislation and probe options Voting comments Update

### DIFF
--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -500,6 +500,11 @@ feature 'Commenting legislation questions' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -465,6 +465,11 @@ feature 'Commenting proposals' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/comments/spending_proposals_spec.rb
+++ b/spec/features/comments/spending_proposals_spec.rb
@@ -460,6 +460,11 @@ feature 'Commenting spending_proposals' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do

--- a/spec/features/custom/probe_option_comments_spec.rb
+++ b/spec/features/custom/probe_option_comments_spec.rb
@@ -468,6 +468,11 @@ feature 'Commenting Probe Options' do
 
       within("#comment_#{@comment.id}_votes") do
         find('.in_favor a').click
+
+        within('.in_favor') do
+          expect(page).to have_content "1"
+        end
+
         find('.against a').click
 
         within('.in_favor') do


### PR DESCRIPTION
## References

* Issue #1605
* PR consul#2734

## Objectives

Fix the flaky specs that appeared in `spec/features/comments/proposals_spec.rb:463` ("Commenting proposals Voting comments Update"), `spec/features/comments/legislation_questions_spec.rb:498` and ("Commenting legislation questions Voting comments Update") and `spec/features/custom/probe_option_comments_spec.rb:466` ("Commenting Probe Options Voting comments Update").

### Explain why the test is flaky, or under which conditions/scenario it fails randomly

As mentioned in consul#2734:

Here's the relevant part of the spec:

```ruby
visit debate_path(create(:debate))

find('.in-favor a').click
find('.against a').click
```

After clicking the first link, there's an AJAX request which replaces the existing .in-favor a and .against a links with new elements. So if Capybara tries to click the existing .against a link at the same moment it's being replaced, clicking the link won't generate a new request.

### Explain why your PR fixes it

Making Capybara check the page for new content before clicking the second link solves the problem.

## Does this PR need a Backport to CONSUL?

Yes, but only backport the first commit, since the second one changes code not present in the main CONSUL repo.