### PR TITLE
Legislation proposals imageable

### DIFF
--- a/app/assets/javascripts/custom/legislation_proposals.js.coffee
+++ b/app/assets/javascripts/custom/legislation_proposals.js.coffee
@@ -7,9 +7,7 @@ App.LegislationProposals =
         $(".js-legislation-proposal-documents").show()
         $("#js-legislation-proposal-geozone").show()
         $("#js-legislation-proposal-tags").show()
-        $("#js-legislation-proposal-label-title").show()
         $("#js-legislation-proposal-label-description").show()
-        $("#js-legislation-proposal-label-question-title").hide()
         $("#js-legislation-proposal-label-question-description").hide()
       when 'question'
         $("#js-legislation-proposal-summary").hide()
@@ -17,9 +15,7 @@ App.LegislationProposals =
         $("#js-legislation-proposal-documents").hide()
         $("#js-legislation-proposal-geozone").hide()
         $("#js-legislation-proposal-tags").hide()
-        $("#js-legislation-proposal-label-title").hide()
         $("#js-legislation-proposal-label-description").hide()
-        $("#js-legislation-proposal-label-question-title").show()
         $("#js-legislation-proposal-label-question-description").show()
   initialize: ->
     $ ->

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -310,19 +310,6 @@ header,
   background: #fff;
 }
 
-.jumbo {
-  background: $highlight;
-
-  @include breakpoint(medium) {
-    padding: rem-calc(24) 0;
-  }
-
-  h1,
-  p {
-    color: $text;
-  }
-}
-
 .jumbo-survey {
   background: #33dadf;
   border-bottom: 1px solid #33dadf;

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -10,13 +10,23 @@
 // ----------------------
 
 .jumbo {
+  background: $highlight;
   margin-bottom: $line-height;
   margin-top: rem-calc(-24);
   padding-bottom: $line-height;
   padding-top: $line-height;
 
+  @include breakpoint(medium) {
+    padding: rem-calc(24) 0;
+  }
+
   &.light {
     background: #ecf0f1;
+  }
+
+  h1,
+  p {
+    color: $text;
   }
 }
 

--- a/app/views/custom/legislation/proposals/_form.html.erb
+++ b/app/views/custom/legislation/proposals/_form.html.erb
@@ -10,12 +10,13 @@
     </div>
 
     <div class="small-12 column">
-      <% if @process.film_library? %>
-        <%= f.label :title, "Título de la película" %>
-      <% else %>
-        <%= f.label :title do %>
-          <span id="js-legislation-proposal-label-title"><%= t("proposals.form.proposal_title") %></span>
-          <span id="js-legislation-proposal-label-question-title"><%= t("legislation_proposals.form.question_title") %></span>
+      <%= f.label :title do %>
+        <% if @process.film_library? %>
+          Título de la película
+        <% elsif @proposal.is_question? %>
+          <%= t("legislation_proposals.form.question_title") %>
+        <% else %>
+          <%= t("proposals.form.proposal_title") %>
         <% end %>
       <% end %>
       <%= f.text_field :title, maxlength: Legislation::Proposal::TITLE_MAX_LENGTH, label: false %>

--- a/app/views/legislation/proposals/_form.html.erb
+++ b/app/views/legislation/proposals/_form.html.erb
@@ -31,6 +31,12 @@
                                    aria: {describedby: "video-url-help-text"} %>
     </div>
 
+    <% if feature?(:allow_images) %>
+      <div class="images small-12 column">
+        <%= render 'images/nested_image', imageable: @proposal, f: f %>
+      </div>
+    <% end %>
+
     <div class="documents small-12 column" data-max-documents="<%= Legislation::Proposal.max_documents_allowed %>">
       <%= render 'documents/nested_documents', documentable: @proposal, f: f %>
     </div>

--- a/app/views/legislation/proposals/_proposal.html.erb
+++ b/app/views/legislation/proposals/_proposal.html.erb
@@ -1,20 +1,17 @@
 <div id="<%= dom_id(proposal) %>"
      class="proposal clear <%= ("human-rights" if proposal.author.id == 505793) %>"
      data-type="proposal">
-  <div class="panel <%= ('with-image' if feature?(:allow_images) && proposal.image.present?) %>">
+  <div class="panel <%= ('with-image' if proposal.image.present?) %>">
     <div class="icon-human-rights"></div>
+    <div class="icon-successful"></div>
 
-    <% if feature?(:allow_images) && proposal.image.present? %>
-      <div class="row" data-equalizer>
-
+    <% if proposal.image.present? %>
+      <div class="row">
         <div class="small-12 medium-3 large-2 column text-center">
-          <div data-equalizer-watch>
-            <%= image_tag proposal.image_url(:thumb),
-                          alt: proposal.image.title.unicode_normalize %>
-          </div>
+          <%= image_tag proposal.image_url(:thumb),
+                        alt: proposal.image.title.unicode_normalize %>
         </div>
-
-        <div class="small-12 medium-6 large-7 column">
+        <div class="small-12 medium-6 large-7 column margin-top">
     <% else %>
       <div class="row">
         <div class="small-12 medium-9 column">

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -39,6 +39,8 @@
 
         </div>
 
+        <%= render_image(@proposal.image, :large, true) if @proposal.image.present? %>
+
         <br>
         <p>
           <%= t("proposals.show.code") %>
@@ -113,9 +115,13 @@
   </div>
 <% end %>
 
-<div class="row">
-  <div class="small-12 column">
-    <%= render "legislation/proposals/filter_subnav" %>
+<div class="additional-content">
+  <div class="filter-subnav">
+    <div class="row">
+      <div class="small-12 column">
+        <%= render "legislation/proposals/filter_subnav" %>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/spec/features/legislation/proposals_spec.rb
+++ b/spec/features/legislation/proposals_spec.rb
@@ -113,4 +113,21 @@ feature 'Legislation Proposals' do
     all("[id^='legislation_proposal_']").collect { |e| e[:id] }
   end
 
+  scenario "Create a legislation proposal with an image", :js do
+    create(:legislation_proposal, process: process)
+
+    login_as user
+
+    visit new_legislation_process_proposal_path(process)
+
+    fill_in 'Proposal title', with: 'Legislation proposal with image'
+    fill_in 'Proposal summary', with: 'Including an image on a legislation proposal'
+    imageable_attach_new_file(create(:image), Rails.root.join('spec/fixtures/files/clippy.jpg'))
+    check 'legislation_proposal_terms_of_service'
+    click_button 'Create proposal'
+
+    expect(page).to have_content 'Legislation proposal with image'
+    expect(page).to have_content 'Including an image on a legislation proposal'
+    expect(page).to have_css("img[alt='#{Legislation::Proposal.last.image.title}']")
+  end
 end


### PR DESCRIPTION
## References

Related PR https://github.com/consul/consul/pull/2922

## Objectives

This feature already exists on this fork, but now it's synced with changes made on CONSUL https://github.com/consul/consul/pull/2922. 

Moreover: 
- Refactors custom legislation proposals form (avoiding use js and failing spec).
- Removes duplicated custom CSS.

