### PR TITLE
 Fix flaky spec: Admin feature flags Enable a disabled feature 

### DIFF
--- a/spec/shared/features/nested_imageable.rb
+++ b/spec/shared/features/nested_imageable.rb
@@ -171,15 +171,14 @@ shared_examples "nested imageable" do |imageable_factory_name, path, imageable_p
     end
 
     scenario "Should show successful notice when resource filled correctly without any nested images", :js do
-      login_as user
-      visit send(path, arguments)
-
-      send(fill_resource_method_name) if fill_resource_method_name
-      click_on submit_button
-
       if has_many_images
         skip "no need to test, there are no attributes for the parent resource"
       else
+        login_as user
+        visit send(path, arguments)
+
+        send(fill_resource_method_name) if fill_resource_method_name
+        click_on submit_button
         expect(page).to have_content imageable_success_notice
       end
     end


### PR DESCRIPTION
# References

* Issue #1609
* [Travis build 10233, job 2](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/421929893) reports a different failure because of the same issue

# Objectives

Fix the flaky specs that appeared in `spec/features/admin/feature_flags_spec.rb:60` ("Admin feature flags Enable a disabled feature") and `spec/features/tags/proposals_spec.rb:119` ("Tags Create with too many tags").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

The feature flags spec fails when using the JavaScript driver, since accessing the features section requires an extra click when JavaScript is enabled (on the "features" tab).

The proposal tags spec also fails when using the JavaScript driver, since it loads CKEditor and replaces the textarea the spec searches for.

Usually these specs would use the Rack driver. However, there was a bug in another spec which caused the next spec to use the JavaScript driver, as mentioned in the commit:

> Skipping a spec in the middle of it, particularly after doing some requests, caused Capybara to keep using the same driver in the following spec.
>
> Since the current spec uses the JavaScript driver, the next test would also use the JavaScript driver, causing apparently random failures if that test was supposed to use the Rack driver.

## Explain why your PR fixes it

Skipping the spec before doing any requests solves the problem.

# Notes

* IMHO, after upgrading to Rails 5 and using transactional fixtures for feature specs (which Rails 5 apparently supports), using JavaScript in every feature spec would lead to specs easier to maintain without making our suite much slower.