### PR TITLE
Legislation proposals categories

### DIFF
--- a/app/views/legislation/proposals/_categories.html.erb
+++ b/app/views/legislation/proposals/_categories.html.erb
@@ -1,5 +1,5 @@
 <div class="sidebar-divider"></div>
-<h2 class="sidebar-title"><%= t("legislation.proposals.categories") %></h2>
+<h2 class="sidebar-title"><%= t("shared.tags_cloud.categories") %></h2>
 <br>
 <ul id="categories" class="no-bullet categories">
   <% @process.tag_list_on(:customs).each do |tag| %>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -123,4 +123,3 @@ en:
       form:
         tags_label: "Categories"
       not_verified: "For vote proposals %{verify_account}."
-      categories: Categories

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -123,4 +123,3 @@ es:
       form:
         tags_label: "Categorías"
       not_verified: "Para votar propuestas %{verify_account}."
-      categories: Categorías


### PR DESCRIPTION
## Objectives

This PR removes unnecessary i18n legislation proposals categories using ` t("shared.tags_cloud.categories")` instead of `t("legislation.proposals.categories")` to avoid conflicts with CONSUL repo.
