### PR TITLE
Update behaviour of newsletter links

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -196,11 +196,8 @@ class ProposalsController < ApplicationController
     end
 
     def login_user!
-      if newsletter_vote? && newsletter_user.present?
       if newsletter_vote? && newsletter_user.present? && newsletter_user.level_two_or_three_verified?
         sign_in(:user, newsletter_user)
-        newsletter_user.update(newsletter_token_used_at: Time.current)
-        newsletter_user.update(newsletter_token: nil)
       end
     end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -197,6 +197,7 @@ class ProposalsController < ApplicationController
 
     def login_user!
       if newsletter_vote? && newsletter_user.present?
+      if newsletter_vote? && newsletter_user.present? && newsletter_user.level_two_or_three_verified?
         sign_in(:user, newsletter_user)
         newsletter_user.update(newsletter_token_used_at: Time.current)
         newsletter_user.update(newsletter_token: nil)

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -6,7 +6,7 @@ class ProposalsController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
   before_action :load_geozones, only: [:edit, :map, :summary]
-  before_action :login_user!, only: [:show, :vote]
+  before_action :login_user!, only: :vote
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
   before_action :destroy_map_location_association, only: :update
   before_action :set_view, only: :index
@@ -24,17 +24,13 @@ class ProposalsController < ApplicationController
   respond_to :html, :js
 
   def show
-    if params[:newsletter_token].present?
-      redirect_to @proposal
-    else
-      super
-      @notifications = @proposal.notifications.not_moderated
-      load_rank
-      @document = Document.new(documentable: @proposal)
-      @related_contents = Kaminari.paginate_array(@proposal.relationed_contents).page(params[:page]).per(5)
+    super
+    @notifications = @proposal.notifications.not_moderated
+    load_rank
+    @document = Document.new(documentable: @proposal)
+    @related_contents = Kaminari.paginate_array(@proposal.relationed_contents).page(params[:page]).per(5)
 
-      redirect_to proposal_path(@proposal), status: :moved_permanently if request.path != proposal_path(@proposal)
-    end
+    redirect_to proposal_path(@proposal), status: :moved_permanently if request.path != proposal_path(@proposal)
   end
 
   def create

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -56,7 +56,8 @@ class ProposalsController < ApplicationController
   def vote
     @proposal.register_vote(current_user, 'yes')
 
-    if request.get?
+    if newsletter_vote?
+      sign_out(:user)
       redirect_to @proposal, notice: t('proposals.notice.voted')
     else
       set_proposal_votes(@proposal)

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -48,7 +48,6 @@ feature 'Vote via email' do
         expect(page).to have_selector ".in-favor a"
       end
 
-      visit vote_proposal_path(@proposal)
       visit vote_proposal_path(@proposal, newsletter_token: "123456")
 
       expect(page).to have_content "You have successfully voted this proposal"
@@ -96,67 +95,24 @@ feature 'Vote via email' do
 
   end
 
-  context "Deleting token" do
+  context "Show link with token" do
 
-    let!(:user) { create(:user, :verified, newsletter_token: "123456") }
-    let(:proposal) { create(:proposal) }
-
-    scenario "Visiting show path" do
-      visit proposal_path(proposal, newsletter_token: "123456")
-
-      expect(page).to have_content(proposal.title)
-
-      user.reload
-      expect(user.newsletter_token_used_at).to be
-      expect(user.newsletter_token).to eq(nil)
-    end
-
-    scenario "Visiting vote path" do
-      visit vote_proposal_path(proposal, newsletter_token: "123456")
     scenario "User is logged in" do
       proposal = create(:proposal)
       user = create(:user, :verified, newsletter_token: "123456")
 
-      expect(page).to have_content "You have successfully voted this proposal"
       login_as(user)
 
-      user.reload
-      expect(user.newsletter_token_used_at).to be
-      expect(user.newsletter_token).to eq(nil)
-    end
-
-    scenario "Voting another proposal after going to show" do
       visit proposal_path(proposal, newsletter_token: "123456")
 
-      expect(page).to have_content(proposal.title)
-
-      user.reload
-      expect(user.newsletter_token).to eq(nil)
-
-      visit vote_proposal_path(proposal, newsletter_token: "123456")
-
-      expect(page).to have_content "You have successfully voted this proposal"
-
-      within('.supports') do
-        expect(page).to have_content "1 support"
-        expect(page).to_not have_selector ".in-favor a"
-      end
       expect_to_be_signed_in
     end
 
-    scenario "Trying to use token again" do
-      visit proposal_path(proposal, newsletter_token: "123456")
-
-      expect(page).to have_content(proposal.title)
-
-      click_link "Sign out"
     scenario "User is not logged in" do
       proposal = create(:proposal)
       create(:user, :verified, newsletter_token: "123456")
 
       visit proposal_path(proposal, newsletter_token: "123456")
-      expect(page).to_not have_link "Sign out"
-      expect(page).to have_link "Sign in"
 
       expect_to_not_be_signed_in
     end

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -38,6 +38,8 @@ feature 'Vote via email' do
     end
 
     scenario 'Verified user is logged in' do
+      @manuela.update(newsletter_token: "123456")
+
       login_as(@manuela)
       visit proposal_path(@proposal)
 
@@ -47,6 +49,7 @@ feature 'Vote via email' do
       end
 
       visit vote_proposal_path(@proposal)
+      visit vote_proposal_path(@proposal, newsletter_token: "123456")
 
       expect(page).to have_content "You have successfully voted this proposal"
 
@@ -54,6 +57,8 @@ feature 'Vote via email' do
         expect(page).to have_content "1 support"
         expect(page).to_not have_selector ".in-favor a"
       end
+
+      expect_to_not_be_signed_in
     end
 
     scenario 'Verified user is not logged in' do
@@ -67,6 +72,8 @@ feature 'Vote via email' do
         expect(page).to have_content "1 support"
         expect(page).to_not have_selector ".in-favor a"
       end
+
+      expect_to_not_be_signed_in
     end
 
     scenario 'Verified user with invalid token' do

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -105,8 +105,12 @@ feature 'Vote via email' do
 
     scenario "Visiting vote path" do
       visit vote_proposal_path(proposal, newsletter_token: "123456")
+    scenario "User is logged in" do
+      proposal = create(:proposal)
+      user = create(:user, :verified, newsletter_token: "123456")
 
       expect(page).to have_content "You have successfully voted this proposal"
+      login_as(user)
 
       user.reload
       expect(user.newsletter_token_used_at).to be
@@ -129,6 +133,7 @@ feature 'Vote via email' do
         expect(page).to have_content "1 support"
         expect(page).to_not have_selector ".in-favor a"
       end
+      expect_to_be_signed_in
     end
 
     scenario "Trying to use token again" do
@@ -137,10 +142,15 @@ feature 'Vote via email' do
       expect(page).to have_content(proposal.title)
 
       click_link "Sign out"
+    scenario "User is not logged in" do
+      proposal = create(:proposal)
+      create(:user, :verified, newsletter_token: "123456")
 
       visit proposal_path(proposal, newsletter_token: "123456")
       expect(page).to_not have_link "Sign out"
       expect(page).to have_link "Sign in"
+
+      expect_to_not_be_signed_in
     end
 
   end

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -90,7 +90,8 @@ feature 'Vote via email' do
 
       visit vote_proposal_path(@proposal, newsletter_token: "123456")
 
-      expect(page).to have_content "You do not have permission to carry out the action 'vote' on proposal."
+      expect(page).to have_content "You must sign in or register to continue"
+      expect(page.current_path).to eq("/users/sign_in")
     end
 
   end

--- a/spec/support/common_actions/users.rb
+++ b/spec/support/common_actions/users.rb
@@ -82,4 +82,5 @@ module Users
   def expect_to_not_be_signed_in
     expect(find('.top-bar-right')).not_to have_content 'My account'
   end
+
 end


### PR DESCRIPTION
## Objectives

- The show link with a token should not login users
- The vote link with a token should login users, vote, and logout
- Unverified users should not login with a token, as they cannot complete the vote task and then get logged out
- Remove the _delete token_ functionality as it conflicts with this new behaviour

## Does this PR need a Backport to CONSUL?

No need
