### PR TITLE
Add counter of emails sent to newsletter preview

### DIFF
--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -26,6 +26,10 @@
       <%= segment_name(@newsletter.segment_recipient) %>
       <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
     </div>
+    <div class="small-12 column">
+      <strong>Enviados</strong><br>
+      <%= Activity.where(actionable: @newsletter).count %>
+    </div>
   </div>
 
   <div class="small-12 column">

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -146,6 +146,21 @@ feature "Admin newsletter emails" do
     end
   end
 
+  context "Counter of emails sent", :js do
+
+    scenario "Display counter" do
+      newsletter = create(:newsletter, segment_recipient: "administrators")
+      visit admin_newsletter_path(newsletter)
+
+      accept_confirm { click_link "Send" }
+
+      expect(page).to have_content "Newsletter sent successfully"
+
+      expect(page).to have_content "1 affected users"
+      expect(page).to have_content "Enviados 1"
+    end
+  end
+
   context "Select list of users to send newsletter" do
 
     scenario "Custom user segments" do


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1680

## Objectives

Add a counter to know how many newsletter emails have been sent already

## Does this PR need a Backport to CONSUL?

Could be useful, but needs some cleaning up
