### PR TITLE
Fix flaky spec: Admin budget investment mark/unmark visible to valuators

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1241,12 +1241,12 @@ feature 'Admin budget investments' do
     end
 
     scenario "Unmark as visible to valuator", :js do
-      Setting['feature.budgets.valuators_allowed'] = true
+      budget.update(phase: 'valuating')
 
       investment1.valuators << valuator
       investment2.valuators << valuator
-      investment1.update(administrator: admin)
-      investment2.update(administrator: admin)
+      investment1.update(administrator: admin, visible_to_valuators: true)
+      investment2.update(administrator: admin, visible_to_valuators: true)
 
       visit admin_budget_budget_investments_path(budget)
       within('#filter-subnav') { click_link 'Under valuation' }
@@ -1346,96 +1346,6 @@ feature 'Admin budget investments' do
 
       expect(page).to have_content('Finished Investment')
       expect(page).not_to have_content('Unfeasible one')
-    end
-  end
-
-  context "Mark as visible to valuators" do
-
-    let(:valuator) { create(:valuator) }
-    let(:admin) { create(:administrator) }
-
-    let(:group) { create(:budget_group, budget: budget) }
-    let(:heading) { create(:budget_heading, group: group) }
-
-    let(:investment1) { create(:budget_investment, heading: heading) }
-    let(:investment2) { create(:budget_investment, heading: heading) }
-
-    scenario "Mark as visible to valuator", :js do
-      investment1.valuators << valuator
-      investment2.valuators << valuator
-      investment1.update(administrator: admin)
-      investment2.update(administrator: admin)
-
-      visit admin_budget_budget_investments_path(budget)
-
-      within("#budget_investment_#{investment1.id}") do
-        check "budget_investment_visible_to_valuators"
-      end
-
-      visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
-
-      within("#budget_investment_#{investment1.id}") do
-        expect(find("#budget_investment_visible_to_valuators")).to be_checked
-      end
-    end
-
-    scenario "Unmark as visible to valuator", :js do
-      budget.update(phase: 'valuating')
-
-      valuator = create(:valuator)
-      admin = create(:administrator)
-
-      group = create(:budget_group, budget: budget)
-      heading = create(:budget_heading, group: group)
-
-      investment1 = create(:budget_investment, heading: heading, visible_to_valuators: true)
-      investment2 = create(:budget_investment, heading: heading, visible_to_valuators: true)
-
-      investment1.valuators << valuator
-      investment2.valuators << valuator
-      investment1.update(administrator: admin)
-      investment2.update(administrator: admin)
-
-      visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
-
-      within("#budget_investment_#{investment1.id}") do
-        uncheck "budget_investment_visible_to_valuators"
-      end
-
-      visit admin_budget_budget_investments_path(budget)
-
-      within("#budget_investment_#{investment1.id}") do
-        expect(find("#budget_investment_visible_to_valuators")).not_to be_checked
-      end
-    end
-
-    scenario "Showing the valuating checkbox" do
-      investment1 = create(:budget_investment, budget: budget, visible_to_valuators: true)
-      investment2 = create(:budget_investment, budget: budget, visible_to_valuators: false)
-
-      investment1.valuators << create(:valuator)
-      investment2.valuators << create(:valuator)
-      investment2.valuators << create(:valuator)
-      investment1.update(administrator: create(:administrator))
-      investment2.update(administrator: create(:administrator))
-
-      visit admin_budget_budget_investments_path(budget)
-
-      expect(page).to have_css("#budget_investment_visible_to_valuators")
-
-      within('#filter-subnav') { click_link 'Under valuation' }
-
-      within("#budget_investment_#{investment1.id}") do
-        valuating_checkbox = find('#budget_investment_visible_to_valuators')
-        expect(valuating_checkbox).to be_checked
-      end
-
-      within("#budget_investment_#{investment2.id}") do
-        valuating_checkbox = find('#budget_investment_visible_to_valuators')
-        expect(valuating_checkbox).not_to be_checked
-      end
     end
   end
 

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1205,6 +1205,7 @@ feature 'Admin budget investments' do
 
       visit admin_budget_budget_investments_path(budget)
       within('#filter-subnav') { click_link 'Under valuation' }
+      expect(page).not_to have_link("Under valuation")
 
       within("#budget_investment_#{investment1.id}") do
         check "budget_investment_visible_to_valuators"
@@ -1250,6 +1251,7 @@ feature 'Admin budget investments' do
 
       visit admin_budget_budget_investments_path(budget)
       within('#filter-subnav') { click_link 'Under valuation' }
+      expect(page).not_to have_link("Under valuation")
 
       within("#budget_investment_#{investment1.id}") do
         uncheck "budget_investment_visible_to_valuators"


### PR DESCRIPTION
# References

* Issue #1194 
* PR #1256 
* [Recent travis build with the failure](https://travis-ci.org/javierv/consul/jobs/400699160)

# Objectives

Fix the flaky specs that appeared in `spec/features/admin/budget_investments_spec:1200` ("Admin budget investments Mark as visible to valuators Mark as visible to valuator") and  `spec/features/admin/budget_investments_spec:1243` ("Admin budget investments Mark as visible to valuators Unmark as visible to valuator")

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

As mentioned in the comments in PR #1256:
    
> "These failures take place because the checkbox is already present before clicking in 'under valuation', and so Capybara doesn't have to wait for the 'under valuation' request to finish before clicking the checkbox."
    
So sometimes Capybara tries to check/uncheck the checkbox at the same time that checkbox is being replaced by the new content, resulting in no request being sent to the server.

## Explain why your PR fixes it

Making Capybara check the page for new content before checking/unchecking the checkbox solves the problem.

# Notes

* These specs were duplicated. I've removed the duplicated ones and left what (I thought) were the most recent ones.