### PR TITLE
Globalize tabs

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -363,19 +363,34 @@ a {
 
   .tabs-title {
     font-size: $base-font-size;
-    margin-bottom: 0;
+    margin-right: $line-height;
   }
 
   .tabs-title > a {
     color: $text-medium;
-    margin-bottom: rem-calc(-1);
-    margin-right: $line-height;
+    position: relative;
+
+    &:hover {
+      background: none;
+      color: $brand;
+      text-decoration: none;
+    }
 
     &[aria-selected='true'],
     &.is-active {
+      border-bottom: 0;
       color: $brand;
-      border-bottom: 2px solid $brand;
       font-weight: bold;
+
+      &::after {
+        background: $brand;
+        border-bottom: 2px solid $brand;
+        bottom: 0;
+        content: '';
+        left: 0;
+        position: absolute;
+        width: 100%;
+      }
     }
   }
 

--- a/app/views/admin/shared/_common_globalize_locales.html.erb
+++ b/app/views/admin/shared/_common_globalize_locales.html.erb
@@ -1,10 +1,11 @@
 <% I18n.available_locales.each do |locale| %>
-  <%= link_to t("admin.translations.remove_language"), "#",
-              id: "js_delete_#{locale}",
-              style: display_translation_style(resource, locale),
-              class: 'float-right delete js-delete-language',
-              data: { locale: locale } %>
-
+  <div class="text-right">
+    <%= link_to t("admin.translations.remove_language"), "#",
+                id: "js_delete_#{locale}",
+                style: display_translation_style(resource, locale),
+                class: 'delete js-delete-language',
+                data: { locale: locale } %>
+  </div>
 <% end %>
 
 <ul class="tabs" data-tabs id="globalize_locale">


### PR DESCRIPTION
## Objectives

Fixes globalize tabs when there is a lot of available locales. Now "Remove language" link is not floating preventing break the layout.

## Visual Changes

**BEFORE**
<img width="1248" alt="languages admin" src="https://user-images.githubusercontent.com/631897/48500816-08e97700-e83c-11e8-8688-a9bcae9b550a.png">

**AFTER**
![screenshot 2018-11-14 at 18 45 50](https://user-images.githubusercontent.com/631897/48501476-92e60f80-e83d-11e8-95af-9aef78f507c5.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL repo.
