### PR TITLE
Adds segment for users that did not receive the last Newsletter

### DIFF
--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -624,6 +624,7 @@ en:
       winner_investment_authors: Authors of winner investments in the current budget
       not_supported_on_current_budget: Users that haven't supported investments on current budget
       invalid_recipients_segment: "Recipients user segment is invalid"
+      pending_last_newsletter: "Pending from last newsletter"
       arganzuela: Arganzuela
       barajas: Barajas
       carabanchel: Carabanchel

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -624,6 +624,7 @@ es:
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
       not_supported_on_current_budget: Usuarios que no han apoyado proyectos de los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"
+      pending_last_newsletter: "Pendientes de la última newsletter"
       arganzuela: Arganzuela
       barajas: Barajas
       carabanchel: Carabanchel

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -9,11 +9,20 @@ class UserSegments
        selected_investment_authors
        winner_investment_authors
        not_supported_on_current_budget
-       beta_testers) + geozones
+       beta_testers
+       pending_last_newsletter) + geozones
   end
 
   def self.all_users
     User.active
+  end
+
+  def self.pending_last_newsletter
+    all_users.where.not(id: sent_user_ids(Newsletter.last))
+  end
+
+  def self.sent_user_ids(newsletter)
+    Activity.where(actionable: newsletter).pluck(:user_id).uniq
   end
 
   def self.administrators

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -18,7 +18,8 @@ class UserSegments
   end
 
   def self.pending_last_newsletter
-    all_users.where.not(id: sent_user_ids(Newsletter.last))
+    last_newsletter = Newsletter.find(26)
+    all_users.where.not(id: sent_user_ids(last_newsletter))
   end
 
   def self.sent_user_ids(newsletter)

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -211,6 +211,47 @@ describe UserSegments do
     end
   end
 
+  context "Pending users for last newsletter" do
+
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:user3) { create(:user) }
+
+    describe "#pending_last_newsletter" do
+      it "returns users that did not receive the last newsletter" do
+        newsletter = create(:newsletter)
+        activity = create(:activity, user: user1, actionable: newsletter)
+
+        expect(described_class.pending_last_newsletter.count).to eq(2)
+        expect(described_class.pending_last_newsletter).to include(user2)
+        expect(described_class.pending_last_newsletter).to include(user3)
+      end
+    end
+
+    describe "#sent_user_ids" do
+      it "returns user_ids that have already received a newsletter" do
+        newsletter = create(:newsletter)
+        create(:activity, user: user1, actionable: newsletter)
+        create(:activity, user: user2, actionable: newsletter)
+
+        expect(described_class.sent_user_ids(newsletter).count).to eq(2)
+        expect(described_class.sent_user_ids(newsletter)).to include(user1.id)
+        expect(described_class.sent_user_ids(newsletter)).to include(user2.id)
+        expect(described_class.sent_user_ids(newsletter)).to_not include(user3.id)
+      end
+
+      it "does not return duplicate user_ids" do
+        newsletter = create(:newsletter)
+        create(:activity, user: user1, actionable: newsletter)
+        create(:activity, user: user1, actionable: newsletter)
+
+        expect(described_class.sent_user_ids(newsletter).count).to eq(1)
+        expect(described_class.sent_user_ids(newsletter)).to eq([user1.id])
+      end
+    end
+
+  end
+
   context "Geozones" do
 
     let!(:new_york) { create(:geozone, name: "New York") }

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -219,7 +219,7 @@ describe UserSegments do
 
     describe "#pending_last_newsletter" do
       it "returns users that did not receive the last newsletter" do
-        newsletter = create(:newsletter)
+        newsletter = create(:newsletter, id: 26)
         activity = create(:activity, user: user1, actionable: newsletter)
 
         expect(described_class.pending_last_newsletter.count).to eq(2)
@@ -230,7 +230,7 @@ describe UserSegments do
 
     describe "#sent_user_ids" do
       it "returns user_ids that have already received a newsletter" do
-        newsletter = create(:newsletter)
+        newsletter = create(:newsletter, id: 26)
         create(:activity, user: user1, actionable: newsletter)
         create(:activity, user: user2, actionable: newsletter)
 
@@ -241,7 +241,7 @@ describe UserSegments do
       end
 
       it "does not return duplicate user_ids" do
-        newsletter = create(:newsletter)
+        newsletter = create(:newsletter, id: 26)
         create(:activity, user: user1, actionable: newsletter)
         create(:activity, user: user1, actionable: newsletter)
 


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1680

## Objectives

Add a user segment with the users that did not receive the last newsletter

## Does this PR need a Backport to CONSUL?

No backport needed, this is a hotfix