### PR TITLE
Display last milestones image

### DIFF
--- a/app/helpers/budget_executions_helper.rb
+++ b/app/helpers/budget_executions_helper.rb
@@ -11,8 +11,8 @@ module BudgetExecutionsHelper
   end
 
   def first_milestone_with_image(investment)
-    investment.milestones.order(publication_date: :asc, created_at: :asc)
-                         .select{ |milestone| milestone.image.present? }.first
+    investment.milestones.order_by_publication_date
+                         .select{ |milestone| milestone.image.present? }.last
   end
 
 end

--- a/app/models/budget/investment/milestone.rb
+++ b/app/models/budget/investment/milestone.rb
@@ -18,7 +18,7 @@ class Budget
       validates :publication_date, presence: true
       validate :description_or_status_present?
 
-      scope :order_by_publication_date, -> { order(publication_date: :asc) }
+      scope :order_by_publication_date, -> { order(publication_date: :asc, created_at: :asc) }
       scope :published,                 -> { where("publication_date <= ?", Date.today) }
       scope :with_status,               -> { where("status_id IS NOT NULL") }
 

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -100,7 +100,7 @@ feature 'Executions' do
       expect(page).to have_css("img[alt='#{investment4.title}']")
     end
 
-    scenario "renders first milestone's image if investment has multiple milestones with images associated" do
+    scenario "renders last milestone's image if investment has multiple milestones with images associated" do
       milestone1 = create(:budget_investment_milestone, investment: investment1,
                                                         publication_date: Date.yesterday)
 
@@ -122,7 +122,7 @@ feature 'Executions' do
       click_link 'Milestones'
 
       expect(page).to have_content(investment1.title)
-      expect(page).to have_css("img[alt='#{milestone2.image.title}']")
+      expect(page).to have_css("img[alt='#{milestone3.image.title}']")
     end
 
   end


### PR DESCRIPTION
Objectives
===================
Always display last milestones image. Also adds a second order to ensure the order to display milestones with same publication date is always the same

Notes
===================
Backport this (with https://github.com/AyuntamientoMadrid/consul/issues/1634) to CONSUL repo.