### PR TITLE
Fixes legislation processes key dates active class

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -101,6 +101,11 @@
 
     .is-active {
       border-bottom: 2px solid $brand;
+
+      a,
+      h4 {
+        color: $brand;
+      }
     }
   }
 }

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -15,7 +15,7 @@
           <% end %>
 
           <% if process.proposals_phase.enabled? %>
-            <li <%= 'class=is-active' if phase.to_sym == :proposals_phase %>>
+            <li <%= 'class=is-active' if phase.to_sym == :proposals %>>
               <%= link_to proposals_legislation_process_path(process) do %>
                 <h4><%= t('legislation.processes.shared.proposals_dates') %></h4>
                 <p><%= format_date(process.proposals_phase_start_date) %> - <%= format_date(process.proposals_phase_end_date) %></p>

--- a/app/views/legislation/processes/debate.html.erb
+++ b/app/views/legislation/processes/debate.html.erb
@@ -8,7 +8,7 @@
 
 <%= render 'documents/additional_documents', documents: @process.documents %>
 
-<%= render 'key_dates', process: @process, phase: :debate %>
+<%= render 'key_dates', process: @process, phase: :debate_phase %>
 
 <div class="row">
   <div class="debate-chooser">


### PR DESCRIPTION
## Objectives

Fixes legislation processes key dates `is-active` class.

## Visual Changes

Before in debate or proposals phase didn't appear the active class:
![none](https://user-images.githubusercontent.com/631897/46736237-d4acf480-cc98-11e8-8527-b5d219f21c15.png)

Now on debate phase:
![1](https://user-images.githubusercontent.com/631897/46736267-e7bfc480-cc98-11e8-8356-088e1674cea5.png)

Now on proposals phase:
![2](https://user-images.githubusercontent.com/631897/46736277-f017ff80-cc98-11e8-810f-61e52b90c7e6.png)

## Does this PR need a Backport to CONSUL?

Yes, backport this to CONSUL repo.
