### PR TITLE
[Upstream] Add missing feature spec: Proposal Notifications In-app notifications from the proposal's author group notifications for the same proposal

### DIFF
--- a/spec/features/proposal_notifications_spec.rb
+++ b/spec/features/proposal_notifications_spec.rb
@@ -364,7 +364,48 @@ feature 'Proposal Notifications' do
       visit new_proposal_notification_path(proposal_id: proposal.id)
     end
 
-    pending "group notifications for the same proposal"
+    context "Group notifications" do
+
+      background do
+        Setting[:proposal_notification_minimum_interval_in_days] = 0
+      end
+
+      after do
+        Setting[:proposal_notification_minimum_interval_in_days] = 3
+      end
+
+      scenario "for the same proposal", :js do
+        author = create(:user)
+        user = create(:user)
+
+        proposal = create(:proposal, author: author)
+
+        create(:follow, :followed_proposal, user: user, followable: proposal)
+
+        login_as author.reload
+
+        3.times do
+          visit new_proposal_notification_path(proposal_id: proposal.id)
+
+          fill_in "Title", with: "Thank you for supporting my proposal"
+          fill_in "Message", with: "Please share it with others so we can make it happen!"
+          click_button "Send message"
+
+          expect(page).to have_content "Your message has been sent correctly."
+        end
+
+        logout
+        login_as user.reload
+        visit root_path
+
+        within("#notifications") { expect(page).to have_content :all, "You have 3 new notifications" }
+        find(".icon-notification").click
+
+        expect(page).to have_css ".notification", count: 3
+        expect(page).to have_content "There is one new notification on #{proposal.title}", count: 3
+      end
+    end
+
   end
 
   scenario "Error messages" do


### PR DESCRIPTION
## References
https://github.com/consul/consul/pull/3066
