### PR TITLE
Edit only existing languages in milestones summary

### DIFF
--- a/app/views/admin/legislation/milestones/_summary_form.html.erb
+++ b/app/views/admin/legislation/milestones/_summary_form.html.erb
@@ -1,4 +1,6 @@
-<%= render "admin/shared/globalize_locales", resource: @process %>
+<%= render "admin/shared/globalize_tabs",
+           resource: @process,
+           display_style: lambda { |locale| enable_translation_style(@process, locale) } %>
 
 <%= translatable_form_for [:admin, @process] do |f| %>
   <%= f.translatable_fields do |translations_form| %>

--- a/app/views/admin/shared/_common_globalize_locales.html.erb
+++ b/app/views/admin/shared/_common_globalize_locales.html.erb
@@ -8,17 +8,7 @@
   </div>
 <% end %>
 
-<ul class="tabs" data-tabs id="globalize_locale">
-  <% I18n.available_locales.each do |locale| %>
-    <li class="tabs-title">
-      <%= link_to name_for_locale(locale), "#",
-                  style: display_style.call(locale),
-                  class: "js-globalize-locale-link #{highlight_class(resource, locale)}",
-                  data: { locale: locale },
-                  remote: true %>
-    </li>
-  <% end %>
-</ul>
+<%= render "admin/shared/globalize_tabs", resource: resource, display_style: display_style %>
 
 <div class="small-12 medium-6">
   <%= select_tag :translation_locale,

--- a/app/views/admin/shared/_globalize_tabs.html.erb
+++ b/app/views/admin/shared/_globalize_tabs.html.erb
@@ -1,0 +1,11 @@
+<ul class="tabs" data-tabs id="globalize_locale">
+  <% I18n.available_locales.each do |locale| %>
+    <li class="tabs-title">
+      <%= link_to name_for_locale(locale), "#",
+                  style: display_style.call(locale),
+                  class: "js-globalize-locale-link #{highlight_class(resource, locale)}",
+                  data: { locale: locale },
+                  remote: true %>
+    </li>
+  <% end %>
+</ul>

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -149,6 +149,9 @@ feature 'Admin legislation processes' do
     scenario "Edit milestones summary", :js do
       visit admin_legislation_process_milestones_path(process)
 
+      expect(page).not_to have_link "Remove language"
+      expect(page).not_to have_field "translation_locale"
+
       within(".translatable-fields[data-locale='en']") do
         fill_in_ckeditor find("textarea", visible: false)[:id],
                          with: "There is still a long journey ahead of us"


### PR DESCRIPTION
## References

* Pull request #1717

## Objectives

Avoid validation errors when trying to add a new language for the milestones summary form. Languages should be added from the "infomation" form, and thie milestones summary form should be used to edit existing languages.

## Visual Changes

### Before

![Options to add and remove languages](https://user-images.githubusercontent.com/35156/49161622-82e42a80-f329-11e8-9cf4-a1ca6c39a932.png)

### After

![No options to add and remove languages](https://user-images.githubusercontent.com/35156/49161652-92637380-f329-11e8-984e-79c91941145e.png)

## Does this PR need a Backport to CONSUL?

Yes.
