### PR TITLE
Administrator ID

### DIFF
--- a/app/views/admin/administrators/index.html.erb
+++ b/app/views/admin/administrators/index.html.erb
@@ -8,12 +8,16 @@
 
     <table>
       <thead>
+        <th scope="col" class="text-center"><%= t("admin.administrators.index.id") %></th>
         <th scope="col"><%= t("admin.administrators.index.name") %></th>
         <th scope="col"><%= t("admin.administrators.index.email") %></th>
         <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
       </thead>
       <% @administrators.each do |administrator| %>
         <tr>
+          <td class="text-center">
+            <%= administrator.id %>
+          </td>
           <td>
             <%= administrator.name %>
           </td>

--- a/app/views/admin/administrators/index.html.erb
+++ b/app/views/admin/administrators/index.html.erb
@@ -14,7 +14,7 @@
         <th scope="col" class="small-3"><%= t("admin.shared.actions") %></th>
       </thead>
       <% @administrators.each do |administrator| %>
-        <tr>
+        <tr id="<%= dom_id(administrator)%>">
           <td class="text-center">
             <%= administrator.id %>
           </td>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -597,6 +597,7 @@ en:
         title: Administrators
         name: Name
         email: Email
+        id: Administrator ID
         no_administrators: There are no administrators.
       administrator:
         add: Add

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -595,6 +595,7 @@ es:
     administrators:
       index:
         title: Administradores
+        id: ID de Administrador
         name: Nombre
         email: Email
         no_administrators: No hay administradores.

--- a/spec/features/admin/administrators_spec.rb
+++ b/spec/features/admin/administrators_spec.rb
@@ -10,6 +10,7 @@ feature 'Admin administrators' do
   end
 
   scenario 'Index' do
+    expect(page).to have_content @administrator.id
     expect(page).to have_content @administrator.name
     expect(page).to have_content @administrator.email
     expect(page).not_to have_content @user.name

--- a/spec/features/admin/administrators_spec.rb
+++ b/spec/features/admin/administrators_spec.rb
@@ -1,42 +1,48 @@
 require 'rails_helper'
 
 feature 'Admin administrators' do
+  let!(:admin) { create(:administrator) }
+  let!(:user) { create(:user, username: 'Jose Luis Balbin') }
+  let!(:user_administrator) { create(:administrator) }
+
   background do
-    @admin = create(:administrator)
-    @user  = create(:user, username: 'Jose Luis Balbin')
-    @administrator = create(:administrator)
-    login_as(@admin.user)
+    login_as(admin.user)
     visit admin_administrators_path
   end
 
   scenario 'Index' do
-    expect(page).to have_content @administrator.id
-    expect(page).to have_content @administrator.name
-    expect(page).to have_content @administrator.email
-    expect(page).not_to have_content @user.name
+    expect(page).to have_content user_administrator.id
+    expect(page).to have_content user_administrator.name
+    expect(page).to have_content user_administrator.email
+    expect(page).not_to have_content user.name
   end
 
   scenario 'Create Administrator', :js do
-    fill_in 'name_or_email', with: @user.email
+    fill_in 'name_or_email', with: user.email
     click_button 'Search'
 
-    expect(page).to have_content @user.name
+    expect(page).to have_content user.name
     click_link 'Add'
     within("#administrators") do
-      expect(page).to have_content @user.name
+      expect(page).to have_content user.name
     end
   end
 
   scenario 'Delete Administrator' do
-    find(:xpath, "//tr[contains(.,'#{@administrator.name}')]/td/a", text: 'Delete').click
+    within "#administrator_#{user_administrator.id}" do
+      click_on "Delete"
+    end
 
     within("#administrators") do
-      expect(page).not_to have_content @administrator.name
+      expect(page).not_to have_content user_administrator.name
     end
   end
 
   scenario 'Delete Administrator when its the current user' do
-    find(:xpath, "//tr[contains(.,'#{@admin.name}')]/td/a", text: 'Delete').click
+
+    within "#administrator_#{admin.id}" do
+      click_on "Delete"
+    end
 
     within("#error") do
       expect(page).to have_content I18n.t("admin.administrators.administrator.restricted_removal")
@@ -45,49 +51,52 @@ feature 'Admin administrators' do
 
   context 'Search' do
 
+    let!(:administrator1) { create(:administrator, user: create(:user,
+                                                                 username: 'Bernard Sumner',
+                                                                 email: 'bernard@sumner.com')) }
+    let!(:administrator2) { create(:administrator, user: create(:user,
+                                                                 username: 'Tony Soprano',
+                                                                 email: 'tony@soprano.com')) }
+
     background do
-      user  = create(:user, username: 'Bernard Sumner', email: 'bernard@sumner.com')
-      user2 = create(:user, username: 'Tony Soprano', email: 'tony@soprano.com')
-      @administrator1 = create(:administrator, user: user)
-      @administrator2 = create(:administrator, user: user2)
       visit admin_administrators_path
     end
 
     scenario 'returns no results if search term is empty' do
-      expect(page).to have_content(@administrator1.name)
-      expect(page).to have_content(@administrator2.name)
+      expect(page).to have_content(administrator1.name)
+      expect(page).to have_content(administrator2.name)
 
       fill_in 'name_or_email', with: ' '
       click_button 'Search'
 
       expect(page).to have_content('Administrators: User search')
       expect(page).to have_content('No results found')
-      expect(page).not_to have_content(@administrator1.name)
-      expect(page).not_to have_content(@administrator2.name)
+      expect(page).not_to have_content(administrator1.name)
+      expect(page).not_to have_content(administrator2.name)
     end
 
     scenario 'search by name' do
-      expect(page).to have_content(@administrator1.name)
-      expect(page).to have_content(@administrator2.name)
+      expect(page).to have_content(administrator1.name)
+      expect(page).to have_content(administrator2.name)
 
       fill_in 'name_or_email', with: 'Sumn'
       click_button 'Search'
 
       expect(page).to have_content('Administrators: User search')
-      expect(page).to have_content(@administrator1.name)
-      expect(page).not_to have_content(@administrator2.name)
+      expect(page).to have_content(administrator1.name)
+      expect(page).not_to have_content(administrator2.name)
     end
 
     scenario 'search by email' do
-      expect(page).to have_content(@administrator1.email)
-      expect(page).to have_content(@administrator2.email)
+      expect(page).to have_content(administrator1.email)
+      expect(page).to have_content(administrator2.email)
 
-      fill_in 'name_or_email', with: @administrator2.email
+      fill_in 'name_or_email', with: administrator2.email
       click_button 'Search'
 
       expect(page).to have_content('Administrators: User search')
-      expect(page).to have_content(@administrator2.email)
-      expect(page).not_to have_content(@administrator1.email)
+      expect(page).to have_content(administrator2.email)
+      expect(page).not_to have_content(administrator1.email)
     end
   end
 


### PR DESCRIPTION
## Objectives

- Adds **Administrator ID** on admin administrators index page.
- Refactors admin administrators spec: this refactoring avoids "Use let instead of an instance variable" rubocop warning. 😌 

## Visual Changes

![administrators_1](https://user-images.githubusercontent.com/631897/48771773-87259d80-ecc2-11e8-9a85-304a0afb705d.png)

This is useful for example to identify an admin comment by their id:

![administrators_2](https://user-images.githubusercontent.com/631897/48771776-87be3400-ecc2-11e8-9405-8f1dc88efaee.png)


## Does this PR need a Backport to CONSUL?

Backport to CONSUL.