### PR TITLE
Check recipient of newsletter before resending

### DIFF
--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -92,6 +92,19 @@ describe Newsletter do
       expect(ActionMailer::Base.deliveries.count).to eq(3)
     end
 
+    it "only sends the newsletter once to each user" do
+      newsletter.deliver
+      newsletter.deliver
+
+      recipients.each do |recipient|
+        email = Mailer.newsletter(newsletter, recipient)
+        expect(email).to deliver_to(recipient)
+      end
+
+      Delayed::Job.all.map(&:invoke_job)
+      expect(ActionMailer::Base.deliveries.count).to eq(3)
+    end
+
     it "sends emails in batches" do
       allow(newsletter).to receive(:batch_size).and_return(1)
 


### PR DESCRIPTION
## Objectives

We have seen a problem if the delayed_job that is processing the newsletter stops, for some reason, and is restarted. In that case the newsletter email was being send twice to the same users.

With this PR we are checking if the user has already received the newsletter and in that case we skip the delivery.

## Does this PR need a Backport to CONSUL?

Yes, this will be useful in CONSUL
