### PR TITLE
Fix flaky spec: Admin legislation draft versions Update Valid legislation draft version

### DIFF
--- a/spec/features/admin/legislation/draft_versions_spec.rb
+++ b/spec/features/admin/legislation/draft_versions_spec.rb
@@ -79,7 +79,7 @@ feature 'Admin legislation draft versions' do
 
       click_link "All"
 
-      expect(page).to have_content 'An example legislation process'
+      expect(page).not_to have_link "All"
 
       click_link 'An example legislation process'
       click_link 'Drafting'


### PR DESCRIPTION
# References

* Issue #1618

# Objectives

Fix the flaky specs that appeared in `spec/features/admin/draft_versions_spec:70` ("Admin legislation draft versions Update Valid legislation draft version").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

Here's the relevant code:

```ruby
click_link "All"

expect(page).to have_content 'An example legislation process'

click_link 'An example legislation process'
```
These failures take place because the link to 'An example legislation process' is already present before clicking "All", and so Capybara doesn't have to wait for the "All" request to finish before clicking the link, as shown in this screenshot:

![Link is already present before clicking the 'All' tab](https://user-images.githubusercontent.com/35156/44770956-eb284200-ab69-11e8-9252-7f010df861b2.png)

So sometimes Capybara tries to click 'An example legislation process' at the same time that link is being replaced by the new content, resulting in no request being sent to the server. Here's the screenshot when the test fails in the line `click_link 'Drafting'`:

![Drafting click not present because we're still in the 'All' tab](https://user-images.githubusercontent.com/35156/44771004-1317a580-ab6a-11e8-8548-146128a0ced4.png)

## Explain why your PR fixes it

Making Capybara check the "All" link isn't present anymore guarantees the "All" request has already been completed before trying to click 'An example legislation process'.

# Notes

* As mentioned in the issue, this PR is **not** related to issue #1228. Even if the failing test is the same one, it fails on a different line.