### PR TITLE
[Upstream] Fix flaky spec for translations

### DIFF
--- a/spec/helpers/locales_helper_spec.rb
+++ b/spec/helpers/locales_helper_spec.rb
@@ -13,6 +13,7 @@ describe LocalesHelper do
     after do
       I18n.backend.reload!
       I18n.enforce_available_locales = default_enforce
+      I18n.backend.send(:init_translations)
     end
 
     it "returns the language name in i18n.language.name translation" do


### PR DESCRIPTION
# References
**PR**: https://github.com/consul/consul/pull/2962

# Objectives
Fix the flaky spec that appeared in `spec/features/localization_spec.rb:20` ("Available locales appear in the locale switcher").