### PR TITLE
Proposals support on mobile

### DIFF
--- a/app/assets/javascripts/foundation_extras.js.coffee
+++ b/app/assets/javascripts/foundation_extras.js.coffee
@@ -4,3 +4,8 @@ App.FoundationExtras =
     $(document).foundation()
     $(window).trigger "load.zf.sticky"
     $(window).trigger "resize"
+
+    clearSticky = ->
+      $("[data-sticky]").foundation("destroy") if $("[data-sticky]").length
+
+    $(document).on("page:before-unload", clearSticky)

--- a/app/assets/javascripts/foundation_extras.js.coffee
+++ b/app/assets/javascripts/foundation_extras.js.coffee
@@ -2,7 +2,6 @@ App.FoundationExtras =
 
   initialize: ->
     $(document).foundation()
-    $(window).trigger "init.zf.sticky"
     $(window).trigger "resize"
 
     clearSticky = ->
@@ -11,3 +10,15 @@ App.FoundationExtras =
     $(document).on("page:before-unload", clearSticky)
 
     window.addEventListener("popstate", clearSticky, false)
+
+    mobile_ui_init = ->
+      $(window).trigger "load.zf.sticky"
+
+    desktop_ui_init = ->
+      $(window).trigger "init.zf.sticky"
+
+    $ ->
+      if $(window).width() < 620
+        do mobile_ui_init
+      else
+        do desktop_ui_init

--- a/app/assets/javascripts/foundation_extras.js.coffee
+++ b/app/assets/javascripts/foundation_extras.js.coffee
@@ -9,3 +9,5 @@ App.FoundationExtras =
       $("[data-sticky]").foundation("destroy") if $("[data-sticky]").length
 
     $(document).on("page:before-unload", clearSticky)
+
+    window.addEventListener("popstate", clearSticky, false)

--- a/app/assets/javascripts/foundation_extras.js.coffee
+++ b/app/assets/javascripts/foundation_extras.js.coffee
@@ -3,3 +3,4 @@ App.FoundationExtras =
   initialize: ->
     $(document).foundation()
     $(window).trigger "load.zf.sticky"
+    $(window).trigger "resize"

--- a/app/assets/javascripts/foundation_extras.js.coffee
+++ b/app/assets/javascripts/foundation_extras.js.coffee
@@ -2,7 +2,7 @@ App.FoundationExtras =
 
   initialize: ->
     $(document).foundation()
-    $(window).trigger "load.zf.sticky"
+    $(window).trigger "init.zf.sticky"
     $(window).trigger "resize"
 
     clearSticky = ->

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -455,6 +455,11 @@ header {
   border-bottom: 1px solid $border;
   margin-bottom: $line-height;
 
+  @include breakpoint(small down) {
+    position: relative;
+    z-index: 10;
+  }
+
   .selected {
     border-bottom: 1px solid #fff;
   }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2684,6 +2684,12 @@ table {
   }
 }
 
+.leaflet-bottom,
+.leaflet-pane,
+.leaflet-top {
+  z-index: 4 !important;
+}
+
 // 24. Homepage
 // ------------
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -454,8 +454,6 @@ header {
   background: $brand;
   border-bottom: 1px solid $border;
   margin-bottom: $line-height;
-  position: relative;
-  z-index: 10;
 
   .selected {
     border-bottom: 1px solid #fff;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1100,9 +1100,12 @@ form {
 
 .notice-container {
   min-width: $line-height * 12;
-  position: absolute;
   right: 24px;
   top: 24px;
+
+  @include breakpoint(medium) {
+    position: absolute;
+  }
 
   .notice {
     height: $line-height * 4;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -454,6 +454,8 @@ header {
   background: $brand;
   border-bottom: 1px solid $border;
   margin-bottom: $line-height;
+  position: relative;
+  z-index: 10;
 
   .selected {
     border-bottom: 1px solid #fff;

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -550,6 +550,15 @@
   }
 }
 
+.fixed-mobile-content {
+
+  @include breakpoint(medium down) {
+    background: #fff;
+    margin-bottom: rem-calc(-1) !important;
+    padding-top: $line-height / 2;
+  }
+}
+
 // 04. List participation
 // ----------------------
 

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -77,7 +77,8 @@
                  data-stick-to="bottom"
                  data-sticky-on="small"
                  data-top-anchor="0"
-                 data-btm-anchor="sticky_stop:top">
+                 data-btm-anchor="sticky_stop"
+                 data-check-every="0">
               <div class="fixed-mobile-content">
                 <div class="sidebar-divider"></div>
                 <h2><%= t("votes.supports") %></h2>

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -71,29 +71,43 @@
             </div>
           <% end %>
 
-          <div class="sidebar-divider"></div>
-          <h2><%= t("votes.supports") %></h2>
-          <div id="<%= dom_id(@proposal) %>_votes">
-            <% if @proposal.draft? %>
-              <div class="callout primary">
-                <p class="small"><%= t("proposals.show.draft") %></p>
+          <div id="proposal_sticky" data-sticky-container>
+            <div class="fixed-mobile-content"
+                 data-sticky
+                 data-stick-to="bottom"
+                 data-sticky-on="small"
+                 data-top-anchor="0"
+                 data-btm-anchor="sticky_stop:top">
+              <div class="fixed-mobile-content">
+                <div class="sidebar-divider"></div>
+                <h2><%= t("votes.supports") %></h2>
+
+                <div id="<%= dom_id(@proposal) %>_votes">
+                  <% if @proposal.draft? %>
+                    <div class="callout primary">
+                      <p class="small"><%= t("proposals.show.draft") %></p>
+                    </div>
+                  <% elsif @proposal.successful? %>
+                    <p>
+                      <%= t("proposals.proposal.successful") %>
+                    </p>
+                  <% elsif @proposal.archived? %>
+                    <div class="padding text-center">
+                      <p>
+                        <strong><%= t("proposals.proposal.supports", count: @proposal.total_votes) %></strong>
+                      </p>
+                      <p><%= t("proposals.proposal.archived") %></p>
+                    </div>
+                  <% else %>
+                    <%= render "votes",
+                              { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: "yes") } %>
+                  <% end %>
+                </div>
               </div>
-            <% elsif @proposal.successful? %>
-              <p>
-                <%= t("proposals.proposal.successful") %>
-              </p>
-            <% elsif @proposal.archived? %>
-              <div class="padding text-center">
-                <p>
-                  <strong><%= t("proposals.proposal.supports", count: @proposal.total_votes) %></strong>
-                </p>
-                <p><%= t("proposals.proposal.archived") %></p>
-              </div>
-            <% else %>
-              <%= render "votes",
-                        { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: "yes") } %>
-            <% end %>
+            </div>
           </div>
+
+          <div id="sticky_stop"></div>
 
           <%= render "proposals/social_share", proposal: @proposal, share_title: t("proposals.show.share") %>
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -67,7 +67,8 @@
                  data-sticky
                  data-stick-to="bottom"
                  data-sticky-on="small"
-                 data-btm-anchor="sticky_stop:top">
+                 data-btm-anchor="sticky_stop"
+                 data-check-every="0">
               <div class="sidebar-divider"></div>
               <h2><%= t("votes.supports") %></h2>
               <div id="<%= dom_id(@proposal) %>_votes">

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -62,29 +62,39 @@
             </div>
           <% end %>
 
-          <div class="sidebar-divider"></div>
-          <h2><%= t("votes.supports") %></h2>
-          <div id="<%= dom_id(@proposal) %>_votes">
-            <% if @proposal.draft? %>
-              <div class="callout primary">
-                <p class=text-center><strong><%= t('.draft') %></strong></p>
+          <div data-sticky-container>
+            <div class="sticky fixed-mobile-content"
+                 data-sticky
+                 data-stick-to="bottom"
+                 data-sticky-on="small"
+                 data-btm-anchor="sticky_stop:top">
+              <div class="sidebar-divider"></div>
+              <h2><%= t("votes.supports") %></h2>
+              <div id="<%= dom_id(@proposal) %>_votes">
+                <% if @proposal.draft? %>
+                  <div class="callout primary">
+                    <p class=text-center><strong><%= t('.draft') %></strong></p>
+                  </div>
+                <% elsif @proposal.successful? %>
+                  <p>
+                    <%= t("proposals.proposal.successful") %>
+                  </p>
+                <% elsif @proposal.archived? %>
+                  <div class="padding text-center">
+                    <p>
+                      <strong><%= t("proposals.proposal.supports", count: @proposal.total_votes) %></strong>
+                    </p>
+                    <p><%= t("proposals.proposal.archived") %></p>
+                  </div>
+                <% else %>
+                  <%= render "votes",
+                            { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: "yes") } %>
+                <% end %>
               </div>
-            <% elsif @proposal.successful? %>
-              <p>
-                <%= t("proposals.proposal.successful") %>
-              </p>
-            <% elsif @proposal.archived? %>
-              <div class="padding text-center">
-                <p>
-                  <strong><%= t("proposals.proposal.supports", count: @proposal.total_votes) %></strong>
-                </p>
-                <p><%= t("proposals.proposal.archived") %></p>
-              </div>
-            <% else %>
-              <%= render "votes",
-                        { proposal: @proposal, vote_url: vote_proposal_path(@proposal, value: "yes") } %>
-            <% end %>
+            </div>
           </div>
+
+          <div id="sticky_stop"></div>
 
           <%= render "proposals/social_share", proposal: @proposal, share_title: t("proposals.show.share") %>
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -181,6 +181,27 @@ describe "Proposals" do
     end
   end
 
+  context "Show on mobile screens" do
+
+    before do
+      Capybara.page.driver.browser.manage.window.resize_to(640, 480)
+    end
+
+    after do
+      Capybara.page.driver.browser.manage.window.maximize
+    end
+
+    scenario "Show support button sticky at bottom", :js do
+      proposal = create(:proposal)
+      visit proposal_path(proposal)
+
+      within("#proposal_sticky") do
+        expect(page).to have_css(".is-stuck")
+        expect(page).not_to have_css(".is-anchored")
+      end
+    end
+  end
+
   context "Embedded video" do
 
     scenario "Show YouTube video" do


### PR DESCRIPTION
## Objectives

Uses [Foundation sticky](https://foundation.zurb.com/sites/docs/sticky.html) on proposals supports button to show on mobile version.

## Visual Changes

Before, on proposals it was necessary a large amount of scroll to reach the support button (CTA) 😅 

![before](https://user-images.githubusercontent.com/631897/49542481-02e43480-f8d6-11e8-8967-713788b91374.png)

Now the button appears sticky to bottom until the user scroll to comments 🎉 

![after](https://user-images.githubusercontent.com/631897/49542520-1e4f3f80-f8d6-11e8-88aa-351103cd21ae.gif)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.