### PR TITLE
Legislation process documents

### DIFF
--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -2,7 +2,7 @@ class Legislation::Process < ActiveRecord::Base
   include ActsAsParanoidAliases
   include Taggable
   include Documentable
-  documentable max_documents_allowed: 3,
+  documentable max_documents_allowed: 4,
                max_file_size: 3.megabytes,
                accepted_content_types: [ "application/pdf" ]
 


### PR DESCRIPTION
## Objectives

Updates `max_documents_allowed` number to legislation process. 

## Notes
These documents are uploaded only by admin users, and in this fork some legislation processes needs 4 documents instead of 3.
