### PR TITLE
Refactor code shared by admin-translatable resources

### DIFF
--- a/app/assets/javascripts/globalize.js.coffee
+++ b/app/assets/javascripts/globalize.js.coffee
@@ -1,6 +1,7 @@
 App.Globalize =
 
   display_locale: (locale) ->
+    App.Globalize.enable_locale(locale)
     $(".js-globalize-locale-link").each ->
       if $(this).data("locale") == locale
         $(this).show()
@@ -27,7 +28,13 @@ App.Globalize =
     next = $(".js-globalize-locale-link:visible").first()
     App.Globalize.highlight_locale(next)
     App.Globalize.display_translations(next.data("locale"))
-    $("#delete_translations_" + locale).val(1)
+    App.Globalize.disable_locale(locale)
+
+  enable_locale: (locale) ->
+    $("#enabled_translations_" + locale).val(1)
+
+  disable_locale: (locale) ->
+    $("#enabled_translations_" + locale).val(0)
 
   initialize: ->
     $('.js-globalize-locale').on 'change', ->

--- a/app/controllers/admin/banners_controller.rb
+++ b/app/controllers/admin/banners_controller.rb
@@ -41,8 +41,9 @@ class Admin::BannersController < Admin::BaseController
       attributes = [:title, :description, :target_url,
                     :post_started_at, :post_ended_at,
                     :background_color, :font_color,
+                    *translation_params(Banner),
                     web_section_ids: []]
-      params.require(:banner).permit(*attributes, *translation_params(params[:banner]))
+      params.require(:banner).permit(*attributes)
     end
 
     def banner_styles
@@ -64,9 +65,5 @@ class Admin::BannersController < Admin::BaseController
     def resource
       @banner = Banner.find(params[:id]) unless @banner
       @banner
-    end
-
-    def resource_model
-      Banner
     end
 end

--- a/app/controllers/admin/budget_investment_milestones_controller.rb
+++ b/app/controllers/admin/budget_investment_milestones_controller.rb
@@ -48,9 +48,10 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
     image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
     documents_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
     attributes = [:title, :description, :publication_date, :budget_investment_id, :status_id,
+                  *translation_params(Budget::Investment::Milestone),
                   image_attributes: image_attributes, documents_attributes: documents_attributes]
 
-    params.require(:budget_investment_milestone).permit(*attributes, translation_params(params[:budget_investment_milestone]))
+    params.require(:budget_investment_milestone).permit(*attributes)
   end
 
   def load_budget_investment
@@ -67,10 +68,6 @@ class Admin::BudgetInvestmentMilestonesController < Admin::BaseController
 
   def load_statuses
     @statuses = Budget::Investment::Status.all
-  end
-
-  def resource_model
-    Budget::Investment::Milestone
   end
 
   def resource

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -9,7 +9,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
 
   def update
     content_params.each do |content|
-      values = content[:values].slice(*translation_params(content[:values]))
+      values = content[:values].slice(*translation_params(I18nContent))
 
       unless values.empty?
         values.each do |key, value|
@@ -43,7 +43,7 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
     end
 
     def resource
-      resource_model.find(content_params[:id])
+      I18nContent.find(content_params[:id])
     end
 
     def content_params

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -51,7 +51,8 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
     end
 
     def delete_translations
-      languages_to_delete = params[:delete_translations].select { |k, v| params[:delete_translations][k] == '1' }.keys
+      languages_to_delete = params[:enabled_translations].select { |_, v| v == '0' }
+                                                         .keys
       languages_to_delete.each do |locale|
         I18nContentTranslation.destroy_all(locale: locale)
       end

--- a/app/controllers/admin/site_customization/information_texts_controller.rb
+++ b/app/controllers/admin/site_customization/information_texts_controller.rb
@@ -33,15 +33,6 @@ class Admin::SiteCustomization::InformationTextsController < Admin::SiteCustomiz
 
   private
 
-    def i18n_content_params
-      attributes = [:key, :value]
-      params.require(:information_texts).permit(*attributes, translation_params(params[:information_texts]))
-    end
-
-    def resource_model
-      I18nContent
-    end
-
     def resource
       I18nContent.find(content_params[:id])
     end

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -7,19 +7,18 @@ module Translatable
 
   private
 
-    # TODO change method interface to remove unnecessary argument
-    def translation_params(_)
-      enabled_translations.flat_map do |locale|
+    def translation_params(resource_model)
+      enabled_translations.flat_map do |loc|
         resource_model.translated_attribute_names.map do |attr_name|
-          resource_model.localized_attr_name_for(attr_name, locale)
+          resource_model.localized_attr_name_for(attr_name, loc)
         end
-      end.tap { |x| Rails.logger.debug "permitted translation params:"; p x}
+      end
     end
 
-    # TODO change to resource
     def delete_translations
-      locales = resource_model.translated_locales
-                              .select { |l| params.dig(:enabled_translations, l) == "0" }
+      locales = resource.translated_locales
+                        .select { |l| params.dig(:enabled_translations, l) == "0" }
+
       locales.each do |l|
         Globalize.with_locale(l) do
           resource.translation.destroy

--- a/app/controllers/concerns/translatable.rb
+++ b/app/controllers/concerns/translatable.rb
@@ -8,10 +8,8 @@ module Translatable
   private
 
     def translation_params(resource_model)
-      enabled_translations.flat_map do |loc|
-        resource_model.translated_attribute_names.map do |attr_name|
-          resource_model.localized_attr_name_for(attr_name, loc)
-        end
+      resource_model.translated_attribute_names.product(enabled_translations).map do |attr_name, loc|
+        resource_model.localized_attr_name_for(attr_name, loc)
       end
     end
 

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -11,7 +11,7 @@ module GlobalizeHelper
   end
 
   def display_translation?(locale)
-    same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none"
+    same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none;"
   end
 
   def translation_enabled_tag(locale, enabled)
@@ -19,7 +19,7 @@ module GlobalizeHelper
   end
 
   def css_to_display_translation?(resource, locale)
-    enable_locale?(resource, locale) ? "" : "display: none"
+    enable_locale?(resource, locale) ? "" : "display: none;"
   end
 
   def enable_locale?(resource, locale)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -6,12 +6,12 @@ module GlobalizeHelper
 
   def locale_options
     I18n.available_locales.map do |locale|
-      [name_for_locale(locale), neutral_locale(locale)]
+      [name_for_locale(locale), locale]
     end
   end
 
   def display_translation?(locale)
-    same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none;"
+    same_locale?(I18n.locale, locale) ? "" : "display: none;"
   end
 
   def translation_enabled_tag(locale, enabled)
@@ -23,7 +23,7 @@ module GlobalizeHelper
   end
 
   def enable_locale?(resource, locale)
-    resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale
+    resource.translated_locales.include?(locale) || locale == I18n.locale
   end
 
   def highlight_current?(locale)
@@ -32,10 +32,6 @@ module GlobalizeHelper
 
   def show_delete?(locale)
     display_translation?(locale)
-  end
-
-  def neutral_locale(locale)
-    locale.to_s.downcase.underscore.to_sym
   end
 
   def globalize(locale, &block)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -27,7 +27,11 @@ module GlobalizeHelper
   end
 
   def css_to_display_translation?(resource, locale)
-    resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale ? "" : "display: none"
+    enable_locale?(resource, locale) ? "" : "display: none"
+  end
+
+  def enable_locale?(resource, locale)
+    resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale
   end
 
   def highlight_current?(locale)

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -14,14 +14,6 @@ module GlobalizeHelper
     same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none"
   end
 
-  def render_translations_to_delete(resource)
-    capture do
-      resource.globalize_locales.each do |locale|
-        concat translation_enabled_tag(locale, enable_locale?(resource, locale))
-      end
-    end
-  end
-
   def translation_enabled_tag(locale, enabled)
     hidden_field_tag("enabled_translations[#{locale}]", (enabled ? 1 : 0))
   end

--- a/app/helpers/globalize_helper.rb
+++ b/app/helpers/globalize_helper.rb
@@ -14,6 +14,18 @@ module GlobalizeHelper
     same_locale?(neutral_locale(I18n.locale), neutral_locale(locale)) ? "" : "display: none"
   end
 
+  def render_translations_to_delete(resource)
+    capture do
+      resource.globalize_locales.each do |locale|
+        concat translation_enabled_tag(locale, enable_locale?(resource, locale))
+      end
+    end
+  end
+
+  def translation_enabled_tag(locale, enabled)
+    hidden_field_tag("enabled_translations[#{locale}]", (enabled ? 1 : 0))
+  end
+
   def css_to_display_translation?(resource, locale)
     resource.translated_locales.include?(neutral_locale(locale)) || locale == I18n.locale ? "" : "display: none"
   end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -1,6 +1,6 @@
 module SiteCustomizationHelper
   def site_customization_enable_translation?(locale)
-    I18nContentTranslation.existing_languages.include?(neutral_locale(locale)) || locale == I18n.locale
+    I18nContentTranslation.existing_languages.include?(locale) || locale == I18n.locale
   end
 
   def site_customization_display_translation?(locale)

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -1,5 +1,9 @@
 module SiteCustomizationHelper
+  def site_customization_enable_translation?(locale)
+    I18nContentTranslation.existing_languages.include?(neutral_locale(locale)) || locale == I18n.locale
+  end
+
   def site_customization_display_translation?(locale)
-    I18nContentTranslation.existing_languages.include?(neutral_locale(locale)) || locale == I18n.locale ? "" : "display: none"
+    site_customization_enable_translation?(locale) ? "" : "display: none"
   end
 end

--- a/app/helpers/site_customization_helper.rb
+++ b/app/helpers/site_customization_helper.rb
@@ -4,6 +4,6 @@ module SiteCustomizationHelper
   end
 
   def site_customization_display_translation?(locale)
-    site_customization_enable_translation?(locale) ? "" : "display: none"
+    site_customization_enable_translation?(locale) ? "" : "display: none;"
   end
 end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -41,7 +41,9 @@ module TranslatableFormHelper
         @template.capture do
           @object.globalize_locales.each do |locale|
             Globalize.with_locale(locale) do
+              label_without_locale = @object.class.human_attribute_name(method)
               final_options = @template.merge_translatable_field_options(options, locale)
+                                       .reverse_merge(label: label_without_locale)
               @template.concat send(field_type, "#{method}_#{locale}", final_options)
             end
           end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -14,11 +14,11 @@ module TranslatableFormHelper
 
   def merge_translatable_field_options(options, locale)
     options.merge(
-      class: (options.fetch(:class, "") + " js-globalize-attribute"),
+      class: "#{options[:class]} js-globalize-attribute".strip,
       style: display_translation?(locale),
       data:  options.fetch(:data, {}).merge(locale: locale),
       label_options: {
-        class: (options.fetch(:class, "") + " js-globalize-attribute"),
+        class: "#{options[:class]} js-globalize-attribute".strip,
         style: display_translation?(locale),
         data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
       }

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -32,7 +32,11 @@ class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
               class: (options.fetch(:class, "") + " js-globalize-attribute"),
               style: @template.display_translation?(locale),
               data:  options.fetch(:data, {}).merge(locale: locale),
-              label: false
+              label_options: {
+                class: (options.fetch(:class, "") + " js-globalize-attribute"),
+                style: @template.display_translation?(locale),
+                data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
+              }
             )
 
             @template.concat send(field_type, "#{method}_#{locale}", final_options)

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -1,0 +1,43 @@
+module TranslatableFormHelper
+  def translatable_form_for(record, options = {})
+    object = record.is_a?(Array) ? record.last : record
+
+    form_for(record, options.merge(builder: TranslatableFormBuilder)) do |f|
+
+      object.globalize_locales.each do |locale|
+        concat translation_enabled_tag(locale, enable_locale?(object, locale))
+      end
+
+      yield(f)
+    end
+  end
+end
+
+class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+
+  def translatable_text_field(method, options = {})
+    translatable_field(:text_field, method, options)
+  end
+  def translatable_text_area(method, options = {})
+    translatable_field(:text_area, method, options)
+  end
+
+  private
+
+    def translatable_field(field_type, method, options = {})
+      @template.capture do
+        @object.globalize_locales.each do |locale|
+          Globalize.with_locale(locale) do
+            final_options = options.merge(
+              class: (options.fetch(:class, "") + " js-globalize-attribute"),
+              style: @template.display_translation?(locale),
+              data:  options.fetch(:data, {}).merge(locale: locale),
+              label: false
+            )
+
+            @template.concat send(field_type, "#{method}_#{locale}", final_options)
+          end
+        end
+      end
+    end
+end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -18,7 +18,7 @@ module TranslatableFormHelper
       style: display_translation?(locale),
       data:  options.fetch(:data, {}).merge(locale: locale),
       label_options: {
-        class: "#{options[:class]} js-globalize-attribute".strip,
+        class: "#{options.dig(:label_options, :class)} js-globalize-attribute".strip,
         style: display_translation?(locale),
         data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
       }

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -1,8 +1,8 @@
 module TranslatableFormHelper
-  def translatable_form_for(record, options = {})
-    object = record.is_a?(Array) ? record.last : record
+  def translatable_form_for(record_or_record_path, options = {})
+    object = record_or_record_path.is_a?(Array) ? record_or_record_path.last : record_or_record_path
 
-    form_for(record, options.merge(builder: TranslatableFormBuilder)) do |f|
+    form_for(record_or_record_path, options.merge(builder: TranslatableFormBuilder)) do |f|
 
       object.globalize_locales.each do |locale|
         concat translation_enabled_tag(locale, enable_locale?(object, locale))

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -24,28 +24,28 @@ module TranslatableFormHelper
       }
     )
   end
-end
 
-class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
+  class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
 
-  def translatable_text_field(method, options = {})
-    translatable_field(:text_field, method, options)
-  end
+    def translatable_text_field(method, options = {})
+      translatable_field(:text_field, method, options)
+    end
 
-  def translatable_text_area(method, options = {})
-    translatable_field(:text_area, method, options)
-  end
+    def translatable_text_area(method, options = {})
+      translatable_field(:text_area, method, options)
+    end
 
-  private
+    private
 
-    def translatable_field(field_type, method, options = {})
-      @template.capture do
-        @object.globalize_locales.each do |locale|
-          Globalize.with_locale(locale) do
-            final_options = @template.merge_translatable_field_options(options, locale)
-            @template.concat send(field_type, "#{method}_#{locale}", final_options)
+      def translatable_field(field_type, method, options = {})
+        @template.capture do
+          @object.globalize_locales.each do |locale|
+            Globalize.with_locale(locale) do
+              final_options = @template.merge_translatable_field_options(options, locale)
+              @template.concat send(field_type, "#{method}_#{locale}", final_options)
+            end
           end
         end
       end
-    end
+  end
 end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -41,10 +41,13 @@ module TranslatableFormHelper
         @template.capture do
           @object.globalize_locales.each do |locale|
             Globalize.with_locale(locale) do
+              localized_attr_name = @object.localized_attr_name_for(method, locale)
+
               label_without_locale = @object.class.human_attribute_name(method)
               final_options = @template.merge_translatable_field_options(options, locale)
                                        .reverse_merge(label: label_without_locale)
-              @template.concat send(field_type, "#{method}_#{locale}", final_options)
+
+              @template.concat send(field_type, localized_attr_name, final_options)
             end
           end
         end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -15,11 +15,11 @@ module TranslatableFormHelper
   def merge_translatable_field_options(options, locale)
     options.merge(
       class: "#{options[:class]} js-globalize-attribute".strip,
-      style: display_translation?(locale),
+      style: "#{options[:style]} #{display_translation?(locale)}".strip,
       data:  options.fetch(:data, {}).merge(locale: locale),
       label_options: {
         class: "#{options.dig(:label_options, :class)} js-globalize-attribute".strip,
-        style: display_translation?(locale),
+        style: "#{options.dig(:label_options, :style)} #{display_translation?(locale)}".strip,
         data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
       }
     )

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -31,6 +31,7 @@ class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
   def translatable_text_field(method, options = {})
     translatable_field(:text_field, method, options)
   end
+
   def translatable_text_area(method, options = {})
     translatable_field(:text_area, method, options)
   end

--- a/app/helpers/translatable_form_helper.rb
+++ b/app/helpers/translatable_form_helper.rb
@@ -11,6 +11,19 @@ module TranslatableFormHelper
       yield(f)
     end
   end
+
+  def merge_translatable_field_options(options, locale)
+    options.merge(
+      class: (options.fetch(:class, "") + " js-globalize-attribute"),
+      style: display_translation?(locale),
+      data:  options.fetch(:data, {}).merge(locale: locale),
+      label_options: {
+        class: (options.fetch(:class, "") + " js-globalize-attribute"),
+        style: display_translation?(locale),
+        data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
+      }
+    )
+  end
 end
 
 class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
@@ -28,17 +41,7 @@ class TranslatableFormBuilder < FoundationRailsHelper::FormBuilder
       @template.capture do
         @object.globalize_locales.each do |locale|
           Globalize.with_locale(locale) do
-            final_options = options.merge(
-              class: (options.fetch(:class, "") + " js-globalize-attribute"),
-              style: @template.display_translation?(locale),
-              data:  options.fetch(:data, {}).merge(locale: locale),
-              label_options: {
-                class: (options.fetch(:class, "") + " js-globalize-attribute"),
-                style: @template.display_translation?(locale),
-                data:  (options.dig(:label_options, :data) || {}) .merge(locale: locale)
-              }
-            )
-
+            final_options = @template.merge_translatable_field_options(options, locale)
             @template.concat send(field_type, "#{method}_#{locale}", final_options)
           end
         end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -5,7 +5,7 @@ class Banner < ActiveRecord::Base
 
   translates :title,       touch: true
   translates :description, touch: true
-  globalize_accessors locales: [:en, :es, :fr, :nl, :val, :pt_br]
+  globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
 
   validates :title, presence: true,
                     length: { minimum: 2 }

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -5,7 +5,7 @@ class Banner < ActiveRecord::Base
 
   translates :title,       touch: true
   translates :description, touch: true
-  globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
+  globalize_accessors
 
   validates :title, presence: true,
                     length: { minimum: 2 }

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -8,7 +8,7 @@ class Budget
                    accepted_content_types: [ "application/pdf" ]
 
       translates :title, :description, touch: true
-      globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
+      globalize_accessors
 
       belongs_to :investment
       belongs_to :status, class_name: 'Budget::Investment::Status'

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -8,7 +8,7 @@ class Budget
                    accepted_content_types: [ "application/pdf" ]
 
       translates :title, :description, touch: true
-      globalize_accessors locales: [:en, :es, :fr, :nl, :val, :pt_br]
+      globalize_accessors locales: I18n.available_locales.map { |l| l.to_s.underscore.to_sym }
 
       belongs_to :investment
       belongs_to :status, class_name: 'Budget::Investment::Status'

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -4,9 +4,7 @@
 
   <%= render 'errors' %>
 
-  <% @banner.globalize_locales.each do |locale| %>
-    <%= hidden_field_tag "delete_translations[#{locale}]", 0 %>
-  <% end %>
+  <%= render_translations_to_delete(@banner) %>
 
   <div class="row">
     <% date_started_at = @banner.post_started_at.present? ? I18n.localize(@banner.post_started_at) : "" %>

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -1,10 +1,8 @@
 <%= render "admin/shared/globalize_locales", resource: @banner %>
 
-<%= form_for [:admin, @banner] do |f| %>
+<%= translatable_form_for [:admin, @banner] do |f| %>
 
   <%= render 'errors' %>
-
-  <%= render_translations_to_delete(@banner) %>
 
   <div class="row">
     <% date_started_at = @banner.post_started_at.present? ? I18n.localize(@banner.post_started_at) : "" %>
@@ -32,18 +30,9 @@
   <div class="row">
     <div class="small-12 medium-6 column">
       <%= f.label :title, t("admin.banners.banner.title") %>
-
-      <% @banner.globalize_locales.each do |locale| %>
-        <% globalize(locale) do %>
-          <%= f.text_field "title_#{locale}",
-                           placeholder: t("admin.banners.banner.title"),
-                           class: "js-globalize-attribute",
-                           data: {js_banner_title: "js_banner_title",
-                                  locale: locale},
-                           style: display_translation?(locale),
-                           label: false %>
-        <% end %>
-      <% end %>
+      <%= f.translatable_text_field :title,
+                                    placeholder: t("admin.banners.banner.title"),
+                                    data: {js_banner_title: "js_banner_title"}%>
     </div>
 
     <div class="small-12 medium-6 column">
@@ -57,17 +46,9 @@
   <div class="row">
     <div class="small-12 column">
       <%= f.label :description, t("admin.banners.banner.description") %>
-      <% @banner.globalize_locales.each do |locale| %>
-        <% globalize(locale) do %>
-          <%= f.text_field "description_#{locale}",
-                           placeholder: t("admin.banners.banner.description"),
-                           class: "js-globalize-attribute",
-                           data: {js_banner_description: "js_banner_description",
-                                  locale: locale},
-                           style: display_translation?(locale),
-                           label: false %>
-        <% end %>
-      <% end %>
+      <%= f.translatable_text_field :description,
+                                    placeholder: t("admin.banners.banner.description"),
+                                    data: {js_banner_description: "js_banner_description"} %>
     </div>
   </div>
 

--- a/app/views/admin/banners/_form.html.erb
+++ b/app/views/admin/banners/_form.html.erb
@@ -29,10 +29,10 @@
 
   <div class="row">
     <div class="small-12 medium-6 column">
-      <%= f.label :title, t("admin.banners.banner.title") %>
       <%= f.translatable_text_field :title,
                                     placeholder: t("admin.banners.banner.title"),
-                                    data: {js_banner_title: "js_banner_title"}%>
+                                    data: {js_banner_title: "js_banner_title"},
+                                    label: t("admin.banners.banner.title") %>
     </div>
 
     <div class="small-12 medium-6 column">
@@ -45,10 +45,10 @@
 
   <div class="row">
     <div class="small-12 column">
-      <%= f.label :description, t("admin.banners.banner.description") %>
       <%= f.translatable_text_field :description,
                                     placeholder: t("admin.banners.banner.description"),
-                                    data: {js_banner_description: "js_banner_description"} %>
+                                    data: {js_banner_description: "js_banner_description"},
+                                    label: t("admin.banners.banner.description")  %>
     </div>
   </div>
 

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -1,8 +1,6 @@
 <%= render "admin/shared/globalize_locales", resource: @milestone %>
 
-<%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
-
-  <%= render_translations_to_delete(@milestone) %>
+<%= translatable_form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
 
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime),
                              maxlength: Budget::Investment::Milestone.title_max_length %>
@@ -17,15 +15,7 @@
   </div>
 
   <%= f.label :description, t("admin.milestones.new.description") %>
-  <% @milestone.globalize_locales.each do |locale| %>
-    <% globalize(locale) do %>
-      <%= f.text_area "description_#{locale}", rows: 5,
-                      class: "js-globalize-attribute",
-                      data: { locale: locale },
-                      style: display_translation?(locale),
-                      label: false %>
-    <% end %>
-  <% end %>
+  <%= f.translatable_text_field :description, rows: 5 %>
 
   <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -14,9 +14,9 @@
                 admin_budget_investment_statuses_path %>
   </div>
 
-  <%= f.translatable_text_field :description,
-                                rows: 5,
-                                label: t("admin.milestones.new.description") %>
+  <%= f.translatable_text_area :description,
+                               rows: 5,
+                               label: t("admin.milestones.new.description") %>
 
   <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -14,8 +14,9 @@
                 admin_budget_investment_statuses_path %>
   </div>
 
-  <%= f.label :description, t("admin.milestones.new.description") %>
-  <%= f.translatable_text_field :description, rows: 5 %>
+  <%= f.translatable_text_field :description,
+                                rows: 5,
+                                label: t("admin.milestones.new.description") %>
 
   <%= f.label :publication_date, t("admin.milestones.new.date") %>
   <%= f.text_field :publication_date,

--- a/app/views/admin/budget_investment_milestones/_form.html.erb
+++ b/app/views/admin/budget_investment_milestones/_form.html.erb
@@ -2,6 +2,8 @@
 
 <%= form_for [:admin, @investment.budget, @investment, @milestone] do |f| %>
 
+  <%= render_translations_to_delete(@milestone) %>
+
   <%= f.hidden_field :title, value: l(Time.current, format: :datetime),
                              maxlength: Budget::Investment::Milestone.title_max_length %>
 
@@ -16,7 +18,6 @@
 
   <%= f.label :description, t("admin.milestones.new.description") %>
   <% @milestone.globalize_locales.each do |locale| %>
-    <%= hidden_field_tag "delete_translations[#{locale}]", 0 %>
     <% globalize(locale) do %>
       <%= f.text_area "description_#{locale}", rows: 5,
                       class: "js-globalize-attribute",

--- a/app/views/admin/shared/_globalize_locales.html.erb
+++ b/app/views/admin/shared/_globalize_locales.html.erb
@@ -1,9 +1,9 @@
 <% I18n.available_locales.each do |locale| %>
   <%= link_to t("admin.translations.remove_language"), "#",
-              id: "delete-#{neutral_locale(locale)}",
+              id: "delete-#{locale}",
               style: show_delete?(locale),
               class: 'float-right delete js-delete-language',
-              data: { locale: neutral_locale(locale) } %>
+              data: { locale: locale } %>
 
 <% end %>
 
@@ -13,7 +13,7 @@
       <%= link_to name_for_locale(locale), "#",
                   style: css_to_display_translation?(resource, locale),
                   class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                  data: { locale: neutral_locale(locale) },
+                  data: { locale: locale },
                   remote: true %>
     </li>
   <% end %>

--- a/app/views/admin/site_customization/information_texts/_form.html.erb
+++ b/app/views/admin/site_customization/information_texts/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_tag admin_site_customization_information_texts_path do %>
   <% I18n.available_locales.each do |l| %>
-    <%= hidden_field_tag "delete_translations[#{l}]", 0 %>
+    <%= translation_enabled_tag l, site_customization_enable_translation?(l) %>
   <% end %>
   <% contents.each do |group| %>
     <% group.each do |content| %>

--- a/app/views/admin/site_customization/information_texts/_form_field.html.erb
+++ b/app/views/admin/site_customization/information_texts/_form_field.html.erb
@@ -11,9 +11,5 @@
   <%= text_area_tag "contents[content_#{content.key}]values[value_#{locale}]",
                     i18n_content_translation ||
                     t(content.key, locale: locale),
-                    { rows: 5,
-                      class: "js-globalize-attribute",
-                      style: display_translation?(locale),
-                      data: { locale: locale }
-                    } %>
+                    merge_translatable_field_options({rows: 5}, locale) %>
 <% end %>

--- a/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
+++ b/app/views/admin/site_customization/information_texts/_globalize_locales.html.erb
@@ -1,9 +1,9 @@
 <% I18n.available_locales.each do |locale| %>
   <%= link_to t("admin.translations.remove_language"), "#",
-              id: "delete-#{neutral_locale(locale)}",
+              id: "delete-#{locale}",
               style: show_delete?(locale),
               class: 'float-right delete js-delete-language',
-              data: { locale: neutral_locale(locale) } %>
+              data: { locale: locale } %>
 
 <% end %>
 
@@ -13,7 +13,7 @@
       <%= link_to name_for_locale(locale), "#",
                   style: site_customization_display_translation?(locale),
                   class: "js-globalize-locale-link #{highlight_current?(locale)}",
-                  data: { locale: neutral_locale(locale) },
+                  data: { locale: locale },
                   remote: true %>
     </li>
   <% end %>

--- a/app/views/budgets/investments/milestones/_milestone.html.erb
+++ b/app/views/budgets/investments/milestones/_milestone.html.erb
@@ -24,11 +24,9 @@
 
     <%= image_tag(milestone.image_url(:large), { id: "image_#{milestone.id}", alt: milestone.image.title, class: "margin" }) if milestone.image.present? %>
 
-    <% globalize(neutral_locale(locale)) do %>
-      <p>
-        <%= text_with_links milestone.description %>
-      </p>
-    <% end %>
+    <p>
+      <%= text_with_links milestone.description %>
+    </p>
 
     <% if milestone.documents.present? %>
       <div class="document-link text-center">

--- a/config/initializers/globalize.rb
+++ b/config/initializers/globalize.rb
@@ -1,0 +1,1 @@
+Globalize.fallbacks = {es: [:es, :en]}

--- a/config/initializers/globalize.rb
+++ b/config/initializers/globalize.rb
@@ -1,1 +1,0 @@
-Globalize.fallbacks = {es: [:es, :en]}

--- a/db/dev_seeds/banners.rb
+++ b/db/dev_seeds/banners.rb
@@ -10,8 +10,7 @@ section "Creating banners" do
                         post_ended_at:   rand((Time.current - 1.day)..(Time.current + 1.week)),
                         created_at: rand((Time.current - 1.week)..Time.current))
     I18n.available_locales.map do |locale|
-      neutral_locale = locale.to_s.downcase.underscore.to_sym
-      Globalize.with_locale(neutral_locale) do
+      Globalize.with_locale(locale) do
         banner.description = "Description for locale #{locale}"
         banner.title = "Title for locale #{locale}"
         banner.save!

--- a/db/dev_seeds/budgets.rb
+++ b/db/dev_seeds/budgets.rb
@@ -194,8 +194,7 @@ section "Creating investment milestones" do
   Budget::Investment.all.each do |investment|
     milestone = Budget::Investment::Milestone.new(investment_id: investment.id, publication_date: Date.tomorrow, status_id: Budget::Investment::Status.all.sample)
     I18n.available_locales.map do |locale|
-      neutral_locale = locale.to_s.downcase.underscore.to_sym
-      Globalize.with_locale(neutral_locale) do
+      Globalize.with_locale(locale) do
         milestone.description = "Description for locale #{locale}"
         milestone.title = I18n.l(Time.current, format: :datetime)
         milestone.save!

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -71,6 +71,18 @@ feature "Translations" do
       expect(page).not_to have_link "Español"
     end
 
+    scenario 'Change value of a translated field to blank' do
+      milestone.update_attributes!(status: create(:budget_investment_status))
+      visit @edit_milestone_url
+
+      fill_in 'budget_investment_milestone_description_en', with: ''
+
+      click_button "Update milestone"
+      expect(page).to have_content "Milestone updated successfully"
+
+      expect(milestone.reload.description).to be_blank
+    end
+
     context "Globalize javascript interface" do
 
       scenario "Highlight current locale", :js do

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -83,6 +83,26 @@ feature "Translations" do
       expect(page).not_to have_content "Description in English"
     end
 
+    scenario "Add a translation for a locale with non-underscored name", :js do
+      visit @edit_milestone_url
+
+      select "Português", from: "translation_locale"
+      fill_in 'budget_investment_milestone_description_pt_br', with: 'Description in pt-BR'
+
+      click_button 'Update milestone'
+      expect(page).to have_content "Milestone updated successfully"
+
+      visit budget_investment_path(investment.budget, investment)
+
+      click_link("Milestones (1)")
+      expect(page).to have_content("Description in English")
+
+      select('Português', from: 'locale-switcher')
+      click_link("Seguimiento (1)")
+
+      expect(page).to have_content('Description in pt-BR')
+    end
+
     context "Globalize javascript interface" do
 
       scenario "Highlight current locale", :js do

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -72,7 +72,6 @@ feature "Translations" do
     end
 
     scenario 'Change value of a translated field to blank' do
-      milestone.update_attributes!(status: create(:budget_investment_status))
       visit @edit_milestone_url
 
       fill_in 'budget_investment_milestone_description_en', with: ''
@@ -80,7 +79,8 @@ feature "Translations" do
       click_button "Update milestone"
       expect(page).to have_content "Milestone updated successfully"
 
-      expect(milestone.reload.description).to be_blank
+      expect(page).to have_content "Milestone updated successfully"
+      expect(page).not_to have_content "Description in English"
     end
 
     context "Globalize javascript interface" do


### PR DESCRIPTION
__NOTE:__ This PR includes commits from open PR https://github.com/AyuntamientoMadrid/consul/pull/1602. That PR should be merged first. See #1612 for explanation. All commits _after_ [571667c Refactor Translatable#translation_params to improve readability](https://github.com/AyuntamientoMadrid/consul/commit/571667c2d9e1f52098b00354b310d2a457ef86c8) are unique to this PR and should be reviewed.


Objectives
===================

Includes various refactors to the code shared by all "translatable" admin-created resources. See commits:

https://github.com/AyuntamientoMadrid/consul/commit/f3e75b712fe89ecb87cce49320d0d30016f633d1 Extract translatable field logic to FormBuilder
f3e75b7 Extract translatable field logic to FormBuilder
e0cc7d8 Avoid duplicating list of locales
7d5dc4a Incorporate label into translatabel field
4903893 Extract merge_translatable_field_options helper method

Additional commits after 1st review by @javierm:

c5eee0e Fix type of field for Milestone form
3485ba9 Change variable name to reflect possibility of being array
df7fb35 Change string manipulation to use interpolation for readability
82915d2 Add missing blank line between methods
8567594 Nest TranslatableFormBuilder in helper module
667a8e2 Fix merging_translatable_field_options helper
68104b7 Fix helper to merge style option correctly
de5d768 Fix translatable field labels to not include locale
e5b33a1 Use standard locale names for Globalize
c20ecad Add :es => :en locale fallback for translatable resources

Visual Changes
===================
None