### PR TITLE
Fix today's booths for officer (fixes time-related flaky specs)

### DIFF
--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -31,7 +31,7 @@ class Officing::BaseController < ApplicationController
 
     def verify_booth
       return unless current_booth.blank?
-      booths = todays_booths_for_officer(current_user.poll_officer)
+      booths = current_user.poll_officer.todays_booths
       case booths.count
       when 0
         redirect_to officing_root_path
@@ -44,10 +44,6 @@ class Officing::BaseController < ApplicationController
 
     def current_booth
       Poll::Booth.where(id: session[:booth_id]).first
-    end
-
-    def todays_booths_for_officer(officer)
-      officer.officer_assignments.by_date(Date.current).map(&:booth).uniq
     end
 
     def letter?

--- a/app/controllers/officing/base_controller.rb
+++ b/app/controllers/officing/base_controller.rb
@@ -47,7 +47,7 @@ class Officing::BaseController < ApplicationController
     end
 
     def todays_booths_for_officer(officer)
-      officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
+      officer.officer_assignments.by_date(Date.current).map(&:booth).uniq
     end
 
     def letter?

--- a/app/controllers/officing/booth_controller.rb
+++ b/app/controllers/officing/booth_controller.rb
@@ -5,7 +5,7 @@ class Officing::BoothController < Officing::BaseController
   before_action :verify_officer_assignment
 
   def new
-    @booths = todays_booths_for_officer(current_user.poll_officer)
+    @booths = current_user.poll_officer.todays_booths
   end
 
   def create

--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -46,7 +46,7 @@ module PollsHelper
   end
 
   def voted_before_sign_in(question)
-    question.answers.where(author: current_user).any? { |vote| current_user.current_sign_in_at >= vote.updated_at }
+    question.answers.where(author: current_user).any? { |vote| current_user.current_sign_in_at > vote.updated_at }
   end
 
   def show_link_to_first_voting?(poll)

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -19,7 +19,7 @@ class Budget
       validate :description_or_status_present?
 
       scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
-      scope :published,                 -> { where("publication_date <= ?", Date.today) }
+      scope :published,                 -> { where("publication_date <= ?", Date.current) }
       scope :with_status,               -> { where("status_id IS NOT NULL") }
 
       def self.title_max_length

--- a/app/models/poll/officer.rb
+++ b/app/models/poll/officer.rb
@@ -23,5 +23,9 @@ class Poll
                                sort {|x, y| y.ends_at <=> x.ends_at}
     end
 
+    def todays_booths
+      officer_assignments.by_date(Date.current).map(&:booth).uniq
+    end
+
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -82,7 +82,7 @@ FactoryBot.define do
     user
     document_number
     document_type    "1"
-    date_of_birth    Time.zone.local(1980, 12, 31).to_date
+    date_of_birth    { Time.zone.local(1980, 12, 31).to_date }
     postal_code      "28013"
     terms_of_service '1'
 
@@ -193,7 +193,7 @@ FactoryBot.define do
     end
 
     trait :archived do
-      created_at 25.months.ago
+      created_at { 25.months.ago }
     end
 
     trait :with_hot_score do
@@ -395,11 +395,11 @@ FactoryBot.define do
     end
 
      trait :hidden do
-       hidden_at Time.current
+       hidden_at { Time.current }
      end
 
      trait :with_ignored_flag do
-       ignored_flag_at Time.current
+       ignored_flag_at { Time.current }
      end
 
     trait :flagged do
@@ -409,7 +409,7 @@ FactoryBot.define do
      end
 
      trait :with_confirmed_hide do
-       confirmed_hide_at Time.current
+       confirmed_hide_at { Time.current }
      end
   end
 
@@ -869,15 +869,15 @@ FactoryBot.define do
     end
 
     trait :ignored do
-      ignored_at Date.current
+      ignored_at { Date.current }
     end
 
     trait :hidden do
-      hidden_at Date.current
+      hidden_at { Date.current }
     end
 
     trait :with_confirmed_hide do
-      confirmed_hide_at Time.current
+      confirmed_hide_at { Time.current }
     end
   end
 
@@ -964,14 +964,14 @@ FactoryBot.define do
     end
 
     trait :in_proposals_phase do
-      proposals_phase_start_date Date.current - 1.day
-      proposals_phase_end_date Date.current + 2.days
+      proposals_phase_start_date { Date.current - 1.day }
+      proposals_phase_end_date { Date.current + 2.days }
       proposals_phase_enabled true
     end
 
     trait :upcoming_proposals_phase do
-      proposals_phase_start_date Date.current + 1.day
-      proposals_phase_end_date Date.current + 2.days
+      proposals_phase_start_date { Date.current + 1.day }
+      proposals_phase_end_date { Date.current + 2.days }
       proposals_phase_enabled true
     end
 
@@ -984,8 +984,8 @@ FactoryBot.define do
     end
 
     trait :open do
-      start_date 1.week.ago
-      end_date   1.week.from_now
+      start_date { 1.week.ago }
+      end_date   { 1.week.from_now }
     end
 
   end
@@ -1143,7 +1143,7 @@ LOREM_IPSUM
 
     trait :sent do
       recipients_count 1
-      sent_at Time.current
+      sent_at { Time.current }
     end
   end
 

--- a/spec/features/admin/admin_notifications_spec.rb
+++ b/spec/features/admin/admin_notifications_spec.rb
@@ -39,7 +39,7 @@ feature "Admin Notifications" do
   end
 
   context "Index" do
-    scenario "Valid Admin Notifications" do
+    scenario "Valid Admin Notifications", :with_frozen_time do
       draft = create(:admin_notification, segment_recipient: :all_users, title: 'Not yet sent')
       sent = create(:admin_notification, :sent, segment_recipient: :administrators,
                                                 title: 'Sent one')

--- a/spec/features/budget_polls/ballot_sheets_spec.rb
+++ b/spec/features/budget_polls/ballot_sheets_spec.rb
@@ -58,7 +58,7 @@ feature 'Poll budget ballot sheets' do
       expect(page).to have_content "#{poll.name}"
     end
 
-    scenario "Access ballot sheets officing with multiple booth assignments" do
+    scenario "Access ballot sheets officing with multiple booth assignments", :with_frozen_time do
       booth_2 = create(:poll_booth)
       create(:poll_booth_assignment, poll: poll, booth: booth)
       create(:poll_booth_assignment, poll: poll, booth: booth_2)

--- a/spec/features/budget_polls/voter_spec.rb
+++ b/spec/features/budget_polls/voter_spec.rb
@@ -1,21 +1,15 @@
 require 'rails_helper'
 
-feature "BudgetPolls" do
+feature "BudgetPolls", :with_frozen_time do
   let(:budget) { create(:budget, :balloting) }
   let(:group) { create(:budget_group, budget: budget) }
   let(:heading) { create(:budget_heading, group: group) }
   let(:investment) { create(:budget_investment, :selected, heading: heading) }
-  let(:poll) { create(:poll, :current, budget: budget, starts_at: "2017-12-01", ends_at: "2018-02-01") }
+  let(:poll) { create(:poll, :current, budget: budget) }
   let(:booth) { create(:poll_booth) }
   let(:officer) { create(:poll_officer) }
   let(:admin) { create(:administrator) }
   let!(:user) { create(:user, :in_census) }
-
-  before do
-    allow(Date).to receive(:current).and_return Date.new(2018,1,1)
-    allow(Date).to receive(:today).and_return Date.new(2018,1,1)
-    allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
-  end
 
   background do
     create(:poll_shift, officer: officer, booth: booth, date: Date.current, task: :vote_collection)

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -141,7 +141,7 @@ feature 'Legislation' do
     end
 
     context 'debate phase' do
-      scenario 'not open' do
+      scenario 'not open', :with_frozen_time do
         process = create(:legislation_process, debate_start_date: Date.current + 1.day, debate_end_date: Date.current + 2.days)
 
         visit legislation_process_path(process)
@@ -176,7 +176,7 @@ feature 'Legislation' do
     end
 
     context 'draft publication phase' do
-      scenario 'not open' do
+      scenario 'not open', :with_frozen_time do
         process = create(:legislation_process, draft_publication_date: Date.current + 1.day)
 
         visit draft_publication_legislation_process_path(process)
@@ -196,7 +196,7 @@ feature 'Legislation' do
     end
 
     context 'allegations phase' do
-      scenario 'not open' do
+      scenario 'not open', :with_frozen_time do
         process = create(:legislation_process, allegations_start_date: Date.current + 1.day, allegations_end_date: Date.current + 2.days)
 
         visit allegations_legislation_process_path(process)
@@ -216,7 +216,7 @@ feature 'Legislation' do
     end
 
     context 'final version publication phase' do
-      scenario 'not open' do
+      scenario 'not open', :with_frozen_time do
         process = create(:legislation_process, result_publication_date: Date.current + 1.day)
 
         visit result_publication_legislation_process_path(process)
@@ -236,7 +236,7 @@ feature 'Legislation' do
     end
 
     context 'proposals phase' do
-      scenario 'not open' do
+      scenario 'not open', :with_frozen_time do
         process = create(:legislation_process, :upcoming_proposals_phase)
 
         visit legislation_process_proposals_path(process)

--- a/spec/features/officing/booth_spec.rb
+++ b/spec/features/officing/booth_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
-feature 'Booth' do
-
-  before do
-    allow(Date).to receive(:current).and_return Date.new(2018,1,1)
-    allow(Date).to receive(:today).and_return Date.new(2018,1,1)
-    allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
-  end
+feature 'Booth', :with_frozen_time do
 
   scenario "Officer with no booth assignments today" do
     officer = create(:poll_officer)

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -1,15 +1,7 @@
 require 'rails_helper'
 
-feature 'Residence' do
+feature 'Residence', :with_frozen_time do
   let(:officer) { create(:poll_officer) }
-
-  background do
-    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
-  end
-
-  after do
-    travel_back
-  end
 
   feature "Officers without assignments" do
 

--- a/spec/features/officing/residence_spec.rb
+++ b/spec/features/officing/residence_spec.rb
@@ -131,11 +131,6 @@ feature 'Residence', :with_frozen_time do
   end
 
   scenario "Verify booth", :js do
-    allow(Date).to receive_messages(
-                          :current => Date.new(2018,1,1),
-                          :today => Date.new(2018,1,1))
-    allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
-
     booth = create(:poll_booth)
     poll = create(:poll)
 

--- a/spec/features/officing/results_spec.rb
+++ b/spec/features/officing/results_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
-feature 'Officing Results' do
+feature 'Officing Results', :with_frozen_time do
   let(:poll) { create(:poll, ends_at: 1.day.ago) }
   let(:booth) { create(:poll_booth) }
   let(:poll_officer) { create(:poll_officer) }
 
   background do
-    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
     create(:poll_booth_assignment, poll: poll, booth: booth)
     create(:poll_shift, :recount_scrutiny_task, officer: poll_officer, booth: booth, date: Date.current)
     @question_1 = create(:poll_question, poll: poll)
@@ -18,10 +17,6 @@ feature 'Officing Results' do
 
     login_as(poll_officer.user)
     set_officing_booth(booth)
-  end
-
-  after do
-    travel_back
   end
 
   scenario 'Only polls where user is officer for results are accessible' do

--- a/spec/features/officing_spec.rb
+++ b/spec/features/officing_spec.rb
@@ -127,7 +127,7 @@ feature 'Poll Officing' do
     expect(page).not_to have_css('#moderation_menu')
   end
 
-  scenario 'Officing dashboard available for multiple sessions', :js do
+  scenario 'Officing dashboard available for multiple sessions', :js, :with_frozen_time do
     poll = create(:poll)
     booth = create(:poll_booth)
     booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -481,17 +481,11 @@ feature 'Polls' do
     end
   end
 
-  context 'Booth & Website' do
+  context 'Booth & Website', :with_frozen_time do
 
-    let(:poll) { create(:poll, summary: "Summary", description: "Description", starts_at: '2017-12-01', ends_at: '2018-02-01') }
+    let(:poll) { create(:poll, summary: "Summary", description: "Description") }
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
-
-    before do
-      allow(Date).to receive(:current).and_return Date.new(2018,1,1)
-      allow(Date).to receive(:today).and_return Date.new(2018,1,1)
-      allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
-    end
 
     scenario 'Already voted on booth cannot vote on website', :js do
 

--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -2,21 +2,15 @@ require 'rails_helper'
 
 feature "Voter" do
 
-  context "Origin" do
+  context "Origin", :with_frozen_time do
 
-    let(:poll) { create(:poll, :current, starts_at: "2017-12-01", ends_at: "2018-02-01") }
+    let(:poll) { create(:poll, :current) }
     let(:question) { create(:poll_question, poll: poll) }
     let(:booth) { create(:poll_booth) }
     let(:officer) { create(:poll_officer) }
     let(:admin) { create(:administrator) }
     let!(:answer_yes) { create(:poll_question_answer, question: question, title: 'Yes') }
     let!(:answer_no) { create(:poll_question_answer, question: question, title: 'No') }
-
-    before do
-      allow(Date).to receive(:current).and_return Date.new(2018,1,1)
-      allow(Date).to receive(:today).and_return Date.new(2018,1,1)
-      allow(Time).to receive(:current).and_return Time.zone.parse("2018-01-01 12:00:00")
-    end
 
     background do
       create(:geozone, :in_census)
@@ -220,12 +214,18 @@ feature "Voter" do
 
         click_link "Sign out"
 
-        login_as user
-        visit poll_path(poll)
+        # Time needs to pass between the moment we vote and the moment
+        # we log in; otherwise the link to vote won't be available.
+        # It's safe to advance one second because this test isn't
+        # affected by possible date changes.
+        travel 1.second do
+          login_as user
+          visit poll_path(poll)
 
-        within("#poll_question_#{question.id}_answers") do
-          expect(page).to have_link(answer_yes.title)
-          expect(page).to have_link(answer_no.title)
+          within("#poll_question_#{question.id}_answers") do
+            expect(page).to have_link(answer_yes.title)
+            expect(page).to have_link(answer_no.title)
+          end
         end
       end
     end

--- a/spec/models/budget/investment/milestone_spec.rb
+++ b/spec/models/budget/investment/milestone_spec.rb
@@ -69,4 +69,16 @@ describe Budget::Investment::Milestone do
     end
   end
 
+  describe ".published" do
+    it "uses the application's time zone date", :with_different_time_zone do
+      published_in_local_time_zone = create(:budget_investment_milestone,
+                                            publication_date: Date.today)
+
+      published_in_application_time_zone = create(:budget_investment_milestone,
+                                                  publication_date: Date.current)
+
+      expect(Budget::Investment::Milestone.published).to include(published_in_application_time_zone)
+      expect(Budget::Investment::Milestone.published).not_to include(published_in_local_time_zone)
+    end
+  end
 end

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -121,4 +121,32 @@ describe Poll::Officer do
       expect(assigned_polls.last).to eq(poll_3)
     end
   end
+
+  describe "todays_booths" do
+    let(:officer) { create(:poll_officer) }
+
+    before do
+      system_zone = ActiveSupport::TimeZone.new("UTC")
+      local_zone = ActiveSupport::TimeZone.new("Madrid")
+
+      # Make sure the date defined by `config.time_zone` and
+      # the local date are different.
+      allow(Time).to receive(:zone).and_return(system_zone)
+      allow(Time).to receive(:now).and_return(Date.current.at_end_of_day.in_time_zone(local_zone))
+      allow(Date).to receive(:today).and_return(Time.now.to_date)
+    end
+
+    it "returns booths for the date defined by the application's time zone" do
+      assignment_with_local_time_zone = create(:poll_officer_assignment,
+                                               date:    Date.today,
+                                               officer: officer)
+
+      assignment_with_application_time_zone = create(:poll_officer_assignment,
+                                                     date:    Date.current,
+                                                     officer: officer)
+
+      expect(officer.todays_booths).to include(assignment_with_application_time_zone.booth)
+      expect(officer.todays_booths).not_to include(assignment_with_local_time_zone.booth)
+    end
+  end
 end

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -125,18 +125,7 @@ describe Poll::Officer do
   describe "todays_booths" do
     let(:officer) { create(:poll_officer) }
 
-    before do
-      system_zone = ActiveSupport::TimeZone.new("UTC")
-      local_zone = ActiveSupport::TimeZone.new("Madrid")
-
-      # Make sure the date defined by `config.time_zone` and
-      # the local date are different.
-      allow(Time).to receive(:zone).and_return(system_zone)
-      allow(Time).to receive(:now).and_return(Date.current.at_end_of_day.in_time_zone(local_zone))
-      allow(Date).to receive(:today).and_return(Time.now.to_date)
-    end
-
-    it "returns booths for the date defined by the application's time zone" do
+    it "returns booths for the application's time zone date", :with_different_time_zone do
       assignment_with_local_time_zone = create(:poll_officer_assignment,
                                                date:    Date.today,
                                                officer: officer)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,6 +96,14 @@ RSpec.configure do |config|
     Bullet.end_request
   end
 
+  config.before(:each, :with_frozen_time) do
+    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
+  end
+
+  config.after(:each, :with_frozen_time) do
+    travel_back
+  end
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,17 @@ RSpec.configure do |config|
     travel_back
   end
 
+  config.before(:each, :with_different_time_zone) do
+    system_zone = ActiveSupport::TimeZone.new("UTC")
+    local_zone = ActiveSupport::TimeZone.new("Madrid")
+
+    # Make sure the date defined by `config.time_zone` and
+    # the local date are different.
+    allow(Time).to receive(:zone).and_return(system_zone)
+    allow(Time).to receive(:now).and_return(Date.current.at_end_of_day.in_time_zone(local_zone))
+    allow(Date).to receive(:today).and_return(Time.now.to_date)
+  end
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"


### PR DESCRIPTION
# References

* Issue #1195
* Issue #1200
* Issue #1202
* Issue #1203
* Issue #1204
* Issue #1209
* Issue #1210
* [Travis job with ballot sheets failure](https://travis-ci.org/javierm/consul/jobs/422313699)
* [Travis job with milestones failure](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/423718182)
* [Travis job before changing booth's code](https://travis-ci.org/javierm/consul/jobs/422575831) (note: the code in this build uses `Timecop` to force the date to be 01:00AM)
* [Travis job after changing booth's code](https://travis-ci.org/javierm/consul/jobs/422589692) (note: the code in this build uses `Timecop` to force the date to be 01:00AM)
* Pull Request consul#2712

# Background

We've been struggling with failing tests around midnight for a long time. Pull Request consul#2712 solved that problem for most of the affected specs by freezing time and using dynamic factories.

However, while those changes made results consistent on machines with the same time zone as Madrid, they were still inconsistent in places with differet time zones, like some of our forks or the machine Travis uses to run the builds.

# Objectives

Fix the flaky specs that appeared in `spec/features/polls/voter_spec.rb:172` ("Voter Origin Trying to vote the same poll in booth and web Trying to vote in booth and then in web"),  `spec/features/officing_spec.rb:130` ("Poll Officing Officing dashboard available for multiple sessions"), `spec/features/officing/booth_spec.rb:38` ("Booth Officer with multiple booth assignments today"), `spec/features/officing/booth_spec.rb:63` ("Booth Display single booth for any number of polls"), 
`spec/features/officing/booth_spec.rb:22` ("Booth Officer with single booth assignment today"), `spec/features/officing/residence_spec.rb:120` ("Residence Assigned officers Error on Census (year of birth)"), `spec/features/officing/residence_spec.rb:59` ("Residence Assigned officers Document number is copied from the census API"), `spec/features/officing/residence_spec.rb:93` ("Residence Assigned officers Error on Census (document number)"), `spec/features/officing/residence_spec.rb:40` ("Residence Assigned officers Verify voter"), `spec/features/officing/residence_spec.rb:81` ("Residence Assigned officers Error on verify"), `spec/features/officing/residence_spec.rb:133` ("Residence Verify booth"), `spec/features/budget_polls/ballot_sheets_spec.rb:61` ("Poll budget ballot sheets Booth assignment Access ballot sheets officing with multiple booth assignments"), `spec/features/budgets/executions_spec.rb:147` ("Executions Filters by milestone status"), `spec/features/admin/admin_notifications_spec.rb:37` ("Admin Notifications Index Valid Admin Notifications"), `spec/features/legislation/processes_spec.rb:180` ("Legislation process page draft publication phase not open"), `spec/features/legislation/processes_spec.rb:201` ("Legislation process page allegations phase not open"), `spec/features/legislation/processes_spec.rb:222` ("Legislation process page final version publication phase not open"), `spec/features/legislation/processes_spec.rb:144` ("Legislation process page debate phase not open"), `spec/features/legislation/processes_spec.rb:243` ("Legislation process page proposals phase not open").

## Explain why the test is flaky, or under which conditions/scenario it fails randomly

As explained in the commit message:

> Using `Date.today` generates the date on the machine the application is
> being executed, and using `Date.current` generates the date defined in
> `Rails.application.config.time_zone`.
>
> Usually we don't notice the difference because most developers use the
> same time zone. However, other forks (and Travis) might notice issues
> once in a while. For example, this code in `Officing::BaseController`:
>
> @officer_assignments ||= current_user.poll_officer.officer_assignments.
>                          where(date: Time.current.to_date)
> (...)
> officer.officer_assignments.by_date(Date.today).map(&:booth).uniq
>
> These lines use different dates, resulting in unexpected results.

## Explain why your PR fixes it

Using `Date.current` in both of them (as the rest of the application does, see for example commit e14a5b2 ) solves the problem.

# Notes

* :warning: When backporting to consul please take into account some affected specs and factories don't exist there. There might be conflicts with consul#2838 as well.
* We can debug these issues locally by executing `TZ=Australia/Canberra rspec`, replacing "Australia/Canberra" to whatever time zone where `Date.today` is different than the date in Madrid.
* According to my tests, all specs mentioned here fail without changing the `todays_booths_for_offcer` code, and all of them pass after changing it no matter what combination of time and time zone we're in. Therefore, AFAIK this PR (finally!) closes all issues mentioned in the references section. I could be wrong, though, and there might be yet another timing issue we haven't found so far.
* These changes also fix flaky specs we hadn't seen fail before (are at least there wasn't an open issue for them). So they might fix more specs we weren't aware were failing.
* I've also included commit b6c16a8 which fixes another use of `Date.today`.
* I've added a few more commits (f4e3412, 44f73fb and 9087784) which aren't related to today's booths for officer but also fix specs failing at midnight. There's an important difference: these commits only fix flaky specs, while the commit changing `todays_booths_for_officer` fixed behaviour affecting the development and production environments. If these changes should be done in a different pull request, please let me know.