### PR TITLE
Fix flaky localization specs

### DIFF
--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -41,12 +41,19 @@ feature 'Localization' do
     expect(page).to have_select('locale-switcher', selected: 'Español')
   end
 
-  scenario 'Locale switcher not present if only one locale' do
-    allow(I18n).to receive(:available_locales).and_return([:en])
+  context "Only one locale" do
+    before do
+      allow(I18n).to receive(:available_locales).and_return([:en])
+      I18n.reload!
+    end
 
-    visit '/'
-    expect(page).not_to have_content('Language')
-    expect(page).not_to have_css('div.locale')
+    after { I18n.reload! }
+
+    scenario "Locale switcher not present" do
+      visit '/'
+      expect(page).not_to have_content('Language')
+      expect(page).not_to have_css('div.locale')
+    end
   end
 
   context "Missing language names" do


### PR DESCRIPTION
## References

* Issue #1630

## Objectives

Fix the flaky specs that appeared in `spec/features/localization_spec.rb:34` ("Localization Changing the locale") and `spec/features/localization_spec.rb:20` ("Localization Available locales appear in the locale switcher").

### Explain why the test is flaky, or under which conditions/scenario it fails randomly

These specs fail when executed after `spec/customization_engine_spec.rb:19` and `spec/features/localization_spec.rb:44`, causing the following sequence:

1. The first test executes `I18n.reload!`, which causes `I18n.config.backend` to set `@translations = nil`.
2. The second test stubs `available_locales` to `[:en]`, causing `@translations` to get only translations for `:en`.
3. The third test doesn't find translations for Spanish because `@translations` only has the English ones, and fails.

### Explain why your PR fixes it

Reloading `I18n` after the test stubbing `available_locales` solves the problem, since it sets `@translations = nil` again, and so it fetches translations for Spanish (and all the other languages).

## Notes

* We might need to call `init_translations`, since `i18n` [doesn't automatically init translations](https://github.com/svenfuchs/i18n/pull/353)