### PR TITLE
Budget executions label

### DIFF
--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -85,7 +85,7 @@
   <div class="small-12 medium-9 large-10 column">
     <%= form_tag(custom_budget_executions_path(@budget), method: :get) do %>
       <div class="small-12 medium-3 column">
-        <%= label_tag t("budgets.executions.filters.label") %>
+        <%= label_tag :status, t("budgets.executions.filters.label") %>
         <%= select_tag :status,
                       options_from_collection_for_select(@statuses,
                       :id, lambda { |s| "#{s.name} (#{filters_select_counts(s.id)})" },


### PR DESCRIPTION
Objectives
===================
This PR adds missing `for` atribute to **budget exections status label tag**.

This was generating a validation error showing an incorrect `for`:
![for](https://user-images.githubusercontent.com/631897/45894828-d5f0ad00-bdcf-11e8-9bb3-5bbc808a281d.png)

This PR fix it!
![status](https://user-images.githubusercontent.com/631897/45894831-d7ba7080-bdcf-11e8-8827-cc2ce171f8f2.png)

Notes
===================
Backport to CONSUL.