### PR TITLE
Remove token after being used once

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -201,6 +201,8 @@ class ProposalsController < ApplicationController
     def login_user!
       if newsletter_vote? && newsletter_user.present?
         sign_in(:user, newsletter_user)
+        newsletter_user.update(newsletter_token_used_at: Time.current)
+        newsletter_user.update(newsletter_token: nil)
       end
     end
 

--- a/db/migrate/20181024160733_add_newsletter_token_used_at_to_users.rb
+++ b/db/migrate/20181024160733_add_newsletter_token_used_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddNewsletterTokenUsedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :newsletter_token_used_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181022173839) do
+ActiveRecord::Schema.define(version: 20181024160733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1529,6 +1529,7 @@ ActiveRecord::Schema.define(version: 20181022173839) do
     t.boolean  "recommended_debates",                                         default: true
     t.boolean  "recommended_proposals",                                       default: true
     t.string   "newsletter_token"
+    t.datetime "newsletter_token_used_at"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1680

## Context

Some users are sharing in social networks the links that they have received in the newsletter

## Objectives

Remove the token after being used, so that other users cannot use it

## Does this PR need a Backport to CONSUL?

No, this is only for the temporary feature in Madrid
