### PR TITLE
Fix scope warning

### DIFF
--- a/app/views/welcome/_cards.html.erb
+++ b/app/views/welcome/_cards.html.erb
@@ -1,7 +1,7 @@
 <h3 class="title"><%= t("welcome.cards.title") %></h3>
 
 <div class="row" data-equalizer data-equalizer-on="medium">
-  <% @cards.find_each do |card| %>
+  <% @cards.each do |card| %>
     <%= render "card", card: card %>
   <% end %>
 </div>


### PR DESCRIPTION
## References

* Pull request #1566

## Objectives

* Fix the `WARN Scoped order and limit are ignored, it's forced to be batch order and batch size` message we were getting in the specs
* Order widget cards by `created_at` instead of `id`; the order we were setting in `Widget::Card.body` was being overwritten when we used `find_each`

## Does this PR need a Backport to CONSUL?

Yes.