### PR TITLE
Use `Date.current` instead of `Date.today`

### DIFF
--- a/spec/lib/tasks/milestones_spec.rb
+++ b/spec/lib/tasks/milestones_spec.rb
@@ -47,7 +47,7 @@ describe "Milestones tasks" do
       expect(status.description).to eq "Good"
       expect(status.hidden_at).to be nil
       expect(status.created_at.to_date).to eq Date.yesterday
-      expect(status.updated_at.to_date).to eq Date.today
+      expect(status.updated_at.to_date).to eq Date.current
     end
 
     it "migrates milestones" do
@@ -63,7 +63,7 @@ describe "Milestones tasks" do
       expect(milestone.publication_date).to eq Date.yesterday
       expect(milestone.status_id).to eq Milestone::Status.first.id
       expect(milestone.created_at.to_date).to eq Date.yesterday
-      expect(milestone.updated_at.to_date).to eq Date.today
+      expect(milestone.updated_at.to_date).to eq Date.current
     end
 
     it "Updates the primary key sequence correctly" do


### PR DESCRIPTION
## References

* Pull request #1698

## Objectives

Fix a test which was failing depending on the time zone of the machine where it was being executed.

## Does this PR need a Backport to CONSUL?

Yes.
