### PR TITLE
Fix flaky spec: Legislation Proposals Each user has a different and consistent random proposals order

### DIFF
--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -121,12 +121,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
 
     def set_random_seed
-      seed = begin
-               Float(params[:random_seed] || session[:random_seed] || (rand(99) / 100.0))
-             rescue
-               0
-             end
-
+      seed = (params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)).to_f
       session[:random_seed] = seed
       params[:random_seed] = seed
       seed = (-1..1).cover?(seed) ? seed : 1

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -121,7 +121,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     end
 
     def set_random_seed
-      seed = (params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)).to_f
+      seed = (params[:random_seed] || session[:random_seed] || rand).to_f
       seed = (-1..1).cover?(seed) ? seed : 1
 
       session[:random_seed] = seed

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -122,9 +122,11 @@ class Legislation::ProcessesController < Legislation::BaseController
 
     def set_random_seed
       seed = (params[:random_seed] || session[:random_seed] || (rand(99) / 100.0)).to_f
+      seed = (-1..1).cover?(seed) ? seed : 1
+
       session[:random_seed] = seed
       params[:random_seed] = seed
-      seed = (-1..1).cover?(seed) ? seed : 1
+
       ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end
 end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -126,7 +126,9 @@ class Legislation::ProcessesController < Legislation::BaseController
              rescue
                0
              end
-      session[:random_seed], params[:random_seed] = seed
+
+      session[:random_seed] = seed
+      params[:random_seed] = seed
       seed = (-1..1).cover?(seed) ? seed : 1
       ::Legislation::Proposal.connection.execute "select setseed(#{seed})"
     end

--- a/spec/features/custom/legislation/proposals_spec.rb
+++ b/spec/features/custom/legislation/proposals_spec.rb
@@ -1,43 +1,9 @@
 require 'rails_helper'
-require 'sessions_helper'
 
 feature 'Legislation Proposals' do
 
-  context "Concerns" do
-    it_behaves_like 'notifiable in-app', Legislation::Proposal
-  end
-
   let(:user)     { create(:user) }
-  let(:user2)    { create(:user) }
-  let(:process)  { create(:legislation_process) }
-  let(:proposal) { create(:legislation_proposal) }
   let(:film_library_process) { create(:legislation_process, film_library: true) }
-
-  scenario 'Random order maintained with pagination', :js do
-    create_list(:legislation_proposal, (Kaminari.config.default_per_page + 2), process: process)
-
-    login_as user
-    visit legislation_process_proposals_path(process)
-    first_page_proposals_order = legislation_proposals_order
-
-    click_link 'Next'
-    expect(page).to have_content "You're on page 2"
-    second_page_proposals_order = legislation_proposals_order
-
-    click_link 'Previous'
-    expect(page).to have_content "You're on page 1"
-
-    expect(legislation_proposals_order).to eq(first_page_proposals_order)
-    expect(first_page_proposals_order & second_page_proposals_order).to eq([])
-  end
-
-  scenario "Only one menu element has 'active' CSS selector" do
-    visit legislation_process_proposal_path(proposal.process, proposal)
-
-    within('#navigation_bar') do
-      expect(page).to have_css('.is-active', count: 1)
-    end
-  end
 
   scenario "Film library proposal", :js do
     create(:legislation_proposal, process: film_library_process)
@@ -55,10 +21,6 @@ feature 'Legislation Proposals' do
     expect(page).to have_content 'Film name'
     expect(page).to have_content 'Summary of the film'
     expect(page).to have_css("img[alt='#{Legislation::Proposal.last.image.title}']")
-  end
-
-  def legislation_proposals_order
-    all("[id^='legislation_proposal_']").collect { |e| e[:id] }
   end
 
 end

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -29,7 +29,7 @@ feature 'Legislation Proposals' do
       )
     end
 
-    scenario 'Each user has a different and consistent random proposals order', :js do
+    scenario "Each user has a different and consistent random proposals order", :js do
       in_browser(:one) do
         login_as user
         visit legislation_process_proposals_path(process)
@@ -55,23 +55,23 @@ feature 'Legislation Proposals' do
       end
     end
 
-    scenario 'Random order maintained with pagination', :js do
+    scenario "Random order maintained with pagination", :js do
       login_as user
       visit legislation_process_proposals_path(process)
       first_page_proposals_order = legislation_proposals_order
 
-      click_link 'Next'
+      click_link "Next"
 
       expect(page).to have_content "You're on page 2"
       expect(first_page_proposals_order & legislation_proposals_order).to eq([])
 
-      click_link 'Previous'
+      click_link "Previous"
 
       expect(page).to have_content "You're on page 1"
       expect(legislation_proposals_order).to eq(first_page_proposals_order)
     end
 
-    scenario 'Does not crash when the seed is not a number' do
+    scenario "Does not crash when the seed is not a number" do
       login_as user
       visit legislation_process_proposals_path(process, random_seed: "Spoof")
 

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -22,6 +22,8 @@ feature 'Legislation Proposals' do
 
   feature "Random pagination" do
     before do
+      allow(Legislation::Proposal).to receive(:default_per_page).and_return(12)
+
       create_list(
         :legislation_proposal,
         (Legislation::Proposal.default_per_page + 2),

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -20,63 +20,63 @@ feature 'Legislation Proposals' do
     end
   end
 
-  scenario 'Each user has a different and consistent random proposals order', :js do
-    create_list(:legislation_proposal, 10, process: process)
+  feature "Random pagination" do
+    before do
+      create_list(
+        :legislation_proposal,
+        (Legislation::Proposal.default_per_page + 2),
+        process: process
+      )
+    end
 
-    in_browser(:one) do
+    scenario 'Each user has a different and consistent random proposals order', :js do
+      in_browser(:one) do
+        login_as user
+        visit legislation_process_proposals_path(process)
+        @first_user_proposals_order = legislation_proposals_order
+      end
+
+      in_browser(:two) do
+        login_as user2
+        visit legislation_process_proposals_path(process)
+        @second_user_proposals_order = legislation_proposals_order
+      end
+
+      expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
+
+      in_browser(:one) do
+        visit legislation_process_proposals_path(process)
+        expect(legislation_proposals_order).to eq(@first_user_proposals_order)
+      end
+
+      in_browser(:two) do
+        visit legislation_process_proposals_path(process)
+        expect(legislation_proposals_order).to eq(@second_user_proposals_order)
+      end
+    end
+
+    scenario 'Random order maintained with pagination', :js do
       login_as user
       visit legislation_process_proposals_path(process)
-      @first_user_proposals_order = legislation_proposals_order
+      first_page_proposals_order = legislation_proposals_order
+
+      click_link 'Next'
+      expect(page).to have_content "You're on page 2"
+      second_page_proposals_order = legislation_proposals_order
+
+      click_link 'Previous'
+      expect(page).to have_content "You're on page 1"
+
+      expect(legislation_proposals_order).to eq(first_page_proposals_order)
+      expect(first_page_proposals_order & second_page_proposals_order).to eq([])
     end
 
-    in_browser(:two) do
-      login_as user2
-      visit legislation_process_proposals_path(process)
-      @second_user_proposals_order = legislation_proposals_order
+    scenario 'Does not crash when the seed is not a number' do
+      login_as user
+      visit legislation_process_proposals_path(process, random_seed: "Spoof")
+
+      expect(page).to have_content "You're on page 1"
     end
-
-    expect(@first_user_proposals_order).not_to eq(@second_user_proposals_order)
-
-    in_browser(:one) do
-      visit legislation_process_proposals_path(process)
-      expect(legislation_proposals_order).to eq(@first_user_proposals_order)
-    end
-
-    in_browser(:two) do
-      visit legislation_process_proposals_path(process)
-      expect(legislation_proposals_order).to eq(@second_user_proposals_order)
-    end
-  end
-
-  scenario 'Random order maintained with pagination', :js do
-    create_list(:legislation_proposal, (Kaminari.config.default_per_page + 2), process: process)
-
-    login_as user
-    visit legislation_process_proposals_path(process)
-    first_page_proposals_order = legislation_proposals_order
-
-    click_link 'Next'
-    expect(page).to have_content "You're on page 2"
-    second_page_proposals_order = legislation_proposals_order
-
-    click_link 'Previous'
-    expect(page).to have_content "You're on page 1"
-
-    expect(legislation_proposals_order).to eq(first_page_proposals_order)
-    expect(first_page_proposals_order & second_page_proposals_order).to eq([])
-  end
-
-  scenario 'Does not crash when the seed is not a number' do
-    create_list(
-      :legislation_proposal,
-      (Legislation::Proposal.default_per_page + 2),
-      process: process
-    )
-
-    login_as user
-    visit legislation_process_proposals_path(process, random_seed: "Spoof")
-
-    expect(page).to have_content "You're on page 1"
   end
 
   context 'Selected filter' do

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -61,14 +61,14 @@ feature 'Legislation Proposals' do
       first_page_proposals_order = legislation_proposals_order
 
       click_link 'Next'
+
       expect(page).to have_content "You're on page 2"
-      second_page_proposals_order = legislation_proposals_order
+      expect(first_page_proposals_order & legislation_proposals_order).to eq([])
 
       click_link 'Previous'
-      expect(page).to have_content "You're on page 1"
 
+      expect(page).to have_content "You're on page 1"
       expect(legislation_proposals_order).to eq(first_page_proposals_order)
-      expect(first_page_proposals_order & second_page_proposals_order).to eq([])
     end
 
     scenario 'Does not crash when the seed is not a number' do

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -66,6 +66,19 @@ feature 'Legislation Proposals' do
     expect(first_page_proposals_order & second_page_proposals_order).to eq([])
   end
 
+  scenario 'Does not crash when the seed is not a number' do
+    create_list(
+      :legislation_proposal,
+      (Legislation::Proposal.default_per_page + 2),
+      process: process
+    )
+
+    login_as user
+    visit legislation_process_proposals_path(process, random_seed: "Spoof")
+
+    expect(page).to have_content "You're on page 1"
+  end
+
   context 'Selected filter' do
     scenario 'apperars even if there are not any selected poposals' do
       create(:legislation_proposal, legislation_process_id: process.id)


### PR DESCRIPTION
## References

* Issue #1659
* Pull request consul#3076
* Some of the refactoring done here is related to consul#2155

## Objectives

Fix the flaky specs that appeared in `spec/features/legislation/proposals_spec.rb:30` ("Legislation Proposals Each user as a different and consistent random proposals order").

### Explain why the test is flaky, or under which conditions/scenario it fails randomly

This test could fail for at least two reasons:

1. We were using two random numbers between 1 and 100 and then we were checking they produced different results. It looks like these numbers weren't random enough and sometimes they generated the same results.
2. <del>The way we were using `setseed`, combined with the way Rails caches SQL results and maybe more unknown factors, sometimes generated different records in what seemed to be the same SQL query with the same seed.</del> UPDATE: as stated on consul#3076, it was probably related to the way we used Capybara sessions.

### Explain why your PR fixes it

1. Using ruby's native `rand` method without any parameters, the probability of these numbers generating the same results is one between millions.

## Notes

* So far this pull request only solves the problem of different users having different results. <del>However, after these changes the spec still fails **on a different line**, due to the same user getting different results sometimes.</del> Solved by consul#3076.
* I tried the implemenation in budget investments (as recommended in consul#2155), and while it solves a few problems (like the current code being specific to PostgreSQL and the separation between the moment we set the seed and the moment we do the query), trying that approach resulted in the records not being random enough, and the spec expecting different results for different users failing because of it.
* The comments HoundCI reports about using instance `let` instead of instance variables in RSpec are false positives.

## Does this PR need a Backport to CONSUL?

Yes.