### PR TITLE
Display first image available for milestones

### DIFF
--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -10,4 +10,9 @@ module BudgetExecutionsHelper
                                       .last.status_id == status rescue false }.count
   end
 
+  def first_milestone_with_image(investment)
+    investment.milestones.order(publication_date: :asc, created_at: :asc)
+                         .select{ |milestone| milestone.image.present? }.first
+  end
+
 end

--- a/app/views/budgets/executions/_image.html.erb
+++ b/app/views/budgets/executions/_image.html.erb
@@ -1,0 +1,9 @@
+<% investment.milestones.order(publication_date: :desc).limit(1).each do |milestone| %>
+  <% if milestone.image.present? %>
+    <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
+  <% elsif investment.image.present? %>
+    <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
+  <% else %>
+    <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
+  <% end %>
+<% end %>

--- a/app/views/budgets/executions/_image.html.erb
+++ b/app/views/budgets/executions/_image.html.erb
@@ -1,9 +1,9 @@
-<% investment.milestones.order(publication_date: :desc).limit(1).each do |milestone| %>
-  <% if milestone.image.present? %>
-    <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
-  <% elsif investment.image.present? %>
-    <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
-  <% else %>
-    <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
-  <% end %>
+<% milestone = first_milestone_with_image(investment) %>
+
+<% if milestone&.image.present? %>
+  <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
+<% elsif investment.image.present? %>
+  <%= image_tag investment.image_url(:large), alt: investment.image.title %>
+<% else %>
+  <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
 <% end %>

--- a/app/views/budgets/executions/_investments.html.erb
+++ b/app/views/budgets/executions/_investments.html.erb
@@ -7,15 +7,7 @@
         <div class="small-12 medium-6 large-4 column end margin-bottom">
           <div class="budget-execution">
             <%= link_to budget_investment_path(@budget, investment, anchor: "tab-milestones"), data: { 'equalizer-watch': true } do %>
-              <% investment.milestones.order(publication_date: :desc).limit(1).each do |milestone| %>
-                <% if milestone.image.present? %>
-                  <%= image_tag milestone.image_url(:large), alt: milestone.image.title %>
-                <% elsif investment.image.present? %>
-                  <%= image_tag investment.image_url(:thumb), alt: investment.image.title %>
-                <% else %>
-                  <%= image_tag "budget_execution_no_image.jpg", alt: investment.title %>
-                <% end %>
-              <% end %>
+              <%= render 'image', investment: investment %>
               <div class="budget-execution-info">
                 <div class="budget-execution-content">
                   <h5><%= investment.title %></h5>

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -61,6 +61,7 @@ feature 'Executions' do
   end
 
   context 'Images' do
+
     scenario 'renders milestone image if available' do
       milestone1 = create(:budget_investment_milestone, investment: investment1)
       create(:image, imageable: milestone1)
@@ -99,15 +100,21 @@ feature 'Executions' do
       expect(page).to have_css("img[alt='#{investment4.title}']")
     end
 
-    scenario "renders last milestone's image if investment has multiple milestones with images associated" do
+    scenario "renders first milestone's image if investment has multiple milestones with images associated" do
       milestone1 = create(:budget_investment_milestone, investment: investment1,
-                                                        publication_date: 2.weeks.ago)
+                                                        publication_date: Date.yesterday)
 
       milestone2 = create(:budget_investment_milestone, investment: investment1,
                                                         publication_date: Date.yesterday)
 
-      create(:image, imageable: milestone1, title: 'First milestone image')
-      create(:image, imageable: milestone2, title: 'Second milestone image')
+      milestone3 = create(:budget_investment_milestone, investment: investment1,
+                                                        publication_date: Date.yesterday)
+
+      milestone4 = create(:budget_investment_milestone, investment: investment1,
+                                                        publication_date: Date.yesterday)
+
+      create(:image, imageable: milestone2, title: 'Image for first milestone with image')
+      create(:image, imageable: milestone3, title: 'Image for second milestone with image')
 
       visit budget_path(budget)
 
@@ -116,8 +123,8 @@ feature 'Executions' do
 
       expect(page).to have_content(investment1.title)
       expect(page).to have_css("img[alt='#{milestone2.image.title}']")
-      expect(page).not_to have_css("img[alt='#{milestone1.image.title}']")
     end
+
   end
 
   context 'Filters' do


### PR DESCRIPTION
Objectives
===================
Sometimes a budget investment has some milestones created on the same date and the image is not displayed correctly. Now always display the first image available for milestones.

Notes
===================
Backport this PR to CONSUL.