### PR TITLE
Clean up newsletter votes code

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -197,7 +197,7 @@ class ProposalsController < ApplicationController
     def login_user!
       if current_user.present?
         @signed_in_before_voting = true
-      elsif newsletter_vote? && newsletter_user.present? && newsletter_user.level_two_or_three_verified?
+      elsif newsletter_vote? && newsletter_user&.can?(:newsletter_vote, Proposal)
         sign_in(:user, newsletter_user)
       end
     end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -6,7 +6,7 @@ class ProposalsController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :load_categories, only: [:index, :new, :create, :edit, :map, :summary]
   before_action :load_geozones, only: [:edit, :map, :summary]
-  before_action :login_user!, only: :newsletter_vote
+  before_action :login_user_with_newsletter_token!, only: :newsletter_vote
   before_action :authenticate_user!, except: [:index, :show, :map, :summary]
   before_action :destroy_map_location_association, only: :update
   before_action :set_view, only: :index
@@ -194,7 +194,7 @@ class ProposalsController < ApplicationController
       end
     end
 
-    def login_user!
+    def login_user_with_newsletter_token!
       if current_user.present?
         @signed_in_before_voting = true
       elsif newsletter_vote? && newsletter_user&.can?(:newsletter_vote, Proposal)

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -62,7 +62,7 @@ class ProposalsController < ApplicationController
   def newsletter_vote
     @proposal.register_vote(current_user, "yes")
 
-    sign_out(:user)
+    sign_out(:user) unless @signed_in_before_voting
     redirect_to @proposal, notice: t("proposals.notice.voted")
   end
 
@@ -195,7 +195,9 @@ class ProposalsController < ApplicationController
     end
 
     def login_user!
-      if newsletter_vote? && newsletter_user.present? && newsletter_user.level_two_or_three_verified?
+      if current_user.present?
+        @signed_in_before_voting = true
+      elsif newsletter_vote? && newsletter_user.present? && newsletter_user.level_two_or_three_verified?
         sign_in(:user, newsletter_user)
       end
     end

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -81,6 +81,7 @@ module Abilities
 
         if user.old_enough_to_participate?
           can :vote, Proposal
+          can :newsletter_vote, Proposal
           can :vote_featured, Proposal
           can :vote, SpendingProposal
 

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -1,7 +1,7 @@
 resources :proposals do
   member do
     post :vote
-    get :vote
+    get :vote, action: :newsletter_vote
     post :vote_featured
     put :flag
     put :unflag

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -29,7 +29,7 @@ feature 'Vote via email' do
         expect(page).to_not have_selector ".in-favor a"
       end
 
-      expect_to_not_be_signed_in
+      expect_to_be_signed_in
     end
 
     scenario 'Verified user is not logged in' do

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -65,5 +65,14 @@ feature 'Vote via email' do
       expect(page.current_path).to eq("/users/sign_in")
     end
 
+    scenario "Underaged user" do
+      @manuela.update(newsletter_token: "123456", date_of_birth: 6.years.ago)
+
+      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+
+      expect(page).to have_content "You must sign in or register to continue"
+      expect(page).to have_current_path "/users/sign_in"
+    end
+
   end
 end

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -3,24 +3,21 @@ require 'rails_helper'
 feature 'Vote via email' do
 
   context "Voting proposals via a GET link" do
-
-    background do
-      @manuela = create(:user, :verified)
-      @proposal = create(:proposal)
-    end
+    let(:proposal) { create(:proposal) }
+    let(:user) { create(:user, :verified) }
 
     scenario 'Verified user is logged in' do
-      @manuela.update(newsletter_token: "123456")
+      user.update(newsletter_token: "123456")
 
-      login_as(@manuela)
-      visit proposal_path(@proposal)
+      login_as(user)
+      visit proposal_path(proposal)
 
       within('.supports') do
         expect(page).to have_content "No supports"
         expect(page).to have_selector ".in-favor a"
       end
 
-      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+      visit vote_proposal_path(proposal, newsletter_token: "123456")
 
       expect(page).to have_content "You have successfully voted this proposal"
 
@@ -33,9 +30,9 @@ feature 'Vote via email' do
     end
 
     scenario 'Verified user is not logged in' do
-      @manuela.update(newsletter_token: "123456")
+      user.update(newsletter_token: "123456")
 
-      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+      visit vote_proposal_path(proposal, newsletter_token: "123456")
 
       expect(page).to have_content "You have successfully voted this proposal"
 
@@ -48,27 +45,27 @@ feature 'Vote via email' do
     end
 
     scenario 'Verified user with invalid token' do
-      @manuela.update(newsletter_token: "123456")
+      user.update(newsletter_token: "123456")
 
-      visit vote_proposal_path(@proposal, newsletter_token: "999999")
+      visit vote_proposal_path(proposal, newsletter_token: "999999")
 
       expect(page).to have_content("You must sign in or register to continue.")
       expect(page.current_path).to eq("/users/sign_in")
     end
 
     scenario 'Unverified user' do
-      user = create(:user, newsletter_token: "123456")
+      user.update(newsletter_token: "123456", verified_at: nil)
 
-      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+      visit vote_proposal_path(proposal, newsletter_token: "123456")
 
       expect(page).to have_content "You must sign in or register to continue"
       expect(page.current_path).to eq("/users/sign_in")
     end
 
     scenario "Underaged user" do
-      @manuela.update(newsletter_token: "123456", date_of_birth: 6.years.ago)
+      user.update(newsletter_token: "123456", date_of_birth: 6.years.ago)
 
-      visit vote_proposal_path(@proposal, newsletter_token: "123456")
+      visit vote_proposal_path(proposal, newsletter_token: "123456")
 
       expect(page).to have_content "You must sign in or register to continue"
       expect(page).to have_current_path "/users/sign_in"


### PR DESCRIPTION
## References

* Pull request #1690

## Background

After voting following a link with a token, we're signing out users in order to avoid anyone clicking the link to get control of a user's account. However, we're also signing out already signed in users.

## Objectives

* Don't sign out users after voting if they were already signed in
* Use different actions for `get` and `post` verbs
* Avoid issues with underaged users trying to vote a proposal
* Remove hound warnings in the specs