### PR TITLE
Fix flaky spec: Welcome screen is not shown to organizations 

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -113,7 +113,7 @@ feature "Home" do
   end
 
   feature 'IE alert' do
-    scenario 'IE visitors are presented with an alert until they close it' do
+    scenario 'IE visitors are presented with an alert until they close it', :page_driver do
       # Selenium API does not include page request/response inspection methods
       # so we must use Capybara::RackTest driver to set the browser's headers
       Capybara.current_session.driver.header(
@@ -134,7 +134,7 @@ feature "Home" do
       expect(page.driver.request.cookies['ie_alert_closed']).to eq('true')
     end
 
-    scenario 'non-IE visitors are not bothered with IE alerts' do
+    scenario 'non-IE visitors are not bothered with IE alerts', :page_driver do
       visit root_path
       expect(page).not_to have_xpath(ie_alert_box_xpath, visible: false)
       expect(page.driver.request.cookies['ie_alert_closed']).to be_nil

--- a/spec/features/polls/nvotes_spec.rb
+++ b/spec/features/polls/nvotes_spec.rb
@@ -52,7 +52,7 @@ feature 'Nvotes' do
 
   context "Store voter" do
 
-    scenario "Valid signature", :nvotes do
+    scenario "Valid signature", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
       poll = create(:poll, :incoming, published: true, nvotes_poll_id: 128)
 
@@ -72,7 +72,7 @@ feature 'Nvotes' do
       expect(Poll::Voter.count).to eq(1)
     end
 
-    scenario "Invalid signature", :nvotes do
+    scenario "Invalid signature", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
       poll = create(:poll, :incoming, published: true, nvotes_poll_id: 128)
       nvote = create(:poll_nvote, user: user, poll: poll)
@@ -91,7 +91,7 @@ feature 'Nvotes' do
       expect(Poll::Voter.count).to eq(0)
     end
 
-    scenario "Officer information", :nvotes do
+    scenario "Officer information", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
       poll = create(:poll, :incoming, published: true, nvotes_poll_id: 128)
 

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -266,7 +266,7 @@ feature "Voter" do
       end
     end
 
-    xscenario "Voting in web - Nvotes", :nvotes do
+    xscenario "Voting in web - Nvotes", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
       poll = create(:poll)
       nvote = create(:poll_nvote, user: user, poll: poll)

--- a/spec/features/representatives_spec.rb
+++ b/spec/features/representatives_spec.rb
@@ -76,12 +76,12 @@ feature 'Representatives' do
       expect(page).not_to have_button("Delegate on #{forum.name}")
     end
 
-    scenario "Forcing the creation returns forbidden" do
+    scenario "Forcing the creation returns forbidden", :page_driver do
       page.driver.post representatives_path(id: forum.id)
       expect(page.status_code).to eq(403)
     end
 
-    scenario "Forcing the deletion returns forbidden" do
+    scenario "Forcing the deletion returns forbidden", :page_driver do
       page.driver.delete representative_path(id: forum.id)
       expect(page.status_code).to eq(403)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ RSpec.configure do |config|
     Capybara.current_driver = Capybara.default_driver
   end
 
-  config.after(:each, :nvotes) do
+  config.after(:each, :page_driver) do
     page.driver.reset!
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,16 +66,8 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation
   end
 
-  config.after(:each, :headless_chrome) do
-    Capybara.current_driver = Capybara.default_driver
-  end
-
   config.after(:each, :page_driver) do
     page.driver.reset!
-  end
-
-  config.before(:each, type: :feature) do
-    Capybara.reset_sessions!
   end
 
   config.before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,11 +61,6 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, :headless_chrome) do
-    Capybara.current_driver  = :headless_chrome
-    DatabaseCleaner.strategy = :truncation
-  end
-
   config.after(:each, :page_driver) do
     page.driver.reset!
   end


### PR DESCRIPTION
# References

* Issue #1623

# Objectives

Fix the flaky specs that appeared in `spec/features/welcome_spec.rb:41` ("Welcome screen is not shown to organizations").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

The test failed if the previous test had set `session["user_return_to"]` and hadn't deleted the cookie. In those situations, the expectation of being redirected to the `root_path` fails.

This scenario took place when the previous test was one of the represetatives tests using `page.driver.post` or `page.driver.delete`. These methods set cookies in the driver and those cookies aren't cleared by executing `Capybara.reset_sessions!`.

## Explain why your PR fixes it

Resetting the driver after every feature spec solves the problem.

# Notes

* Even though this specific issue doesn't affect the main CONSUL repository (no representatives spec there), I'd backport this PR anyway, since it offers a general solution for similar issues.
* Some related refactoring in RSpec `config.before` and `config.after` blocks has been included in this PR.