### PR TITLE
Update milestone status texts

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -132,7 +132,7 @@ en:
         image: "Proposal descriptive image"
         image_title: "Image title"
       milestone:
-        status_id: "Current investment status (optional)"
+        status_id: "Current status (optional)"
         title: "Title"
         description: "Description (optional if there's an status assigned)"
         publication_date: "Publication date"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -276,8 +276,8 @@ en:
         milestone: Milestone
         new_milestone: Create new milestone
       form:
-        admin_statuses: Admin investment statuses
-        no_statuses_defined: There are no defined investment statuses yet
+        admin_statuses: Manage statuses
+        no_statuses_defined: There are no defined statuses yet
       new:
         creating: Create milestone
         date: Date

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -132,7 +132,7 @@ es:
         image: "Imagen descriptiva del proyecto de gasto"
         image_title: "Título de la imagen"
       milestone:
-        status_id: "Estado actual del proyecto (opcional)"
+        status_id: "Estado actual (opcional)"
         title: "Título"
         description: "Descripción (opcional si hay un estado asignado)"
         publication_date: "Fecha de publicación"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -276,7 +276,7 @@ es:
         milestone: Seguimiento
         new_milestone: Crear nuevo hito
       form:
-        admin_statuses: Gestionar estados de proyectos
+        admin_statuses: Gestionar estados
         no_statuses_defined: No hay estados definidos
       new:
         creating: Crear hito

--- a/spec/shared/features/milestoneable.rb
+++ b/spec/shared/features/milestoneable.rb
@@ -52,7 +52,6 @@ shared_examples "milestoneable" do |factory_name, path_name|
     end
 
     scenario "Show no_milestones text", :js do
-      create(:budget_investment)
       login_as(create(:user))
 
       visit path


### PR DESCRIPTION
## References

* Pull Request #1698

## Objectives

Update milestone status texts so they don't make reference to budget investments, since milestones are now polymorphic.

## Visual changes

### Before

![Reference to investment](https://user-images.githubusercontent.com/35156/49159926-de141e00-f325-11e8-94e7-ac539b34eaa2.png)

### After

![No reference to investment](https://user-images.githubusercontent.com/35156/49159931-e0767800-f325-11e8-94e9-b54e49569338.png)

## Does this PR need a Backport to CONSUL?

Yes.