### PR TITLE
Increase delayed jobs max run time

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ end
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 10
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 500.minutes
+Delayed::Worker.max_run_time = 1500.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.raise_signal_exceptions = :term


### PR DESCRIPTION
## Objectives

Increase the max time an asincronous process can take from 8 hours to 25 hours

## Does this PR need a Backport to CONSUL?

Yes, just in case other big cities run into the issue of sending huge newsletter that take many hours
