### PR TITLE
Update rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -426,3 +426,6 @@ Security/MarshalLoad:
 
 Security/YAMLLoad:
   Enabled: true
+
+Style/PercentLiteralDelimiters:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Layout/IndentationConsistency:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
+Layout/TrailingBlankLines:
+  Enabled: true
+
 Layout/TrailingWhitespace:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Layout/IndentationConsistency:
 Layout/EndOfLine:
   EnforcedStyle: lf
 
+Layout/TrailingWhitespace:
+  Enabled: true
+
 Bundler/DuplicatedGem:
   Enabled: true
 


### PR DESCRIPTION
# References

* Pull request #1644.

# Objectives

Add rules to rubocop in order to receive automatic feedback (when we start using Hound) and document code conventions so contributors can follow them.

Three rules have been added: add a newline character at the end of the file, don't add trailing whitespaces, and use `%w[]` for word arrays. We were already encouraging the first two and have recently agreed on the third one.

# Notes

Backport to consul. Even if we don't use Hound there, it still can help contributors who use rubocop.