### PR TITLE
[WIP] Add selected to Legislation::Proposals and its interface

### DIFF
--- a/app/controllers/admin/legislation/proposals_controller.rb
+++ b/app/controllers/admin/legislation/proposals_controller.rb
@@ -1,7 +1,23 @@
 class Admin::Legislation::ProposalsController < Admin::Legislation::BaseController
+
+  has_orders %w{id title supports}, only: :index
+
   load_and_authorize_resource :process, class: "Legislation::Process"
   load_and_authorize_resource :proposal, class: "Legislation::Proposal", through: :process
 
   def index
+    @proposals = @proposals.send("sort_by_#{@current_order}").page(params[:page])
   end
+
+  def update
+    @proposal.selected = !@proposal.selected
+
+    if @proposal.save
+      notice = t('admin.legislation.proposals.update.notice')
+    else
+      notice = t('admin.legislation.proposals.update.error')
+    end
+    redirect_to admin_legislation_process_proposals_path, notice: notice
+  end
+
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -1,5 +1,7 @@
 class Legislation::ProcessesController < Legislation::BaseController
   has_filters %w{open next past}, only: :index
+  has_filters %w{all selected}, only: :proposals
+
   load_and_authorize_resource :process
 
   before_action :set_random_seed, only: :proposals
@@ -88,8 +90,8 @@ class Legislation::ProcessesController < Legislation::BaseController
   def proposals
     set_process
     @phase = :proposals_phase
-    @proposals = ::Legislation::Proposal.where(process: @process).order('random()').page(params[:page])
-
+    @proposals = ::Legislation::Proposal.where(process: @process).send(@current_filter).order('random()').page(params[:page])
+    @valid_filters = [] unless @proposals.map(&:selected).include? true
     if @process.proposals_phase.started? || (current_user && current_user.administrator?)
       legislation_proposal_votes(@proposals)
       render :proposals

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -50,9 +50,13 @@ class Legislation::Proposal < ActiveRecord::Base
   scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
   scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
   scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
+  scope :sort_by_title,            -> { reorder(title: :asc) }
+  scope :sort_by_id,               -> { reorder(id: :asc) }
+  scope :sort_by_supports,         -> { reorder(cached_votes_up: :asc) }
   scope :sort_by_random,           -> { reorder("RANDOM()") }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago)}
+  scope :selected,                 -> { where(selected: true) }
 
   def to_param
     "#{id}-#{title}".parameterize

--- a/app/views/admin/legislation/proposals/index.html.erb
+++ b/app/views/admin/legislation/proposals/index.html.erb
@@ -11,4 +11,44 @@
   <%= render 'admin/legislation/processes/subnav', process: @process, active: 'proposals' %>
 
   <%= render 'form' %>
+
+<% if @proposals.any? %>
+  <h3><%= page_entries_info @proposals %></h3>
+
+  <%= render 'shared/wide_order_selector', i18n_namespace: "admin.legislation.processes.proposals" %>
+
+  <table class="stack" id="proposals_table">
+    <thead>
+      <tr>
+        <th class="text-center"><%= t("admin.legislation.proposals.index.id") %></th>
+        <th><%= t("admin.legislation.proposals.index.title") %></th>
+        <th class="text-center"><%= t("admin.legislation.proposals.index.supports") %></th>
+        <th><%= t("admin.legislation.proposals.index.selected") %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @proposals.each do |proposal| %>
+        <tr id="<%= dom_id(proposal) %>">
+          <td class="text-center"><%= proposal.id %></td>
+          <td><%= proposal.title %></td>
+          <td class="text-center"><%= proposal.cached_votes_up %></td>
+          <td>
+            <% if proposal.selected?
+                 button_text = t("admin.legislation.proposals.index.selected")
+                 clas = 'button expanded'
+               else
+                 button_text = t("admin.legislation.proposals.index.select")
+                 clas = 'button hollow expanded'
+               end %>
+            <%= link_to button_text, admin_legislation_process_proposal_path(@process, proposal), method: 'PUT', class: clas %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @proposals %>
+<% end %>
+
 </div>

--- a/app/views/legislation/processes/proposals.html.erb
+++ b/app/views/legislation/processes/proposals.html.erb
@@ -18,6 +18,7 @@
               <p><%= t('.empty_proposals') %></p>
             </div>
           <% else %>
+            <%= render 'shared/filter_subnav', i18n_namespace: "legislation.processes.proposals" %>
             <%= render @proposals %>
             <%= paginate @proposals %>
           <% end %>

--- a/app/views/shared/_wide_order_selector.html.erb
+++ b/app/views/shared/_wide_order_selector.html.erb
@@ -2,6 +2,7 @@
    #
    #   i18n_namespace: for example "moderation.debates.index"
 %>
+
 <% if @valid_orders.present? && @valid_orders.count > 1 %>
   <div class="wide-order-selector small-12 medium-8">
     <form>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -79,6 +79,9 @@ en:
       legislation/process:
         one: "Process"
         other: "Processes"
+      legislation/proposal:
+        one: "Proposal"
+        other: "Proposals"
       legislation/draft_versions:
         one: "Draft version"
         other: "Draft versions"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -402,6 +402,12 @@ en:
           back: Back
           title: Create new collaborative legislation process
           submit_button: Create process
+        proposals:
+          select_order: Sort by
+          orders:
+            id: Id
+            title: Title
+            supports: Supports
         process:
           title: Process
           comments: Comments
@@ -419,6 +425,14 @@ en:
         index:
           title: Proposals
           back: Back
+          id: Id
+          title: Title
+          supports: Supports
+          select: Select
+          selected: Selected
+        update:
+          notice: 'Proposal updated successfully'
+          error: Proposal couldn't be updated
         form:
           custom_categories: Categories
           custom_categories_description: Categories that users can select creating the proposal.

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -52,6 +52,9 @@ en:
         more_info: More information and context
       proposals:
         empty_proposals: There are no proposals
+        filters:
+          all: All
+          selected: Selected
       debate:
         empty_questions: There aren't any questions
         participate: Participate in the debate

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -79,6 +79,9 @@ es:
       legislation/process:
         one: "Proceso"
         other: "Procesos"
+      legislation/proposal:
+        one: "Propuesta"
+        other: "Propuestas"
       legislation/draft_versions:
         one: "Versión borrador"
         other: "Versiones borrador"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -402,6 +402,12 @@ es:
           back: Volver
           title: Crear nuevo proceso de legislación colaborativa
           submit_button: Crear proceso
+        proposals:
+          select_order: Ordenar por
+          orders:
+            id: Id
+            title: Título
+            supports: Apoyos
         process:
           title: Proceso
           comments: Comentarios
@@ -419,6 +425,14 @@ es:
         index:
           title: Propuestas
           back: Volver
+          id: Id
+          title: Título
+          supports: Apoyos
+          select: Seleccionar
+          selected: Seleccionado
+        update:
+          notice: Propuesta actualizada correctamente.
+          error: No se ha podido actualizar la propuesta
         form:
           custom_categories: Categorías
           custom_categories_description: Categorías que el usuario puede seleccionar al crear la propuesta.

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -52,6 +52,9 @@ es:
         more_info: Más información y contexto
       proposals:
         empty_proposals: No hay propuestas
+        filters:
+          all: Todos
+          selected: Seleccionados
       debate:
         empty_questions: No hay preguntas
         participate: Realiza tus aportaciones al debate previo participando en los siguientes temas.

--- a/db/migrate/20180807104331_add_selected_to_legislation_proposals.rb
+++ b/db/migrate/20180807104331_add_selected_to_legislation_proposals.rb
@@ -1,0 +1,5 @@
+class AddSelectedToLegislationProposals < ActiveRecord::Migration
+  def change
+    add_column :legislation_proposals, :selected, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180727140800) do
+ActiveRecord::Schema.define(version: 20180807104331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -698,6 +698,7 @@ ActiveRecord::Schema.define(version: 20180727140800) do
     t.integer  "cached_votes_total",                default: 0
     t.integer  "cached_votes_down",                 default: 0
     t.string   "proposal_type"
+    t.boolean  "selected"
   end
 
   add_index "legislation_proposals", ["legislation_process_id"], name: "index_legislation_proposals_on_legislation_process_id", using: :btree

--- a/spec/features/admin/legislation/proposals_spec.rb
+++ b/spec/features/admin/legislation/proposals_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+feature 'Admin legislation processes' do
+
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  context "Index" do
+
+    scenario 'Displaying legislation proposals' do
+      proposal = create(:legislation_proposal, cached_votes_up: 10)
+      visit admin_legislation_process_proposals_path(proposal.legislation_process_id)
+      within "#legislation_proposal_#{proposal.id}" do
+        expect(page).to have_content(proposal.title)
+        expect(page).to have_content(proposal.id)
+        expect(page).to have_content(proposal.cached_votes_up)
+        expect(page).to have_content('Select')
+      end
+    end
+
+    scenario 'Selecting legislation proposals' do
+      proposal = create(:legislation_proposal, cached_votes_up: 10)
+      visit admin_legislation_process_proposals_path(proposal.legislation_process_id)
+
+      click_link 'Select'
+      within "#legislation_proposal_#{proposal.id}" do
+        expect(page).to have_content('Selected')
+      end
+    end
+
+    scenario 'Sorting legislation proposals by title', js: true do
+      legislation_process = create(:legislation_process)
+      create(:legislation_proposal, title: 'bbbb', cached_votes_up: 10, legislation_process_id: legislation_process.id)
+      create(:legislation_proposal, title: 'aaaa', cached_votes_up: 20, legislation_process_id: legislation_process.id)
+      create(:legislation_proposal, title: 'cccc', cached_votes_up: 30, legislation_process_id: legislation_process.id)
+      visit admin_legislation_process_proposals_path(legislation_process.id)
+
+      select "Title", from: "order-selector-participation"
+
+      within('#proposals_table') do
+        within(:xpath, "//tbody/tr[1]") do
+          expect(page).to have_content('aaaa')
+        end
+        within(:xpath, "//tbody/tr[2]") do
+          expect(page).to have_content('bbbb')
+        end
+        within(:xpath, "//tbody/tr[3]") do
+          expect(page).to have_content('cccc')
+        end
+      end
+    end
+
+    scenario 'Sorting legislation proposals by supports', js: true do
+      legislation_process = create(:legislation_process)
+      create(:legislation_proposal, title: 'bbbb', cached_votes_up: 10, legislation_process_id: legislation_process.id)
+      create(:legislation_proposal, title: 'aaaa', cached_votes_up: 20, legislation_process_id: legislation_process.id)
+      create(:legislation_proposal, title: 'cccc', cached_votes_up: 30, legislation_process_id: legislation_process.id)
+      visit admin_legislation_process_proposals_path(legislation_process.id)
+
+      select "Supports", from: "order-selector-participation"
+
+      within('#proposals_table') do
+        within(:xpath, "//tbody/tr[1]") do
+          expect(page).to have_content('10')
+        end
+        within(:xpath, "//tbody/tr[2]") do
+          expect(page).to have_content('20')
+        end
+        within(:xpath, "//tbody/tr[3]") do
+          expect(page).to have_content('30')
+        end
+      end
+    end
+
+    scenario 'Sorting legislation proposals by Id', js: true do
+      legislation_process = create(:legislation_process)
+      proposal1 = create(:legislation_proposal, title: 'bbbb', cached_votes_up: 10, legislation_process_id: legislation_process.id)
+      proposal2 = create(:legislation_proposal, title: 'aaaa', cached_votes_up: 20, legislation_process_id: legislation_process.id)
+      proposal3 = create(:legislation_proposal, title: 'cccc', cached_votes_up: 30, legislation_process_id: legislation_process.id)
+      visit admin_legislation_process_proposals_path(legislation_process.id)
+
+      select "Id", from: "order-selector-participation"
+
+      within('#proposals_table') do
+        within(:xpath, "//tbody/tr[1]") do
+          expect(page).to have_content(proposal1.id)
+        end
+        within(:xpath, "//tbody/tr[2]") do
+          expect(page).to have_content(proposal2.id)
+        end
+        within(:xpath, "//tbody/tr[3]") do
+          expect(page).to have_content(proposal3.id)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -66,6 +66,33 @@ feature 'Legislation Proposals' do
     end
   end
 
+  scenario 'Selected filter apperars only if exists any eslecte poposal' do
+    legislation_process = create(:legislation_process)
+    create(:legislation_proposal, legislation_process_id: legislation_process.id)
+
+    visit legislation_process_proposals_path(legislation_process.id)
+
+    expect(page).not_to have_content('Selected')
+
+    create(:legislation_proposal, legislation_process_id: legislation_process.id, selected: true)
+
+    visit legislation_process_proposals_path(legislation_process.id)
+
+    expect(page).to have_content('Selected')
+  end
+
+  scenario 'Selected filter works correctly' do
+    legislation_process = create(:legislation_process)
+    proposal1 = create(:legislation_proposal, legislation_process_id: legislation_process.id)
+    proposal2 = create(:legislation_proposal, legislation_process_id: legislation_process.id, selected: true)
+    visit legislation_process_proposals_path(legislation_process.id)
+
+    click_link 'Selected'
+
+    expect(page).to have_css("div#legislation_proposal_#{proposal2.id}")
+    expect(page).not_to have_css("div#legislation_proposal_#{proposal1.id}")
+  end
+
   def legislation_proposals_order
     all("[id^='legislation_proposal_']").collect { |e| e[:id] }
   end


### PR DESCRIPTION
References
===================
https://github.com/consul/consul/issues/2739

Objectives
===================
- Add a new attribute to Legislation::Proposal -> selected
- Change the admin interface 0.0.0.0:3000/admin/legislation/processes/X/proposals
  with the proposals list and a select button for each proposal
- Change the public interface 0.0.0.0:3000/legislation/processes/X/proposals
  if any shown proposal is selected now appears filters for only show the selected proposals (or all)

Visual Changes
===================
- admin interface changes
![peek 09-08-2018 14-41](https://user-images.githubusercontent.com/33748390/43899500-6d87bfec-9be2-11e8-8e29-584fa663a47a.gif)

- public interface changes
![peek 09-08-2018 14-40](https://user-images.githubusercontent.com/33748390/43899482-5f2ade70-9be2-11e8-9206-c7079f4a2c63.gif)

Notes
===================
None