### PR TITLE
Add pending specs: Proposal Notifications Limits

### DIFF
--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -360,7 +360,7 @@ en:
         proposal_notification:
           attributes:
             minimum_interval:
-              invalid: "You have to wait a minium of %{interval} days between notifications"
+              invalid: "You have to wait a minimum of %{interval} days between notifications"
         signature:
           attributes:
             document_number:

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -399,7 +399,7 @@ feature 'Proposal Notifications' do
       fill_in "Message", with: "Please share it again with others so we can make it happen!"
       click_button "Send message"
 
-      expect(page).to have_content "You have to wait a minium of 3 days between notifications"
+      expect(page).to have_content "You have to wait a minimum of 3 days between notifications"
       expect(page).not_to have_content "Your message has been sent correctly."
     end
 
@@ -424,7 +424,7 @@ feature 'Proposal Notifications' do
       click_button "Send message"
 
       expect(page).to have_content "Your message has been sent correctly."
-      expect(page).not_to have_content "You have to wait a minium of 3 days between notifications"
+      expect(page).not_to have_content "You have to wait a minimum of 3 days between notifications"
 
       travel_back
     end

--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -381,8 +381,53 @@ feature 'Proposal Notifications' do
 
   context "Limits" do
 
-    pending "Cannot send more than one notification within established interval"
-    pending "use timecop to make sure notifications can be sent after time interval"
+    scenario "Cannot send more than one notification within established interval" do
+      author = create(:user)
+      proposal = create(:proposal, author: author)
+
+      login_as author.reload
+
+      visit new_proposal_notification_path(proposal_id: proposal.id)
+      fill_in "Title", with: "Thank you for supporting my proposal"
+      fill_in "Message", with: "Please share it with others so we can make it happen!"
+      click_button "Send message"
+
+      expect(page).to have_content "Your message has been sent correctly."
+
+      visit new_proposal_notification_path(proposal_id: proposal.id)
+      fill_in "Title", with: "Thank you again for supporting my proposal"
+      fill_in "Message", with: "Please share it again with others so we can make it happen!"
+      click_button "Send message"
+
+      expect(page).to have_content "You have to wait a minium of 3 days between notifications"
+      expect(page).not_to have_content "Your message has been sent correctly."
+    end
+
+    scenario "Use time traveling to make sure notifications can be sent after time interval" do
+      author = create(:user)
+      proposal = create(:proposal, author: author)
+
+      login_as author.reload
+
+      visit new_proposal_notification_path(proposal_id: proposal.id)
+      fill_in "Title", with: "Thank you for supporting my proposal"
+      fill_in "Message", with: "Please share it with others so we can make it happen!"
+      click_button "Send message"
+
+      expect(page).to have_content "Your message has been sent correctly."
+
+      travel 3.days + 1.second
+
+      visit new_proposal_notification_path(proposal_id: proposal.id)
+      fill_in "Title", with: "Thank you again for supporting my proposal"
+      fill_in "Message", with: "Please share it again with others so we can make it happen!"
+      click_button "Send message"
+
+      expect(page).to have_content "Your message has been sent correctly."
+      expect(page).not_to have_content "You have to wait a minium of 3 days between notifications"
+
+      travel_back
+    end
 
   end
 

--- a/spec/models/proposal_notification_spec.rb
+++ b/spec/models/proposal_notification_spec.rb
@@ -50,7 +50,7 @@ describe ProposalNotification do
       Setting[:proposal_notification_minimum_interval_in_days] = 3
     end
 
-    it "is not valid if below minium interval" do
+    it "is not valid if below minimum interval" do
       proposal = create(:proposal)
 
       notification1 = create(:proposal_notification, proposal: proposal)
@@ -60,7 +60,7 @@ describe ProposalNotification do
       expect(notification2).not_to be_valid
     end
 
-    it "is valid if notifications above minium interval" do
+    it "is valid if notifications above minimum interval" do
       proposal = create(:proposal)
 
       notification1 = create(:proposal_notification, proposal: proposal, created_at: 4.days.ago)


### PR DESCRIPTION
in `./spec/features/proposal_notifications_spec.rb` add the specs:

- Proposal Notifications Limits Cannot send more than one notification
  within established interval

- Proposal Notifications Limit use time traveling to make sure notifications
  can be sent after time interval

## Does this PR need a Backport to CONSUL?
Yes