### PR TITLE
Budgets admin

### DIFF
--- a/app/views/admin/budgets/index.html.erb
+++ b/app/views/admin/budgets/index.html.erb
@@ -6,49 +6,55 @@
 
 <%= render 'shared/filter_subnav', i18n_namespace: "admin.budgets.index" %>
 
-<h3><%= page_entries_info @budgets %></h3>
+<% if @budgets.any? %>
+  <h3><%= page_entries_info @budgets %></h3>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t("admin.budgets.index.table_name") %></th>
-      <th><%= t("admin.budgets.index.table_phase") %></th>
-      <th><%= t("admin.budgets.index.table_investments") %></th>
-      <th><%= t("admin.budgets.index.table_edit_groups") %></th>
-      <th><%= t("admin.budgets.index.table_edit_budget") %></th>
-      <th><%= t("admin.budgets.index.table_admin_ballots") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @budgets.each do |budget| %>
-      <tr id="<%= dom_id(budget) %>" class="budget">
-        <td>
-          <%= budget.name %>
-        </td>
-        <td class="small">
-          <%= t("budgets.phase.#{budget.phase}") %>
-        </td>
-        <td>
-          <%= link_to t("admin.budgets.index.budget_investments"),
-                         admin_budget_budget_investments_path(budget_id: budget.id),
-                         class: "button hollow medium" %>
-        </td>
-        <td class="small">
-          <%= link_to t("admin.budgets.index.edit_groups"), admin_budget_path(budget) %>
-        </td>
-        <td class="small">
-          <%= link_to t("admin.budgets.index.edit_budget"), edit_admin_budget_path(budget) %>
-        </td>
-        <td class="small">
-          <% if budget.poll.present? %>
-            <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_booth_assignments_path(budget.poll) %>
-          <% else %>
-            <%= link_to_create_budget_poll(budget) %>
-          <% end %>
-        </td>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("admin.budgets.index.table_name") %></th>
+        <th><%= t("admin.budgets.index.table_phase") %></th>
+        <th><%= t("admin.budgets.index.table_investments") %></th>
+        <th><%= t("admin.budgets.index.table_edit_groups") %></th>
+        <th><%= t("admin.budgets.index.table_edit_budget") %></th>
+        <th><%= t("admin.budgets.index.table_admin_ballots") %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @budgets.each do |budget| %>
+        <tr id="<%= dom_id(budget) %>" class="budget">
+          <td>
+            <%= budget.name %>
+          </td>
+          <td class="small">
+            <%= t("budgets.phase.#{budget.phase}") %>
+          </td>
+          <td>
+            <%= link_to t("admin.budgets.index.budget_investments"),
+                           admin_budget_budget_investments_path(budget_id: budget.id),
+                           class: "button hollow medium" %>
+          </td>
+          <td class="small">
+            <%= link_to t("admin.budgets.index.edit_groups"), admin_budget_path(budget) %>
+          </td>
+          <td class="small">
+            <%= link_to t("admin.budgets.index.edit_budget"), edit_admin_budget_path(budget) %>
+          </td>
+          <td class="small">
+            <% if budget.poll.present? %>
+              <%= link_to t("admin.budgets.index.admin_ballots"), admin_poll_booth_assignments_path(budget.poll) %>
+            <% else %>
+              <%= link_to_create_budget_poll(budget) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 
-<%= paginate @budgets %>
+  <%= paginate @budgets %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.budgets.index.no_budgets") %>
+  </div>
+<% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -89,6 +89,7 @@ en:
         edit_groups: Edit headings groups
         edit_budget: Edit budget
         admin_ballots: Admin ballots
+        no_budgets: "There are no open budgets."
       create:
         notice: New participatory budget created successfully!
       update:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -89,6 +89,7 @@ es:
         edit_groups: Editar grupos de partidas
         edit_budget: Editar presupuesto
         admin_ballots: Gestionar urnas
+        no_budgets: "No hay presupuestos abiertos."
       create:
         notice: "¡Presupuestos participativos creados con éxito!"
       update:

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -25,6 +25,12 @@ feature 'Admin budgets' do
 
   context 'Index' do
 
+    scenario 'Displaying no open budgets text' do
+      visit admin_budgets_path
+
+      expect(page).to have_content("There are no open budgets.")
+    end
+
     scenario 'Displaying budgets' do
       budget = create(:budget)
       visit admin_budgets_path
@@ -119,7 +125,7 @@ feature 'Admin budgets' do
       click_link 'Delete budget'
 
       expect(page).to have_content('Budget deleted successfully')
-      expect(page).to have_content('budgets cannot be found')
+      expect(page).to have_content('There are no open budgets.')
     end
 
     scenario 'Try to destroy a budget with investments' do


### PR DESCRIPTION
## Objectives

This PR improves message when there are no budgets adding consistency with the rest of Admin panel sections.

## Visual Changes

**BEFORE**
<img width="1240" alt="before" src="https://user-images.githubusercontent.com/631897/48059679-19ee1480-e1ba-11e8-9b08-7e28c18d77db.png">

**AFTER**
<img width="1240" alt="after" src="https://user-images.githubusercontent.com/631897/48059681-1ce90500-e1ba-11e8-8a29-ca986cc00cb9.png">

## Does this PR need a Backport to CONSUL?

Backport this to CONSUL repo.