### PR TITLE
Budget executions images

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1692,9 +1692,10 @@
 
     img {
       height: $line-height * 9;
+      min-width: 100%;
+      max-width: none;
       transition-duration: 0.3s;
       transition-property: transform;
-      width: 100%;
     }
 
     &:hover {


### PR DESCRIPTION
## Objectives

This PR improves styles to show budgets executions images.

With this changes, all images adapt better to avoid big stretch or squeeze on images. 

## Visual Changes
![budget_executions_images](https://user-images.githubusercontent.com/631897/46209777-1354bd80-c32f-11e8-946a-2fbd416d78d8.jpg)

## Does this PR need a Backport to CONSUL?

Yes. Backport this PR to CONSUL.

