### PR TITLE
Add specs for categories after validation errors

### DIFF
--- a/spec/features/tags/budget_investments_spec.rb
+++ b/spec/features/tags/budget_investments_spec.rb
@@ -189,6 +189,18 @@ feature 'Tags' do
     expect(page.html).not_to include 'user_id=1, &a=3, <script>alert("hey");</script>'
   end
 
+  scenario 'Create with errors' do
+    login_as(author)
+
+    visit new_budget_investment_path(budget_id: budget.id)
+    click_button 'Create Investment'
+
+    within("#category_tags") do
+      expect(page).to have_content('Economía')
+      expect(page).to have_content('Medio Ambiente')
+    end
+  end
+
   context "Filter" do
 
     scenario "From index" do

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -160,6 +160,22 @@ feature 'Tags' do
     expect(page.html).not_to include 'user_id=1, &a=3, <script>alert("hey");</script>'
   end
 
+  scenario 'Create with errors' do
+    create(:tag, :category, name: 'Economía')
+    create(:tag, :category, name: 'Medio Ambiente')
+
+    user = create(:user)
+    login_as(user)
+
+    visit new_proposal_path
+    click_button 'Create proposal'
+
+    within("#category_tags") do
+      expect(page).to have_content("Economía")
+      expect(page).to have_content("Medio Ambiente")
+    end
+  end
+
   scenario 'Update' do
     proposal = create(:proposal, tag_list: 'Economía')
 
@@ -175,6 +191,24 @@ feature 'Tags' do
     within('.tags') do
       expect(page).to have_css('a', text: 'Economía')
       expect(page).to have_css('a', text: 'Hacienda')
+    end
+  end
+
+  scenario 'Update with errors' do
+    create(:tag, :category, name: 'Economía')
+    create(:tag, :category, name: 'Medio Ambiente')
+
+    proposal = create(:proposal, tag_list: 'Economía')
+
+    login_as(proposal.author)
+    visit edit_proposal_path(proposal)
+
+    fill_in 'proposal_title', with: ''
+    click_button 'Save changes'
+
+    within("#category_tags") do
+      expect(page).to have_content("Economía")
+      expect(page).to have_content("Medio Ambiente")
     end
   end
 


### PR DESCRIPTION
Objectives
===================
Add missing specs to check category tags are still being loaded and displayed, after submitting the form with validation errors.

Visual Changes
===================
None

Notes
===================
Budget::Investment can not be updated yet, so not need to add that spec
