### PR TITLE
Increase batch size for newsletters

### DIFF
--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -38,7 +38,7 @@ class Newsletter < ActiveRecord::Base
   end
 
   def batch_size
-    10000
+    50000
   end
 
   def batch_interval


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1680

## Context
Newsletters emails are send in batches of 10.000 every 20.minutes

## Objectives
Speed up the delivery of newsletters, by increasing the number of emails send from 10.000 to 50.000

## Does this PR need a Backport to CONSUL?

No, it's a temporary increase in speed for marketing reasons
