### PR TITLE
Add voting links via get to newsletters 

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -130,7 +130,7 @@ class Mailer < ApplicationMailer
     end
   end
 
-  def newsletter(newsletter, recipient_email, token)
+  def newsletter(newsletter, recipient_email, token=nil)
     @newsletter = newsletter
     @email_to = recipient_email
     @token = token

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -130,9 +130,10 @@ class Mailer < ApplicationMailer
     end
   end
 
-  def newsletter(newsletter, recipient_email)
+  def newsletter(newsletter, recipient_email, token)
     @newsletter = newsletter
     @email_to = recipient_email
+    @token = token
 
     mail(to: @email_to, from: @newsletter.from, subject: @newsletter.subject)
   end

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -12,6 +12,7 @@
         <%= link_to "Apoyar esta propuesta", 
                     vote_proposal_url(proposal, newsletter_token: @token) %>
       </p>
+      <br/>
     <% end %>
   </p>
 </td>

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -1,5 +1,17 @@
 <td style="padding-bottom: 20px; padding-left: 10px;">
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
     <%= safe_html_with_links @newsletter.body.html_safe %>
+
+    <% @newsletter.proposals.each do |proposal| %>
+      <p>
+        <%= link_to proposal.title, 
+                  proposal_url(proposal, newsletter_token: @token) %>
+      </p>
+
+      <p>
+        <%= link_to "Apoyar esta propuesta", 
+                    vote_proposal_url(proposal, newsletter_token: @token) %>
+      </p>
+    <% end %>
   </p>
 </td>

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -1,18 +1,17 @@
 <td style="padding-bottom: 20px; padding-left: 10px;">
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
     <%= safe_html_with_links @newsletter.body.html_safe %>
-
-    <% @newsletter.proposals.each do |proposal| %>
-      <p>
-        <%= link_to proposal.title, 
-                  proposal_url(proposal, newsletter_token: @token) %>
-      </p>
-
-      <p>
-        <%= link_to "Apoyar esta propuesta", 
-                    vote_proposal_url(proposal, newsletter_token: @token) %>
-      </p>
-      <br/>
-    <% end %>
   </p>
+
+  <% @newsletter.proposals.each do |proposal| %>
+    <p style="font-family: 'Open Sans',arial,sans-serif;font-size: 14px;line-height: 24px;
+              margin-bottom: 48px;">
+      <%= link_to proposal.title,
+                proposal_url(proposal, newsletter_token: @token),
+                style: "text-decoration: none" %>
+      <br>
+      <%= link_to "Apoyar esta propuesta",
+                  vote_proposal_url(proposal, newsletter_token: @token) %>
+    </p>
+  <% end %>
 </td>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -394,6 +394,7 @@ en:
       start_new: Create new proposal
     notice:
       retired: Proposal retired
+      voted: You have successfully voted this proposal
     proposal:
       created: "You've created a proposal!"
       share:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -391,6 +391,7 @@ es:
       start_new: Crear una propuesta
     notice:
       retired: Propuesta retirada
+      voted: Has apoyado esta propuesta
     proposal:
       created: "¡Has creado una propuesta!"
       share:

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -1,6 +1,7 @@
 resources :proposals do
   member do
     post :vote
+    get :vote
     post :vote_featured
     put :flag
     put :unflag

--- a/db/migrate/20181022173839_add_newsletter_token_to_users.rb
+++ b/db/migrate/20181022173839_add_newsletter_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddNewsletterTokenToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :newsletter_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180924071722) do
+ActiveRecord::Schema.define(version: 20181022173839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1528,6 +1528,7 @@ ActiveRecord::Schema.define(version: 20180924071722) do
     t.boolean  "public_interests",                                            default: false
     t.boolean  "recommended_debates",                                         default: true
     t.boolean  "recommended_proposals",                                       default: true
+    t.string   "newsletter_token"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -54,7 +54,8 @@ class UserSegments
   end
 
   def self.beta_testers
-    testers = %w(voodoorai2000@gmail.com
+    testers = %w(aranacm@madrid.es
+                 voodoorai2000@gmail.com
                  javim@elretirao.net)
 
     User.where(email: testers).order('created_at ASC')

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -56,6 +56,7 @@ class UserSegments
   def self.beta_testers
     testers = %w(aranacm@madrid.es
                  voodoorai2000@gmail.com
+                 alberto@decabeza.es
                  javim@elretirao.net)
 
     User.where(email: testers).order('created_at ASC')

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -54,9 +54,8 @@ class UserSegments
   end
 
   def self.beta_testers
-    testers = %w(aranacm@madrid.es
-                 alberto@decabeza.es
-                 voodoorai2000@gmail.com)
+    testers = %w(voodoorai2000@gmail.com
+                 javim@elretirao.net)
 
     User.where(email: testers).order('created_at ASC')
   end

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+feature 'Vote via email' do
+
+  context "Email" do
+    scenario "Displays a show link to the top 5 proposals with a token"
+    scenario "Displays a vote link to the top 5 proposals with a token"
+
+    scenario "Token can be used for multiples proposals"
+    scenario "The user can still one vote once per proposal"
+  end
+
+  context "voting Proposals via a GET link" do
+
+    background do
+      @manuela = create(:user, :verified)
+      @proposal = create(:proposal)
+    end
+
+    scenario 'Verified user is logged in' do
+      login_as(@manuela)
+      visit proposal_path(@proposal)
+
+      within('.supports') do
+        expect(page).to have_content "No supports"
+        expect(page).to have_selector ".in-favor a"
+      end
+
+      visit vote_proposal_path(@proposal)
+
+      expect(page).to have_content "You have successfully voted this proposal"
+
+      within('.supports') do
+        expect(page).to have_content "1 support"
+        expect(page).to_not have_selector ".in-favor a"
+      end
+    end
+
+    scenario 'Verified user is not logged in' do
+      @manuela.update(newsletter_token: "123456")
+
+      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+
+      expect(page).to have_content "You have successfully voted this proposal"
+
+      within('.supports') do
+        expect(page).to have_content "1 support"
+        expect(page).to_not have_selector ".in-favor a"
+      end
+    end
+
+    scenario 'Verified user with invalid token' do
+      @manuela.update(newsletter_token: "123456")
+
+      visit vote_proposal_path(@proposal, newsletter_token: "999999")
+
+      expect(page).to have_content "You must sign in or register to continue."
+
+      within('.supports') do
+        expect(page).to have_content "0 supports"
+      end
+    end
+
+    scenario 'Unverified user is logged in'
+    scenario 'Unverified user is not logged in'
+    scenario 'Unverified user with invalid token'
+  end
+
+end

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -3,14 +3,34 @@ require 'rails_helper'
 feature 'Vote via email' do
 
   context "Email" do
-    scenario "Displays a show link to the top 5 proposals with a token"
-    scenario "Displays a vote link to the top 5 proposals with a token"
 
-    scenario "Token can be used for multiples proposals"
-    scenario "The user can still one vote once per proposal"
+    scenario "Displays a show link and vote link to proposals" do
+      user = create(:user, newsletter: true)
+      proposal = create(:proposal)
+
+      admin = create(:administrator)
+      login_as(admin.user)
+
+      visit new_admin_newsletter_path
+
+      fill_in_newsletter_form(segment_recipient: 'All users')
+      click_button "Create Newsletter"
+
+      expect(page).to have_content "Newsletter created successfully"
+      click_link "Send"
+
+      user.reload
+      show_link = proposal_path(proposal, newsletter_token: user.newsletter_token)
+      vote_link = vote_proposal_path(proposal, newsletter_token: user.newsletter_token)
+
+      email = unread_emails_for(user.email).first
+      expect(email).to have_body_text(show_link)
+      expect(email).to have_body_text(vote_link)
+    end
+
   end
 
-  context "voting Proposals via a GET link" do
+  context "Voting proposals via a GET link" do
 
     background do
       @manuela = create(:user, :verified)
@@ -54,16 +74,17 @@ feature 'Vote via email' do
 
       visit vote_proposal_path(@proposal, newsletter_token: "999999")
 
-      expect(page).to have_content "You must sign in or register to continue."
-
-      within('.supports') do
-        expect(page).to have_content "0 supports"
-      end
+      expect(page).to have_content("You must sign in or register to continue.")
+      expect(page.current_path).to eq("/users/sign_in")
     end
 
-    scenario 'Unverified user is logged in'
-    scenario 'Unverified user is not logged in'
-    scenario 'Unverified user with invalid token'
-  end
+    scenario 'Unverified user' do
+      user = create(:user, newsletter_token: "123456")
 
+      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+
+      expect(page).to have_content "You do not have permission to carry out the action 'vote' on proposal."
+    end
+
+  end
 end

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -154,4 +154,22 @@ describe Newsletter do
     end
 
   end
+
+  context "voting with token" do
+
+    describe "#generate_user_token" do
+      it "returns a token if the email is valid"
+      it "returns nil if the email is invalid"
+    end
+
+    describe "#deliver" do
+      it "skips invalid tokens"
+    end
+
+    describe "#proposals" do
+      it "returns the 5 most voted proposals" do
+        #take into account only active proposals
+      end
+    end
+  end
 end

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -155,21 +155,4 @@ describe Newsletter do
 
   end
 
-  context "voting with token" do
-
-    describe "#generate_user_token" do
-      it "returns a token if the email is valid"
-      it "returns nil if the email is invalid"
-    end
-
-    describe "#deliver" do
-      it "skips invalid tokens"
-    end
-
-    describe "#proposals" do
-      it "returns the 5 most voted proposals" do
-        #take into account only active proposals
-      end
-    end
-  end
 end


### PR DESCRIPTION
## References
**PR**: https://github.com/AyuntamientoMadrid/consul/pull/261

## Objectives

- Add the top 5 proposals to the newsletter
- Add a show link to each of these proposals
- Add a vote link to each of these proposals
- Make sure to login users if they are not logged in when following these links

## Notes
- This is a quick fix to send a marketing newsletter
- Do not backport to CONSUL 😌(this behaviour would be applied to all newsletters)
- Complete specs before deploying to production
- Revert PR once marketing campaign is over
