### PR TITLE
Legislation proposals categories

### DIFF
--- a/app/views/legislation/proposals/_categories.html.erb
+++ b/app/views/legislation/proposals/_categories.html.erb
@@ -1,5 +1,5 @@
 <div class="sidebar-divider"></div>
-<h2 class="sidebar-title"><%= t("legislation.proposals.categories.genre") %></h2>
+<h2 class="sidebar-title"><%= t("legislation.proposals.categories") %></h2>
 <br>
 <ul id="categories" class="no-bullet categories">
   <% @process.tag_list_on(:customs).each do |tag| %>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -123,5 +123,4 @@ en:
       form:
         tags_label: "Categories"
       not_verified: "For vote proposals %{verify_account}."
-      categories:
-          genre: Categories
+      categories: Categories

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -123,5 +123,4 @@ es:
       form:
         tags_label: "Categorías"
       not_verified: "Para votar propuestas %{verify_account}."
-      categories:
-          genre: Categorías
+      categories: Categorías

--- a/spec/features/tags/custom/legislation/proposals_spec.rb
+++ b/spec/features/tags/custom/legislation/proposals_spec.rb
@@ -166,7 +166,7 @@ feature 'Tags' do
 
   context 'Tag cloud' do
 
-    scenario 'Display genre tags' do
+    scenario 'Display category tags' do
       tag_list = ["Action", "Adventure"]
 
       film_library_process.tag_list_on(:customs).add(tag_list)


### PR DESCRIPTION
## References

Related PR: https://github.com/AyuntamientoMadrid/consul/pull/1638/

## Objectives

After Add tag filtering for legislation proposals this PR removes unnecesary `genre:` i18n key.

## Does this PR need a Backport to CONSUL?

Yes, backport the first commit. Also add the changes made on [`legislation/proposals/_categories.html.erb`](https://github.com/AyuntamientoMadrid/consul/commit/65341101a3bc3c4a81237223d84a02e74167bfa4#diff-2cd858e7850739b05fcfcfa44b925527R1)
