### PR TITLE
Bring back CKEditor images button

### DIFF
--- a/app/views/admin/site_customization/pages/_form.html.erb
+++ b/app/views/admin/site_customization/pages/_form.html.erb
@@ -41,7 +41,8 @@
     <%= f.translatable_text_field :title %>
     <%= f.translatable_text_field :subtitle %>
     <div class="ckeditor">
-      <%= f.translatable_cktext_area :content %>
+      <%= f.translatable_cktext_area :content,
+                                     ckeditor: { language: I18n.locale, toolbar: "admin" } %>
     </div>
     <div class="small-12 medium-6 large-3 margin-top">
       <%= f.submit class: "button success expanded" %>

--- a/spec/features/admin/site_customization/pages_spec.rb
+++ b/spec/features/admin/site_customization/pages_spec.rb
@@ -41,8 +41,11 @@ feature "Admin custom pages" do
   end
 
   context "Update" do
-    scenario "Valid custom page" do
+    let!(:custom_page) do
       create(:site_customization_page, title: "An example custom page", slug: "custom-example-page")
+    end
+
+    scenario "Valid custom page" do
       visit admin_root_path
 
       within("#side_menu") do
@@ -61,6 +64,14 @@ feature "Admin custom pages" do
       expect(page).to have_content "Page updated successfully"
       expect(page).to have_content "Another example custom page"
       expect(page).to have_content "another-custom-example-page"
+    end
+
+    scenario "Allows images in CKEditor", :js do
+      visit edit_admin_site_customization_page_path(custom_page)
+
+      within(".ckeditor") do
+        expect(page).to have_css(".cke_toolbar .cke_button__image_icon")
+      end
     end
   end
 


### PR DESCRIPTION
## References

* Pull request consul#2876
* Issue consul#2495
* Pull requext consul#2913

## Objectives

* Bring back the button to attach images for custom pages
* Add a test so we don't accidentally remove it again

## Notes

* As stated in the commit message, testing the whole functionality made the test hang on my machine.