### PR TITLE
Draft phase on legislation processes

### DIFF
--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -50,8 +50,8 @@ class Legislation::Process < ActiveRecord::Base
 
   scope :published, -> { where(published: true) }
   scope :not_in_draft, -> { where("draft_phase_enabled = false or (draft_start_date IS NOT NULL and
-                                   draft_end_date IS NOT NULL and (draft_start_date >= ? or
-                                   draft_end_date <= ?))", Date.current, Date.current) }
+                                   draft_end_date IS NOT NULL and (draft_start_date > ? or
+                                   draft_end_date < ?))", Date.current, Date.current) }
 
   def draft_phase
     Legislation::Process::Phase.new(draft_start_date, draft_end_date, draft_phase_enabled)

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -99,14 +99,6 @@ describe Legislation::Process do
                                               end_date: Date.current + 3.days) }
     let!(:process_3) { create(:legislation_process, start_date: Date.current - 4.days,
                                               end_date: Date.current - 3.days) }
-    let!(:process_4) { create(:legislation_process, draft_start_date: Date.current - 3.days,
-                                              draft_end_date: Date.current - 2.days) }
-    let!(:process_5) { create(:legislation_process, draft_start_date: Date.current - 2.days,
-                                              draft_end_date: Date.current + 2.days,
-                                              draft_phase_enabled: false) }
-    let!(:process_6) { create(:legislation_process, draft_start_date: Date.current - 2.days,
-                                              draft_end_date: Date.current + 2.days,
-                                              draft_phase_enabled: true) }
 
     it "filters open" do
       open_processes = ::Legislation::Process.open
@@ -117,11 +109,39 @@ describe Legislation::Process do
     end
 
     it "filters draft phase" do
-      draft_processes = ::Legislation::Process.not_in_draft
+      process_before_draft = create(
+        :legislation_process,
+        draft_start_date: Date.current - 3.days,
+        draft_end_date: Date.current - 2.days
+      )
 
-      expect(draft_processes).to include(process_4)
-      expect(draft_processes).to include(process_5)
-      expect(draft_processes).not_to include(process_6)
+      process_with_draft_disabled = create(
+        :legislation_process,
+        draft_start_date: Date.current - 2.days,
+        draft_end_date: Date.current + 2.days,
+        draft_phase_enabled: false
+      )
+
+      process_with_draft_enabled = create(
+        :legislation_process,
+        draft_start_date: Date.current - 2.days,
+        draft_end_date: Date.current + 2.days,
+        draft_phase_enabled: true
+      )
+
+      process_with_draft_only_today = create(
+        :legislation_process,
+        draft_start_date: Date.current,
+        draft_end_date: Date.current,
+        draft_phase_enabled: true
+      )
+
+      processes_not_in_draft = ::Legislation::Process.not_in_draft
+
+      expect(processes_not_in_draft).to include(process_before_draft)
+      expect(processes_not_in_draft).to include(process_with_draft_disabled)
+      expect(processes_not_in_draft).not_to include(process_with_draft_enabled)
+      expect(processes_not_in_draft).not_to include(process_with_draft_only_today)
     end
 
     it "filters next" do


### PR DESCRIPTION
## References

Previous PR: https://github.com/AyuntamientoMadrid/consul/pull/1741/

## Objectives

Hides process on index if draft dates match with date current. Before, on `scope :not_in_draft` if the `draft_start_date` or `draft_end_date` was matching with `Date.current` the process was showing on processes index page. We want to hide all processes with active draft phase.

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.
