### PR TITLE
Rename Admin::Proposals to Admin::HiddenProposals

### DIFF
--- a/app/controllers/admin/hidden_proposals_controller.rb
+++ b/app/controllers/admin/hidden_proposals_controller.rb
@@ -1,7 +1,7 @@
 class Admin::HiddenProposalsController < Admin::BaseController
   include FeatureFlags
 
-  has_filters %w{without_confirmed_hide all with_confirmed_hide}, only: :index
+  has_filters %w[without_confirmed_hide all with_confirmed_hide], only: :index
 
   feature_flag :proposals
 

--- a/app/controllers/admin/hidden_proposals_controller.rb
+++ b/app/controllers/admin/hidden_proposals_controller.rb
@@ -1,4 +1,4 @@
-class Admin::ProposalsController < Admin::BaseController
+class Admin::HiddenProposalsController < Admin::BaseController
   include FeatureFlags
 
   has_filters %w{without_confirmed_hide all with_confirmed_hide}, only: :index

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -21,7 +21,12 @@ module AdminHelper
   end
 
   def menu_moderated_content?
-    ["hidden_proposals", "debates", "comments", "hidden_users", "activity", "hidden_budget_investments"].include?(controller_name) && controller.class.parent != Admin::Legislation
+    moderated_sections.include?(controller_name) && controller.class.parent != Admin::Legislation
+  end
+
+  def moderated_sections
+    ["hidden_proposals", "debates", "comments", "hidden_users", "activity",
+     "hidden_budget_investments"]
   end
 
   def menu_budget?

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -21,7 +21,7 @@ module AdminHelper
   end
 
   def menu_moderated_content?
-    ["proposals", "debates", "comments", "hidden_users", "activity", "hidden_budget_investments"].include?(controller_name) && controller.class.parent != Admin::Legislation
+    ["hidden_proposals", "debates", "comments", "hidden_users", "activity", "hidden_budget_investments"].include?(controller_name) && controller.class.parent != Admin::Legislation
   end
 
   def menu_budget?

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -144,8 +144,8 @@
       </a>
       <ul <%= "class=is-active" if menu_moderated_content? %>>
         <% if feature?(:proposals) %>
-          <li <%= "class=is-active" if controller_name == "proposals" && controller.class.parent != Admin::Legislation %>>
-            <%= link_to t("admin.menu.hidden_proposals"), admin_proposals_path %>
+          <li <%= "class=is-active" if controller_name == "hidden_proposals" %>>
+            <%= link_to t("admin.menu.hidden_proposals"), admin_hidden_proposals_path %>
           </li>
         <% end %>
 

--- a/app/views/admin/hidden_proposals/index.html.erb
+++ b/app/views/admin/hidden_proposals/index.html.erb
@@ -1,7 +1,7 @@
-<h2><%= t("admin.proposals.index.title") %></h2>
+<h2><%= t("admin.hidden_proposals.index.title") %></h2>
 <p><%= t("admin.shared.moderated_content") %></p>
 
-<%= render 'shared/filter_subnav', i18n_namespace: "admin.proposals.index" %>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.hidden_proposals.index" %>
 
 <% if @proposals.any? %>
   <h3 class="margin"><%= page_entries_info @proposals %></h3>
@@ -33,13 +33,13 @@
         </td>
         <td class="align-top">
           <%= link_to t("admin.actions.restore"),
-                restore_admin_proposal_path(proposal, request.query_parameters),
+                restore_admin_hidden_proposal_path(proposal, request.query_parameters),
                 method: :put,
                 data: { confirm: t("admin.actions.confirm") },
                 class: "button hollow warning" %>
           <% unless proposal.confirmed_hide? %>
             <%= link_to t("admin.actions.confirm_hide"),
-                  confirm_hide_admin_proposal_path(proposal, request.query_parameters),
+                  confirm_hide_admin_hidden_proposal_path(proposal, request.query_parameters),
                   method: :put,
                   class: "button" %>
           <% end %>
@@ -52,6 +52,6 @@
   <%= paginate @proposals %>
 <% else %>
   <div class="callout primary margin">
-    <%= t("admin.proposals.index.no_hidden_proposals") %>
+    <%= t("admin.hidden_proposals.index.no_hidden_proposals") %>
   </div>
 <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -133,7 +133,7 @@ ignore_unused:
   - 'admin.comments.index.filter*'
   - 'admin.banners.index.filters.*'
   - 'admin.debates.index.filter*'
-  - 'admin.proposals.index.filter*'
+  - 'admin.hidden_proposals.index.filter*'
   - 'admin.proposal_notifications.index.filter*'
   - 'admin.budgets.index.filter*'
   - 'admin.budget_investments.index.filter*'

--- a/config/locales/de-DE/admin.yml
+++ b/config/locales/de-DE/admin.yml
@@ -1004,7 +1004,7 @@ de:
       search:
         title: Organisationen suchen
         no_results: Keine Organisationen gefunden.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filter
         filters:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1058,7 +1058,7 @@ en:
       search:
         title: Search Organisations
         no_results: No organizations found.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filter
         filters:

--- a/config/locales/es-AR/admin.yml
+++ b/config/locales/es-AR/admin.yml
@@ -906,7 +906,7 @@ es-AR:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-BO/admin.yml
+++ b/config/locales/es-BO/admin.yml
@@ -711,7 +711,7 @@ es-BO:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-CL/admin.yml
+++ b/config/locales/es-CL/admin.yml
@@ -841,7 +841,7 @@ es-CL:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-CO/admin.yml
+++ b/config/locales/es-CO/admin.yml
@@ -711,7 +711,7 @@ es-CO:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-CR/admin.yml
+++ b/config/locales/es-CR/admin.yml
@@ -711,7 +711,7 @@ es-CR:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-DO/admin.yml
+++ b/config/locales/es-DO/admin.yml
@@ -711,7 +711,7 @@ es-DO:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-EC/admin.yml
+++ b/config/locales/es-EC/admin.yml
@@ -711,7 +711,7 @@ es-EC:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-GT/admin.yml
+++ b/config/locales/es-GT/admin.yml
@@ -711,7 +711,7 @@ es-GT:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-HN/admin.yml
+++ b/config/locales/es-HN/admin.yml
@@ -711,7 +711,7 @@ es-HN:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-MX/admin.yml
+++ b/config/locales/es-MX/admin.yml
@@ -711,7 +711,7 @@ es-MX:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-NI/admin.yml
+++ b/config/locales/es-NI/admin.yml
@@ -711,7 +711,7 @@ es-NI:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-PA/admin.yml
+++ b/config/locales/es-PA/admin.yml
@@ -711,7 +711,7 @@ es-PA:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-PE/admin.yml
+++ b/config/locales/es-PE/admin.yml
@@ -711,7 +711,7 @@ es-PE:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-PR/admin.yml
+++ b/config/locales/es-PR/admin.yml
@@ -711,7 +711,7 @@ es-PR:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-PY/admin.yml
+++ b/config/locales/es-PY/admin.yml
@@ -711,7 +711,7 @@ es-PY:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-SV/admin.yml
+++ b/config/locales/es-SV/admin.yml
@@ -711,7 +711,7 @@ es-SV:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-UY/admin.yml
+++ b/config/locales/es-UY/admin.yml
@@ -711,7 +711,7 @@ es-UY:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es-VE/admin.yml
+++ b/config/locales/es-VE/admin.yml
@@ -773,7 +773,7 @@ es-VE:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1057,7 +1057,7 @@ es:
       search:
         title: Buscar Organizaciones
         no_results: No se han encontrado organizaciones.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/fa-IR/admin.yml
+++ b/config/locales/fa-IR/admin.yml
@@ -863,7 +863,7 @@ fa:
       search:
         title: جستجو سازمان ها
         no_results: هیچ سازمان یافت نشد
-    proposals:
+    hidden_proposals:
       index:
         filter: فیلتر
         filters:

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -1006,7 +1006,7 @@ fr:
       search:
         title: Rechercher une organisation
         no_results: Aucune organisation trouvée.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtrer
         filters:

--- a/config/locales/gl/admin.yml
+++ b/config/locales/gl/admin.yml
@@ -1028,7 +1028,7 @@ gl:
       search:
         title: Buscar organizacións
         no_results: Non se atoparon organizacións.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/he/admin.yml
+++ b/config/locales/he/admin.yml
@@ -228,7 +228,7 @@ he:
         verify: Verify
       search:
         title: Search Organisations
-    proposals:
+    hidden_proposals:
       index:
         filter: Filter
         filters:

--- a/config/locales/id-ID/admin.yml
+++ b/config/locales/id-ID/admin.yml
@@ -738,7 +738,7 @@ id:
       search:
         title: Cari organisasi
         no_results: Tidak ada organisasi yang ditemukan.
-    proposals:
+    hidden_proposals:
       index:
         filters:
           with_confirmed_hide: Dikonfirmasi

--- a/config/locales/it/admin.yml
+++ b/config/locales/it/admin.yml
@@ -1009,7 +1009,7 @@ it:
       search:
         title: Cerca Organizzazioni
         no_results: Nessuna organizzazione trovata.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtra
         filters:

--- a/config/locales/nl/admin.yml
+++ b/config/locales/nl/admin.yml
@@ -1010,7 +1010,7 @@ nl:
       search:
         title: Zoek Organisaties
         no_results: Geen organisaties gevonden.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filter
         filters:

--- a/config/locales/pl-PL/admin.yml
+++ b/config/locales/pl-PL/admin.yml
@@ -1014,7 +1014,7 @@ pl:
       search:
         title: Szukaj organizacji
         no_results: Nie znaleziono organizacji.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtr
         filters:

--- a/config/locales/pt-BR/admin.yml
+++ b/config/locales/pt-BR/admin.yml
@@ -1013,7 +1013,7 @@ pt-BR:
       search:
         title: Buscar Organizações
         no_results: Nenhuma organização encontrada.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtro
         filters:

--- a/config/locales/sq-AL/admin.yml
+++ b/config/locales/sq-AL/admin.yml
@@ -1013,7 +1013,7 @@ sq:
       search:
         title: Kërko Organizatat
         no_results: Asnjë organizatë nuk u gjet.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtër
         filters:

--- a/config/locales/sv-SE/admin.yml
+++ b/config/locales/sv-SE/admin.yml
@@ -1008,7 +1008,7 @@ sv:
       search:
         title: Sök organisationer
         no_results: Inga organisationer.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtrera
         filters:

--- a/config/locales/val/admin.yml
+++ b/config/locales/val/admin.yml
@@ -970,7 +970,7 @@ val:
       search:
         title: Cercar Organitzacions
         no_results: No s'han trobat organitzacions.
-    proposals:
+    hidden_proposals:
       index:
         filter: Filtre
         filters:

--- a/config/locales/zh-CN/admin.yml
+++ b/config/locales/zh-CN/admin.yml
@@ -1007,7 +1007,7 @@ zh-CN:
       search:
         title: 搜索组织
         no_results: 未找到任何组织。
-    proposals:
+    hidden_proposals:
       index:
         filter: 过滤器
         filters:

--- a/config/locales/zh-TW/admin.yml
+++ b/config/locales/zh-TW/admin.yml
@@ -1010,7 +1010,7 @@ zh-TW:
       search:
         title: 搜尋組織
         no_results: 未找到任何組織。
-    proposals:
+    hidden_proposals:
       index:
         filter: 篩選器
         filters:

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -29,7 +29,7 @@ namespace :admin do
     end
   end
 
-  resources :proposals, only: :index do
+  resources :hidden_proposals, only: :index do
     member do
       put :restore
       put :confirm_hide

--- a/spec/features/admin/activity_spec.rb
+++ b/spec/features/admin/activity_spec.rb
@@ -53,7 +53,7 @@ feature 'Admin activity' do
     scenario "Shows admin restores" do
       proposal = create(:proposal, :hidden)
 
-      visit admin_proposals_path
+      visit admin_hidden_proposals_path
 
       within("#proposal_#{proposal.id}") do
         click_on "Restore"

--- a/spec/features/admin/hidden_proposals_spec.rb
+++ b/spec/features/admin/hidden_proposals_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Admin proposals' do
+feature 'Admin hidden proposals' do
 
   background do
     admin = create(:administrator)
@@ -12,14 +12,14 @@ feature 'Admin proposals' do
     admin = create(:administrator)
     login_as(admin.user)
 
-    expect{ visit admin_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
+    expect{ visit admin_hidden_proposals_path }.to raise_exception(FeatureFlags::FeatureDisabled)
 
     Setting['feature.proposals'] = true
   end
 
   scenario 'List shows all relevant info' do
     proposal = create(:proposal, :hidden)
-    visit admin_proposals_path
+    visit admin_hidden_proposals_path
 
     expect(page).to have_content(proposal.title)
     expect(page).to have_content(proposal.summary)
@@ -31,7 +31,7 @@ feature 'Admin proposals' do
 
   scenario 'Restore' do
     proposal = create(:proposal, :hidden)
-    visit admin_proposals_path
+    visit admin_hidden_proposals_path
 
     click_link 'Restore'
 
@@ -43,7 +43,7 @@ feature 'Admin proposals' do
 
   scenario 'Confirm hide' do
     proposal = create(:proposal, :hidden)
-    visit admin_proposals_path
+    visit admin_hidden_proposals_path
 
     click_link 'Confirm moderation'
 
@@ -55,22 +55,22 @@ feature 'Admin proposals' do
   end
 
   scenario "Current filter is properly highlighted" do
-    visit admin_proposals_path
+    visit admin_hidden_proposals_path
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
     expect(page).to have_link('Confirmed')
 
-    visit admin_proposals_path(filter: 'Pending')
+    visit admin_hidden_proposals_path(filter: 'Pending')
     expect(page).not_to have_link('Pending')
     expect(page).to have_link('All')
     expect(page).to have_link('Confirmed')
 
-    visit admin_proposals_path(filter: 'all')
+    visit admin_hidden_proposals_path(filter: 'all')
     expect(page).to have_link('Pending')
     expect(page).not_to have_link('All')
     expect(page).to have_link('Confirmed')
 
-    visit admin_proposals_path(filter: 'with_confirmed_hide')
+    visit admin_hidden_proposals_path(filter: 'with_confirmed_hide')
     expect(page).to have_link('All')
     expect(page).to have_link('Pending')
     expect(page).not_to have_link('Confirmed')
@@ -80,15 +80,15 @@ feature 'Admin proposals' do
     create(:proposal, :hidden, title: "Unconfirmed proposal")
     create(:proposal, :hidden, :with_confirmed_hide, title: "Confirmed proposal")
 
-    visit admin_proposals_path(filter: 'pending')
+    visit admin_hidden_proposals_path(filter: 'pending')
     expect(page).to have_content('Unconfirmed proposal')
     expect(page).not_to have_content('Confirmed proposal')
 
-    visit admin_proposals_path(filter: 'all')
+    visit admin_hidden_proposals_path(filter: 'all')
     expect(page).to have_content('Unconfirmed proposal')
     expect(page).to have_content('Confirmed proposal')
 
-    visit admin_proposals_path(filter: 'with_confirmed_hide')
+    visit admin_hidden_proposals_path(filter: 'with_confirmed_hide')
     expect(page).not_to have_content('Unconfirmed proposal')
     expect(page).to have_content('Confirmed proposal')
   end
@@ -97,7 +97,7 @@ feature 'Admin proposals' do
     per_page = Kaminari.config.default_per_page
     (per_page + 2).times { create(:proposal, :hidden, :with_confirmed_hide) }
 
-    visit admin_proposals_path(filter: 'with_confirmed_hide', page: 2)
+    visit admin_hidden_proposals_path(filter: 'with_confirmed_hide', page: 2)
 
     click_on('Restore', match: :first, exact: true)
 


### PR DESCRIPTION
## References

* Issue consul#2740

## Objectives

Change the name of the `Admin::Proposals` controller, since it's there to manage hidden proposals and we're going to introduce a new "Proposals" section in the administration.

## Does this PR need a Backport to CONSUL?

Yes.