### PR TITLE
Remove code to generate a special newsletter

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -130,10 +130,9 @@ class Mailer < ApplicationMailer
     end
   end
 
-  def newsletter(newsletter, recipient_email, token=nil)
+  def newsletter(newsletter, recipient_email)
     @newsletter = newsletter
     @email_to = recipient_email
-    @token = token
 
     mail(to: @email_to, from: @newsletter.from, subject: @newsletter.subject)
   end

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -1,4 +1,5 @@
 class Newsletter < ActiveRecord::Base
+  has_many :activities, as: :actionable
 
   validates :subject, presence: true
   validates :segment_recipient, presence: true

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -28,8 +28,7 @@ class Newsletter < ActiveRecord::Base
     list_of_recipient_emails_in_batches.each do |recipient_emails|
       recipient_emails.each do |recipient_email|
         if valid_email?(recipient_email)
-          token = generate_user_token(recipient_email)
-          Mailer.delay(run_at: run_at).newsletter(self, recipient_email, token)
+          Mailer.delay(run_at: run_at).newsletter(self, recipient_email)
           log_delivery(recipient_email)
         end
       end
@@ -38,7 +37,7 @@ class Newsletter < ActiveRecord::Base
   end
 
   def batch_size
-    50000
+    10000
   end
 
   def batch_interval
@@ -51,22 +50,6 @@ class Newsletter < ActiveRecord::Base
 
   def list_of_recipient_emails_in_batches
     list_of_recipient_emails.in_groups_of(batch_size, false)
-  end
-
-  def generate_user_token(email)
-    user = User.where(email: email).first
-    if user.present?
-      user.update(newsletter_token: generate_token)
-      user.newsletter_token
-    end
-  end
-
-  def generate_token
-    Devise.friendly_token
-  end
-
-  def proposals
-    Proposal.unsuccessful.not_archived.not_retired.sort_by_confidence_score.limit(5)
   end
 
   private

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -26,6 +26,12 @@
       <%= segment_name(@newsletter.segment_recipient) %>
       <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
     </div>
+
+    <div class="small-12 column">
+      <strong>
+        <%= t("admin.newsletters.show.sent_emails", count: @newsletter.activities.count) %>
+      </strong>
+    </div>
   </div>
 
   <div class="small-12 column">

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -26,10 +26,6 @@
       <%= segment_name(@newsletter.segment_recipient) %>
       <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
     </div>
-    <div class="small-12 column">
-      <strong>Enviados</strong><br>
-      <%= Activity.where(actionable: @newsletter).count %>
-    </div>
   </div>
 
   <div class="small-12 column">

--- a/app/views/mailer/newsletter.html.erb
+++ b/app/views/mailer/newsletter.html.erb
@@ -2,16 +2,4 @@
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;line-height: 24px;">
     <%= safe_html_with_links @newsletter.body.html_safe %>
   </p>
-
-  <% @newsletter.proposals.each do |proposal| %>
-    <p style="font-family: 'Open Sans',arial,sans-serif;font-size: 14px;line-height: 24px;
-              margin-bottom: 48px;">
-      <%= link_to proposal.title,
-                proposal_url(proposal, newsletter_token: @token),
-                style: "text-decoration: none" %>
-      <br>
-      <%= link_to "Apoyar esta propuesta",
-                  vote_proposal_url(proposal, newsletter_token: @token) %>
-    </p>
-  <% end %>
 </td>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ set :keep_releases, 5
 
 set :local_user, ENV['USER']
 
-set :delayed_job_workers, 10
+set :delayed_job_workers, 2
 set :delayed_job_roles, :background
 
 set(:config_files, %w(

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -6,7 +6,7 @@ end
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 10
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 500.minutes
+Delayed::Worker.max_run_time = 1500.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.raise_signal_exceptions = :term

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -4,9 +4,9 @@ else
   Delayed::Worker.delay_jobs = true
 end
 Delayed::Worker.destroy_failed_jobs = false
-Delayed::Worker.sleep_delay = 1
-Delayed::Worker.max_attempts = 1
-Delayed::Worker.max_run_time = 1500.minutes
+Delayed::Worker.sleep_delay = 10
+Delayed::Worker.max_attempts = 3
+Delayed::Worker.max_run_time = 500.minutes
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.raise_signal_exceptions = :term

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -671,6 +671,9 @@ en:
         title: Newsletter preview
         send: Send
         affected_users: (%{n} affected users)
+        sent_emails:
+          one: 1 email sent
+          other: "%{count} emails sent"
         sent_at: Sent at
         subject: Subject
         segment_recipient: Recipients

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -624,7 +624,6 @@ en:
       winner_investment_authors: Authors of winner investments in the current budget
       not_supported_on_current_budget: Users that haven't supported investments on current budget
       invalid_recipients_segment: "Recipients user segment is invalid"
-      pending_last_newsletter: "Pending from last newsletter"
       arganzuela: Arganzuela
       barajas: Barajas
       carabanchel: Carabanchel

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -624,7 +624,6 @@ es:
       winner_investment_authors: Usuarios autores de proyectos de gasto ganadoras en los actuales presupuestos
       not_supported_on_current_budget: Usuarios que no han apoyado proyectos de los actuales presupuestos
       invalid_recipients_segment: "El segmento de destinatarios es inválido"
-      pending_last_newsletter: "Pendientes de la última newsletter"
       arganzuela: Arganzuela
       barajas: Barajas
       carabanchel: Carabanchel

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -671,6 +671,9 @@ es:
         title: Vista previa de newsletter
         send: Enviar
         affected_users: (%{n} usuarios afectados)
+        sent_emails:
+          one: 1 correo enviado
+          other: "%{count} correos enviados"
         sent_at: Enviado
         subject: Asunto
         segment_recipient: Destinatarios

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -9,32 +9,11 @@ class UserSegments
        selected_investment_authors
        winner_investment_authors
        not_supported_on_current_budget
-       beta_testers
-       pending_last_newsletter) + geozones
+       beta_testers) + geozones
   end
 
   def self.all_users
     User.active
-  end
-
-  def self.pending_last_newsletter
-    User.where(id: pending_user_ids)
-  end
-
-  def self.last_newsletter
-    Newsletter.find(28)
-  end
-
-  def self.pending_user_ids
-    all_user_ids - sent_user_ids(last_newsletter) - sent_user_ids(Newsletter.find(26)) - sent_user_ids(Newsletter.find(30))
-  end
-
-  def self.all_user_ids
-    all_users.pluck(:id)
-  end
-
-  def self.sent_user_ids(newsletter)
-    Activity.where(actionable: newsletter).pluck(:user_id).uniq
   end
 
   def self.administrators
@@ -76,9 +55,8 @@ class UserSegments
 
   def self.beta_testers
     testers = %w(aranacm@madrid.es
-                 voodoorai2000@gmail.com
                  alberto@decabeza.es
-                 javim@elretirao.net)
+                 voodoorai2000@gmail.com)
 
     User.where(email: testers).order('created_at ASC')
   end

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -146,6 +146,21 @@ feature "Admin newsletter emails" do
     end
   end
 
+  context "Counter of emails sent", :js do
+
+    scenario "Display counter" do
+      newsletter = create(:newsletter, segment_recipient: "administrators")
+      visit admin_newsletter_path(newsletter)
+
+      accept_confirm { click_link "Send" }
+
+      expect(page).to have_content "Newsletter sent successfully"
+
+      expect(page).to have_content "1 affected users"
+      expect(page).to have_content "1 email sent"
+    end
+  end
+
   context "Select list of users to send newsletter" do
 
     scenario "Custom user segments" do

--- a/spec/features/admin/emails/newsletters_spec.rb
+++ b/spec/features/admin/emails/newsletters_spec.rb
@@ -146,21 +146,6 @@ feature "Admin newsletter emails" do
     end
   end
 
-  context "Counter of emails sent", :js do
-
-    scenario "Display counter" do
-      newsletter = create(:newsletter, segment_recipient: "administrators")
-      visit admin_newsletter_path(newsletter)
-
-      accept_confirm { click_link "Send" }
-
-      expect(page).to have_content "Newsletter sent successfully"
-
-      expect(page).to have_content "1 affected users"
-      expect(page).to have_content "Enviados 1"
-    end
-  end
-
   context "Select list of users to send newsletter" do
 
     scenario "Custom user segments" do

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -2,34 +2,6 @@ require 'rails_helper'
 
 feature 'Vote via email' do
 
-  context "Email" do
-
-    scenario "Displays a show link and vote link to proposals" do
-      user = create(:user, newsletter: true)
-      proposal = create(:proposal)
-
-      admin = create(:administrator)
-      login_as(admin.user)
-
-      visit new_admin_newsletter_path
-
-      fill_in_newsletter_form(segment_recipient: 'All users')
-      click_button "Create Newsletter"
-
-      expect(page).to have_content "Newsletter created successfully"
-      click_link "Send"
-
-      user.reload
-      show_link = proposal_path(proposal, newsletter_token: user.newsletter_token)
-      vote_link = vote_proposal_path(proposal, newsletter_token: user.newsletter_token)
-
-      email = unread_emails_for(user.email).first
-      expect(email).to have_body_text(show_link)
-      expect(email).to have_body_text(vote_link)
-    end
-
-  end
-
   context "Voting proposals via a GET link" do
 
     background do
@@ -91,30 +63,6 @@ feature 'Vote via email' do
 
       expect(page).to have_content "You must sign in or register to continue"
       expect(page.current_path).to eq("/users/sign_in")
-    end
-
-  end
-
-  context "Show link with token" do
-
-    scenario "User is logged in" do
-      proposal = create(:proposal)
-      user = create(:user, :verified, newsletter_token: "123456")
-
-      login_as(user)
-
-      visit proposal_path(proposal, newsletter_token: "123456")
-
-      expect_to_be_signed_in
-    end
-
-    scenario "User is not logged in" do
-      proposal = create(:proposal)
-      create(:user, :verified, newsletter_token: "123456")
-
-      visit proposal_path(proposal, newsletter_token: "123456")
-
-      expect_to_not_be_signed_in
     end
 
   end

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -211,47 +211,6 @@ describe UserSegments do
     end
   end
 
-  context "Pending users for last newsletter" do
-
-    let!(:user1) { create(:user) }
-    let!(:user2) { create(:user) }
-    let!(:user3) { create(:user) }
-
-    describe "#pending_last_newsletter" do
-      it "returns users that did not receive the last newsletter" do
-        newsletter = create(:newsletter, id: 28)
-        activity = create(:activity, user: user1, actionable: newsletter)
-
-        expect(described_class.pending_last_newsletter.count).to eq(2)
-        expect(described_class.pending_last_newsletter).to include(user2)
-        expect(described_class.pending_last_newsletter).to include(user3)
-      end
-    end
-
-    describe "#sent_user_ids" do
-      it "returns user_ids that have already received a newsletter" do
-        newsletter = create(:newsletter, id: 28)
-        create(:activity, user: user1, actionable: newsletter)
-        create(:activity, user: user2, actionable: newsletter)
-
-        expect(described_class.sent_user_ids(newsletter).count).to eq(2)
-        expect(described_class.sent_user_ids(newsletter)).to include(user1.id)
-        expect(described_class.sent_user_ids(newsletter)).to include(user2.id)
-        expect(described_class.sent_user_ids(newsletter)).to_not include(user3.id)
-      end
-
-      it "does not return duplicate user_ids" do
-        newsletter = create(:newsletter, id: 28)
-        create(:activity, user: user1, actionable: newsletter)
-        create(:activity, user: user1, actionable: newsletter)
-
-        expect(described_class.sent_user_ids(newsletter).count).to eq(1)
-        expect(described_class.sent_user_ids(newsletter)).to eq([user1.id])
-      end
-    end
-
-  end
-
   context "Geozones" do
 
     let!(:new_york) { create(:geozone, name: "New York") }

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -154,5 +154,4 @@ describe Newsletter do
     end
 
   end
-
 end

--- a/spec/support/common_actions/users.rb
+++ b/spec/support/common_actions/users.rb
@@ -82,5 +82,4 @@ module Users
   def expect_to_not_be_signed_in
     expect(find('.top-bar-right')).not_to have_content 'My account'
   end
-
 end


### PR DESCRIPTION
## References

* Pull requests #1680, #1682, #1683, #1684, #1685, #1687, #1688, #1689
* Commits b5b090e, fc726f1, cddbc86, dc1c276

In case you're wondering, 1681 isn't related, and 1686 and 1690 add code related to the proposals controller which should **not** be deleted yet.

## Objectives

* Remove the code used to generate a newsletter with links to vote the top proposals
* Group all changes which need backport in one pull request

## Does this PR need a Backport to CONSUL?

Yes, but skip the first commit when doing so.