### PR TITLE
Fix flaky annotation comments specs

### DIFF
--- a/app/controllers/legislation/annotations_controller.rb
+++ b/app/controllers/legislation/annotations_controller.rb
@@ -8,7 +8,7 @@ class Legislation::AnnotationsController < Legislation::BaseController
   load_and_authorize_resource :draft_version, through: :process
   load_and_authorize_resource
 
-  has_orders %w{most_voted newest}, only: :show
+  has_orders %w[most_voted newest oldest], only: :show
 
   def index
     @annotations = @draft_version.annotations

--- a/lib/comment_tree.rb
+++ b/lib/comment_tree.rb
@@ -2,14 +2,17 @@ class CommentTree
 
   ROOT_COMMENTS_PER_PAGE = 10
 
-  attr_accessor :root_comments, :comments, :commentable, :page, :order
+  attr_reader :root_comments, :commentable, :page, :order
 
   def initialize(commentable, page, order = "confidence_score", valuations: false)
     @commentable = commentable
     @page = page
     @order = order
     @valuations = valuations
-    @comments = root_comments + root_descendants
+  end
+
+  def comments
+    @comments ||= root_comments + root_descendants
   end
 
   def root_comments

--- a/lib/merged_comment_tree.rb
+++ b/lib/merged_comment_tree.rb
@@ -1,14 +1,10 @@
 class MergedCommentTree < CommentTree
-  attr_accessor :commentables, :array_order
+  attr_reader :commentables, :array_order
 
   def initialize(commentables, page, order = "confidence_score")
     @commentables = commentables
-    @commentable = commentables.first
-    @page = page
-    @order = order
+    super(commentables.first, page, order)
     @array_order = set_array_order(order)
-
-    @comments = root_comments + root_descendants
   end
 
   def root_comments

--- a/lib/merged_comment_tree.rb
+++ b/lib/merged_comment_tree.rb
@@ -1,24 +1,13 @@
 class MergedCommentTree < CommentTree
-  attr_reader :commentables, :array_order
+  attr_reader :commentables
 
   def initialize(commentables, page, order = "confidence_score")
     @commentables = commentables
     super(commentables.first, page, order)
-    @array_order = set_array_order(order)
   end
 
-  def root_comments
-    Kaminari.paginate_array(commentables.flatten.map(&:comments).map(&:roots).flatten.sort_by {|a| a[array_order]}.reverse).
-    page(page).per(ROOT_COMMENTS_PER_PAGE)
-  end
-
-  def set_array_order(order)
-    case order
-    when "newest"
-      "created_at"
-    else
-      "confidence_score"
-    end
+  def base_comments
+    Comment.where(commentable: commentables.flatten)
   end
 
 end

--- a/spec/features/comments/legislation_annotations_spec.rb
+++ b/spec/features/comments/legislation_annotations_spec.rb
@@ -14,7 +14,7 @@ describe "Commenting legislation questions" do
 
     expect(page).to have_css(".comment", count: 4)
 
-    comment = Comment.first
+    comment = Comment.last
     within first(".comment") do
       expect(page).to have_content comment.user.name
       expect(page).to have_content I18n.l(comment.created_at, format: :datetime)
@@ -144,7 +144,7 @@ describe "Commenting legislation questions" do
                                                             legislation_annotation.draft_version,
                                                             legislation_annotation)
 
-    within all(".comment").last do
+    within all(".comment").first do
       expect(page).to have_content "Built with http://rubyonrails.org/"
       expect(page).to have_link("http://rubyonrails.org/", href: "http://rubyonrails.org/")
       expect(find_link("http://rubyonrails.org/")[:rel]).to eq("nofollow")
@@ -160,7 +160,7 @@ describe "Commenting legislation questions" do
                                                             legislation_annotation.draft_version,
                                                             legislation_annotation)
 
-    within all(".comment").last do
+    within all(".comment").first do
       expect(page).to have_content "click me http://www.url.com"
       expect(page).to have_link("http://www.url.com", href: "http://www.url.com")
       expect(page).not_to have_link("click me")


### PR DESCRIPTION
## References

* Issue #1180
* [Comment in consul#2129](https://github.com/consul/consul/issues/2129#issuecomment-344741720) mentioning related flakies
* [Comment in consul#2455](https://github.com/consul/consul/pull/2455#issuecomment-401971618) showing the specs still fail sometimes
* [Travis build 24494, job 1](https://travis-ci.org/consul/consul/jobs/436433654) and [Travis build 11237, job 6](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/508062387)

## Objectives

Fix the flaky specs that appeared in `spec/features/admin/feature_flags_spec.rb:8` ("Commenting legislation questions Index"), `spec/features/comments/legislation_annotations_spec.rb:143` ("Commenting legislation questions Turns links into html links") and `spec/features/comments/legislation_annotations_spec.rb:159` ("Commenting legislation questions Sanitizes comment body for security")

### Explain why the test is flaky, or under which conditions/scenario it fails randomly

The spec fails because comments in annotations are ordered by score. However, when several comments have the same score, no other order is defined. This meant specs assuming the last comment displayed was the last comment created failed sometimes.

### Explain why your PR fixes it

Using `ActiveRecord` relations instead of arrays makes it easy to reuse scopes used everywhere else in the code, and so comments with the same score are now ordered by date.

## Notes

* Before commit 792b15b, comments with the same score were displayed from recent to old, and after that commit comments were (usually) displayed from old to recent, although we couldn't always predict the exact order. Now they're displayed from recent to old again. @voodoorai2000 What's the intended behaviour? I think I didn't fully get the use of `sort_by` and `sort_descendants_by` in `CommentTree`, so I'm not sure I chose the right scope.
* I've also restored the `oldest` scope removed in 792b15b, thinking it was removed because it was hard to implement and now it isn't hard to implement anymore.
* While working on this issue I found a line saying: `<span id="annotation-link" data-sub-annotation-ids="8">`. @voodoorai2000 Do you know what this `8` is used for?
* Even though existing specs seem to cover these changes, I wonder if more specs should be added :thinking:.