### PR TITLE
Custom legislation processes content

### DIFF
--- a/app/views/custom/legislation/processes/proposals.html.erb
+++ b/app/views/custom/legislation/processes/proposals.html.erb
@@ -1,0 +1,43 @@
+<% provide :title do %><%= @process.title %><% end %>
+
+<%= render 'legislation/processes/header', process: @process, header: :full %>
+
+<%= render 'custom_documents' %>
+
+<%= render 'custom_results' %>
+
+<%= render 'key_dates', process: @process, phase: :proposals %>
+
+<div class="row">
+  <div class="debate-chooser">
+    <div class="row">
+      <div class="small-12 medium-9 column">
+        <div class="legislation-proposals">
+          <% if @proposals.empty? %>
+            <div class="callout primary">
+              <p><%= t("legislation.processes.proposals.empty_proposals") %></p>
+            </div>
+          <% else %>
+            <%= render @proposals %>
+            <%= paginate @proposals %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="small-12 medium-3 column">
+        <% if @process.proposals_phase.open? %>
+          <% if @process.title == "PLENO ABIERTO" %>
+            <p><%= link_to t("proposals.index.start_proposal_question"),
+                            (user_signed_in? ? new_legislation_process_proposal_path(@process) : new_user_session_path),
+                            class: 'button expanded', id: 'create-new-proposal' %></p>
+          <% else %>
+            <p><%= link_to t("proposals.index.start_proposal"),
+                            (user_signed_in? ? new_legislation_process_proposal_path(@process) : new_user_session_path),
+                            class: 'button expanded', id: 'create-new-proposal' %></p>
+          <% end %>
+        <% end %>
+        <%= render 'legislation/proposals/categories', taggable: @process %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/custom/legislation/proposals/_form.html.erb
+++ b/app/views/custom/legislation/proposals/_form.html.erb
@@ -1,0 +1,96 @@
+<%= form_for(@proposal, url: form_url) do |f| %>
+  <%= render 'shared/errors', resource: @proposal %>
+
+  <%= f.hidden_field(:legislation_process_id, :value => params[:process_id]) %>
+
+  <div class="row">
+    <div class="small-12 column <%= "hide" unless @process.title == "PLENO ABIERTO" %>">
+      <%= f.label :proposal_type, t("proposals.form.proposal_type") %>
+      <%= f.select :proposal_type, proposal_type_options, label: false %>
+    </div>
+
+    <div class="small-12 column">
+
+      <%= f.label :title do %>
+        <span id="js-legislation-proposal-label-title"><%= t("proposals.form.proposal_title") %></span>
+        <span id="js-legislation-proposal-label-question-title"><%= t("legislation_proposals.form.question_title") %></span>
+      <% end %>
+      <%= f.text_field :title, maxlength: Legislation::Proposal::TITLE_MAX_LENGTH, label: false %>
+    </div>
+
+    <%= f.invisible_captcha :subtitle %>
+
+    <div class="small-12 column" id="js-legislation-proposal-summary">
+      <%= f.label :summary, t("proposals.form.proposal_summary") %>
+      <p class="help-text" id="summary-help-text"><%= t("proposals.form.proposal_summary_note") %></p>
+      <%= f.text_area :summary, rows: 4, maxlength: 200, label: false,
+                      placeholder: t('proposals.form.proposal_summary'),
+                      aria: {describedby: "summary-help-text"} %>
+    </div>
+
+    <div class="ckeditor small-12 column">
+      <%= f.label :description do %>
+        <span id="js-legislation-proposal-label-description">
+           <%= t("proposals.form.proposal_text") %>
+        </span>
+        <span id="js-legislation-proposal-label-question-description">
+          <%= t("legislation_proposals.form.question_description") %>
+        </span>
+      <% end %>
+      <%= f.cktext_area :description, maxlength: Legislation::Proposal.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
+    </div>
+
+    <div class="small-12 column" id="js-legislation-proposal-video-url">
+      <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
+      <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
+      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
+                                   aria: {describedby: "video-url-help-text"} %>
+    </div>
+
+    <% if feature?(:allow_attached_documents) %>
+      <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>" id="js-legislation-proposal-documents">
+        <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
+      </div>
+    <% end %>
+
+    <div class="small-12 medium-6 column" id="js-legislation-proposal-geozone">
+      <%= f.label :geozone_id,  t("proposals.form.geozone") %>
+      <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
+    </div>
+
+    <div class="small-12 column" id="js-legislation-proposal-tags">
+      <%= f.label :tag_list, t("legislation.proposals.form.tags_label") %>
+      <p class="help-text" id="tag-list-help-text"><%= t("proposals.form.tags_instructions") %></p>
+
+      <div id="category_tags" class="tags">
+        <% @process.tag_list_on(:customs).each do |tag| %>
+          <a class="js-add-tag-link"><%= tag %></a>
+        <% end %>
+      </div>
+
+      <br>
+      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s,
+                        label: false,
+                        placeholder: t("proposals.form.tags_placeholder"),
+                        class: 'js-tag-list',
+                        aria: {describedby: "tag-list-help-text"} %>
+    </div>
+
+    <div class="small-12 column">
+      <% if @proposal.new_record? %>
+        <%= f.label :terms_of_service do %>
+          <%= f.check_box :terms_of_service, title: t('form.accept_terms_title'), label: false %>
+          <span class="checkbox">
+            <%= t("form.accept_terms",
+                policy: link_to(t("form.policy"), "/privacy", target: "blank"),
+                conditions: link_to(t("form.conditions"), "/conditions", target: "blank")).html_safe %>
+          </span>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="actions small-12 column">
+      <%= f.submit(class: "button", value: t("proposals.#{action_name}.form.submit_button")) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/custom/legislation/proposals/show.html.erb
+++ b/app/views/custom/legislation/proposals/show.html.erb
@@ -105,7 +105,7 @@
            By only allowing voting in the index of Proposals,
            hopefully citizens will see other interesting proposals
            to vote for -->
-      <% unless @process.id == 24 %>
+      <% unless @process.title == "PLENO ABIERTO" %>
         <aside class="small-12 medium-3 column">
           <div class="sidebar-divider"></div>
           <h2><%= t("votes.supports") %></h2>

--- a/app/views/legislation/processes/_custom_results.html.erb
+++ b/app/views/legislation/processes/_custom_results.html.erb
@@ -1,3 +1,3 @@
-<% if @process.id == 24 %>
+<% if @process.title == "PLENO ABIERTO" %>
   <%= render 'results_process_24' %>
 <% end %>

--- a/app/views/legislation/processes/proposals.html.erb
+++ b/app/views/legislation/processes/proposals.html.erb
@@ -2,10 +2,6 @@
 
 <%= render 'legislation/processes/header', process: @process, header: :full %>
 
-<%= render 'custom_documents' %>
-
-<%= render 'custom_results' %>
-
 <%= render 'key_dates', process: @process, phase: :proposals %>
 
 <div class="row">
@@ -13,28 +9,19 @@
     <div class="row">
       <div class="small-12 medium-9 column">
         <div class="legislation-proposals">
-          <% if @proposals.empty? %>
+          <% if @process.proposals.empty? %>
             <div class="callout primary">
               <p><%= t('.empty_proposals') %></p>
             </div>
           <% else %>
-            <%= render @proposals %>
-            <%= paginate @proposals %>
+            <%= render @process.proposals %>
           <% end %>
         </div>
       </div>
 
       <div class="small-12 medium-3 column">
         <% if @process.proposals_phase.open? %>
-          <% if @process.id == 24 %>
-            <p><%= link_to t("proposals.index.start_proposal_question"),
-                            (user_signed_in? ? new_legislation_process_proposal_path(@process) : new_user_session_path),
-                            class: 'button expanded', id: 'create-new-proposal' %></p>
-          <% else %>
-            <p><%= link_to t("proposals.index.start_proposal"),
-                            (user_signed_in? ? new_legislation_process_proposal_path(@process) : new_user_session_path),
-                            class: 'button expanded', id: 'create-new-proposal' %></p>
-          <% end %>
+          <p><%= link_to t("proposals.index.start_proposal"), new_legislation_process_proposal_path(@process), class: 'button expanded' %></p>
         <% end %>
         <%= render 'legislation/proposals/categories', taggable: @process %>
       </div>

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -4,23 +4,14 @@
   <%= f.hidden_field(:legislation_process_id, :value => params[:process_id]) %>
 
   <div class="row">
-    <div class="small-12 column <%= "hide" unless @process.id == 24 %>">
-      <%= f.label :proposal_type, t("proposals.form.proposal_type") %>
-      <%= f.select :proposal_type, proposal_type_options, label: false %>
-    </div>
-
     <div class="small-12 column">
-
-      <%= f.label :title do %>
-        <span id="js-legislation-proposal-label-title"><%= t("proposals.form.proposal_title") %></span>
-        <span id="js-legislation-proposal-label-question-title"><%= t("legislation_proposals.form.question_title") %></span>
-      <% end %>
-      <%= f.text_field :title, maxlength: Legislation::Proposal::TITLE_MAX_LENGTH, label: false %>
+      <%= f.label :title, t("proposals.form.proposal_title") %>
+      <%= f.text_field :title, maxlength: Legislation::Proposal.title_max_length, placeholder: t("proposals.form.proposal_title"), label: false %>
     </div>
 
     <%= f.invisible_captcha :subtitle %>
 
-    <div class="small-12 column" id="js-legislation-proposal-summary">
+    <div class="small-12 column">
       <%= f.label :summary, t("proposals.form.proposal_summary") %>
       <p class="help-text" id="summary-help-text"><%= t("proposals.form.proposal_summary_note") %></p>
       <%= f.text_area :summary, rows: 4, maxlength: 200, label: false,
@@ -29,36 +20,27 @@
     </div>
 
     <div class="ckeditor small-12 column">
-      <%= f.label :description do %>
-        <span id="js-legislation-proposal-label-description">
-           <%= t("proposals.form.proposal_text") %>
-        </span>
-        <span id="js-legislation-proposal-label-question-description">
-          <%= t("legislation_proposals.form.question_description") %>
-        </span>
-      <% end %>
+      <%= f.label :description, t("proposals.form.proposal_text") %>
       <%= f.cktext_area :description, maxlength: Legislation::Proposal.description_max_length, ckeditor: { language: I18n.locale }, label: false %>
     </div>
 
-    <div class="small-12 column" id="js-legislation-proposal-video-url">
+    <div class="small-12 column">
       <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
       <p class="help-text" id="video-url-help-text"><%= t("proposals.form.proposal_video_url_note") %></p>
       <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false,
                                    aria: {describedby: "video-url-help-text"} %>
     </div>
 
-    <% if feature?(:allow_attached_documents) %>
-      <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>" id="js-legislation-proposal-documents">
-        <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
-      </div>
-    <% end %>
+    <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>">
+      <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
+    </div>
 
-    <div class="small-12 medium-6 column" id="js-legislation-proposal-geozone">
+    <div class="small-12 medium-6 column">
       <%= f.label :geozone_id,  t("proposals.form.geozone") %>
       <%= f.select :geozone_id, geozone_select_options, {include_blank: t("geozones.none"), label: false} %>
     </div>
 
-    <div class="small-12 column" id="js-legislation-proposal-tags">
+    <div class="small-12 column">
       <%= f.label :tag_list, t("legislation.proposals.form.tags_label") %>
       <p class="help-text" id="tag-list-help-text"><%= t("proposals.form.tags_instructions") %></p>
 


### PR DESCRIPTION
References
===================
Related issue: https://github.com/AyuntamientoMadrid/consul/issues/1233

Objectives
===================
This PR moves custom legislation processes content to the correct `custom` folders.

Also changes `@process.id` condition to `@process.title` to avoid **features/legislation/processes_spec.rb:237** failing randomly as referenced in https://github.com/AyuntamientoMadrid/consul/issues/1233.

Notes
===================
Backport the first commit to CONSUL repo.