### PR TITLE
Budget investment show

### DIFF
--- a/app/views/budgets/investments/_investment_show.html.erb
+++ b/app/views/budgets/investments/_investment_show.html.erb
@@ -159,7 +159,7 @@
           <div class="callout success">
             <%= t("budgets.investments.show.project_selected_html") %>
           </div>
-        <% elsif !investment.selected? && @budget.balloting_or_later? %>
+        <% elsif @budget.balloting_or_later? %>
           <div class="callout warning">
             <%= t("budgets.investments.show.project_not_selected_html") %>
           </div>

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1061,6 +1061,25 @@ feature 'Budget Investments' do
     expect(page).to have_content("This investment project has not been selected for balloting phase")
   end
 
+  scenario "Show title (no message)" do
+    user = create(:user)
+    login_as(user)
+
+    investment = create(:budget_investment,
+                        :feasible,
+                        :finished,
+                        budget: budget,
+                        group: group,
+                        heading: heading)
+
+    visit budget_investment_path(budget_id: budget.id, id: investment.id)
+
+    within("aside") do
+      expect(page).to have_content("Investment project")
+      expect(page).to have_css(".label-budget-investment")
+    end
+  end
+
   scenario "Show (unfeasible budget investment with valuation not finished)" do
     user = create(:user)
     login_as(user)


### PR DESCRIPTION
## Objectives

This PR:

- Removes unnecessary condition when display unselected message. 
- Adds spec when no message is displayed. Should show only "Investment project" label.

## Does this PR need a Backport to CONSUL?

Backport to CONSUL repo.

