### PR TITLE
[Upstream] Add not_to Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -336,9 +336,6 @@ RSpec/NestedGroups:
   Enabled: true
   Max: 4
 
-RSpec/NotToNot:
-  Enabled: true
-
 RSpec/OverwritingSetup:
   Enabled: true
 

--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -26,3 +26,6 @@ Layout/TrailingBlankLines:
 
 Layout/TrailingWhitespace:
   Enabled: true
+
+RSpec/NotToNot:
+  Enabled: true

--- a/spec/features/admin/poll/questions/answers/images/images_spec.rb
+++ b/spec/features/admin/poll/questions/answers/images/images_spec.rb
@@ -14,7 +14,7 @@ feature 'Images' do
 
       visit admin_answer_images_path(answer)
 
-      expect(page).to_not have_css("img[title='']")
+      expect(page).not_to have_css("img[title='']")
     end
 
     scenario 'Answer with images' do
@@ -35,8 +35,8 @@ feature 'Images' do
     image = create(:image)
 
     visit admin_answer_images_path(answer)
-    expect(page).to_not have_css("img[title='clippy.jpg']")
-    expect(page).to_not have_content('clippy.jpg')
+    expect(page).not_to have_css("img[title='clippy.jpg']")
+    expect(page).not_to have_content('clippy.jpg')
 
     visit new_admin_answer_image_path(answer)
     imageable_attach_new_file(image, Rails.root.join('spec/fixtures/files/clippy.jpg'))
@@ -59,8 +59,8 @@ feature 'Images' do
       click_link 'Remove image'
     end
 
-    expect(page).to_not have_css("img[title='#{image.title}']")
-    expect(page).to_not have_content(image.title)
+    expect(page).not_to have_css("img[title='#{image.title}']")
+    expect(page).not_to have_content(image.title)
   end
 
 end

--- a/spec/features/admin/valuator_groups_spec.rb
+++ b/spec/features/admin/valuator_groups_spec.rb
@@ -118,7 +118,7 @@ feature "Valuator groups" do
       click_button "Update valuator"
 
       expect(page).to have_content "Valuator updated successfully"
-      expect(page).to_not have_content "Health"
+      expect(page).not_to have_content "Health"
     end
 
   end

--- a/spec/features/budget_polls/officing_spec.rb
+++ b/spec/features/budget_polls/officing_spec.rb
@@ -54,7 +54,7 @@ feature 'Budget Poll Officing' do
       login_as user
       visit officing_root_path
 
-      expect(page).to_not have_link("Decide Madrid Polling", href: "/officing")
+      expect(page).not_to have_link("Decide Madrid Polling", href: "/officing")
     end
 
     scenario "Polling officers header menu" do
@@ -64,7 +64,7 @@ feature 'Budget Poll Officing' do
       login_as user
       visit officing_root_path
 
-      expect(page).to_not have_link("Polling officers", href: "/officing")
+      expect(page).not_to have_link("Polling officers", href: "/officing")
     end
 
   end

--- a/spec/features/budget_polls/questions_spec.rb
+++ b/spec/features/budget_polls/questions_spec.rb
@@ -16,7 +16,7 @@ feature "Poll Questions" do
     visit admin_questions_path
 
     expect(page).to have_select("poll_id", text: "Citizen Proposal Poll")
-    expect(page).to_not have_select("poll_id", text: "Participatory Budget Poll")
+    expect(page).not_to have_select("poll_id", text: "Participatory Budget Poll")
   end
 
 end

--- a/spec/features/budget_polls/voter_spec.rb
+++ b/spec/features/budget_polls/voter_spec.rb
@@ -155,7 +155,7 @@ feature "BudgetPolls", :with_frozen_time do
       expect(page).to have_content poll.name
 
       within("#side_menu") do
-        expect(page).to_not have_content("Validate document")
+        expect(page).not_to have_content("Validate document")
       end
 
       within("#poll_#{poll.id}") do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -367,8 +367,8 @@ feature 'Budgets' do
       expect(page).to have_css("#budget_heading_#{heading1.id}")
       expect(page).to have_css("#budget_heading_#{heading2.id}")
 
-      expect(page).to_not have_css("#budget_heading_#{heading3.id}")
-      expect(page).to_not have_css("#budget_heading_#{heading4.id}")
+      expect(page).not_to have_css("#budget_heading_#{heading3.id}")
+      expect(page).not_to have_css("#budget_heading_#{heading4.id}")
     end
 
     scenario "See results button is showed if the budget has finished for all users" do

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -60,7 +60,7 @@ feature 'Budget Investments' do
     investments.each do |investment|
       within('#budget-investments') do
         expect(page).to     have_link investment.title
-        expect(page).to_not have_content(investment.description)
+        expect(page).not_to have_content(investment.description)
       end
     end
 

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -79,7 +79,7 @@ feature 'Results' do
     scenario "Display links to finished budget results" do
       (Budget::Phase::PHASE_KINDS - ['finished']).each do |phase|
         budget = create(:budget, phase: phase)
-        expect(page).to_not have_css("#budget_#{budget.id}_results", text: "See results")
+        expect(page).not_to have_css("#budget_#{budget.id}_results", text: "See results")
       end
 
       finished_budget1 = create(:budget, phase: "finished")

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -59,7 +59,7 @@ feature 'Debates' do
     debates.each do |debate|
       within('#debates') do
         expect(page).to     have_link debate.title
-        expect(page).to_not have_content debate.description
+        expect(page).not_to have_content debate.description
       end
     end
 

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -153,7 +153,7 @@ feature 'Legislation' do
 
         visit legislation_process_path(process)
 
-        expect(page).to_not have_content("Additional information")
+        expect(page).not_to have_content("Additional information")
       end
 
       scenario "Shows another translation when the default locale isn't available" do
@@ -172,7 +172,7 @@ feature 'Legislation' do
         visit legislation_process_path(process)
 
         expect(page).to     have_content("This phase is not open yet")
-        expect(page).to_not have_content("Participate in the debate")
+        expect(page).not_to have_content("Participate in the debate")
       end
 
       scenario 'open without questions' do
@@ -180,8 +180,8 @@ feature 'Legislation' do
 
         visit legislation_process_path(process)
 
-        expect(page).to_not have_content("Participate in the debate")
-        expect(page).to_not have_content("This phase is not open yet")
+        expect(page).not_to have_content("Participate in the debate")
+        expect(page).not_to have_content("This phase is not open yet")
       end
 
       scenario 'open with questions' do
@@ -194,7 +194,7 @@ feature 'Legislation' do
         expect(page).to     have_content("Question 1")
         expect(page).to     have_content("Question 2")
         expect(page).to     have_content("Participate in the debate")
-        expect(page).to_not have_content("This phase is not open yet")
+        expect(page).not_to have_content("This phase is not open yet")
       end
 
       include_examples "not published permissions", :debate_legislation_process_path

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -20,7 +20,7 @@ feature "Notifications" do
     expect(page).to have_css(".notification", count: 2)
     expect(page).to have_content(read1.notifiable_title)
     expect(page).to have_content(read2.notifiable_title)
-    expect(page).to_not have_content(unread.notifiable_title)
+    expect(page).not_to have_content(unread.notifiable_title)
   end
 
   scenario "View unread" do
@@ -34,7 +34,7 @@ feature "Notifications" do
     expect(page).to have_css(".notification", count: 2)
     expect(page).to have_content(unread1.notifiable_title)
     expect(page).to have_content(unread2.notifiable_title)
-    expect(page).to_not have_content(read.notifiable_title)
+    expect(page).not_to have_content(read.notifiable_title)
   end
 
   scenario "View single notification" do
@@ -66,7 +66,7 @@ feature "Notifications" do
 
     expect(page).to have_css(".notification", count: 1)
     expect(page).to have_content(notification2.notifiable_title)
-    expect(page).to_not have_content(notification1.notifiable_title)
+    expect(page).not_to have_content(notification1.notifiable_title)
   end
 
   scenario "Mark all as read" do
@@ -113,7 +113,7 @@ feature "Notifications" do
     first(".notification a").click
 
     within("#notifications") do
-      expect(page).to_not have_css(".icon-circle")
+      expect(page).not_to have_css(".icon-circle")
     end
   end
 
@@ -126,7 +126,7 @@ feature "Notifications" do
     logout
     visit root_path
 
-    expect(page).to_not have_css("#notifications")
+    expect(page).not_to have_css("#notifications")
   end
 
   scenario "Notification's notifiable model no longer includes Notifiable module" do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -67,7 +67,7 @@ feature 'Proposals' do
       proposals.each do |proposal|
         within('#proposals') do
           expect(page).to     have_link proposal.title
-          expect(page).to_not have_content proposal.summary
+          expect(page).not_to have_content proposal.summary
         end
       end
 

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -208,7 +208,7 @@ feature 'Users' do
         click_link 'Cancel login'
 
         visit '/'
-        expect_to_not_be_signed_in
+        expect_not_to_be_signed_in
       end
 
       scenario 'Sign in, user was already signed up with OAuth' do

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -41,7 +41,7 @@ feature 'Vote via email' do
         expect(page).to_not have_selector ".in-favor a"
       end
 
-      expect_to_not_be_signed_in
+      expect_not_to_be_signed_in
     end
 
     scenario 'Verified user with invalid token' do

--- a/spec/features/vote_via_email_spec.rb
+++ b/spec/features/vote_via_email_spec.rb
@@ -23,7 +23,7 @@ feature 'Vote via email' do
 
       within('.supports') do
         expect(page).to have_content "1 support"
-        expect(page).to_not have_selector ".in-favor a"
+        expect(page).not_to have_selector ".in-favor a"
       end
 
       expect_to_be_signed_in
@@ -38,7 +38,7 @@ feature 'Vote via email' do
 
       within('.supports') do
         expect(page).to have_content "1 support"
-        expect(page).to_not have_selector ".in-favor a"
+        expect(page).not_to have_selector ".in-favor a"
       end
 
       expect_not_to_be_signed_in

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -230,32 +230,32 @@ describe UserSegments do
       expect(described_class).to respond_to("new_york")
       expect(described_class).to respond_to("california")
       expect(described_class).to respond_to("mars")
-      expect(described_class).to_not respond_to("jupiter")
+      expect(described_class).not_to respond_to("jupiter")
     end
 
     it "includes geozones in available segments" do
       expect(described_class.segments).to include("new_york")
       expect(described_class.segments).to include("california")
       expect(described_class.segments).to include("mars")
-      expect(described_class.segments).to_not include("jupiter")
+      expect(described_class.segments).not_to include("jupiter")
     end
 
     it "does not include the generic city as a segment" do
-      expect(described_class.segments).to_not include("city")
+      expect(described_class.segments).not_to include("city")
     end
 
     it "returns users of a geozone" do
       expect(described_class.new_york).to include(user1)
       expect(described_class.new_york).to include(user2)
-      expect(described_class.new_york).to_not include(user3)
-      expect(described_class.new_york).to_not include(user4)
+      expect(described_class.new_york).not_to include(user3)
+      expect(described_class.new_york).not_to include(user4)
     end
 
     it "only returns active users of a geozone" do
       user2.update(erased_at: Time.current)
 
       expect(described_class.new_york).to include(user1)
-      expect(described_class.new_york).to_not include(user2)
+      expect(described_class.new_york).not_to include(user2)
     end
 
   end

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -343,9 +343,9 @@ describe Budget::Investment do
 
       investments_by_budget = Budget::Investment.by_budget(budget1)
 
-       expect(investments_by_budget).to include investment1
-       expect(investments_by_budget).to include investment2
-       expect(investments_by_budget).not_to include investment3
+      expect(investments_by_budget).to include investment1
+      expect(investments_by_budget).to include investment2
+      expect(investments_by_budget).not_to include investment3
     end
   end
 

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -343,9 +343,9 @@ describe Budget::Investment do
 
       investments_by_budget = Budget::Investment.by_budget(budget1)
 
-      expect(investments_by_budget).to include investment1
-      expect(investments_by_budget).to include investment2
-      expect(investments_by_budget).to_not include investment3
+       expect(investments_by_budget).to include investment1
+       expect(investments_by_budget).to include investment2
+       expect(investments_by_budget).not_to include investment3
     end
   end
 
@@ -962,11 +962,11 @@ describe Budget::Investment do
 
       expect(another_investment.headings_voted_by_user(user1)).to include(new_york.id)
       expect(another_investment.headings_voted_by_user(user1)).to include(san_franciso.id)
-      expect(another_investment.headings_voted_by_user(user1)).to_not include(another_heading.id)
+      expect(another_investment.headings_voted_by_user(user1)).not_to include(another_heading.id)
 
-      expect(another_investment.headings_voted_by_user(user2)).to_not include(new_york.id)
-      expect(another_investment.headings_voted_by_user(user2)).to_not include(san_franciso.id)
-      expect(another_investment.headings_voted_by_user(user2)).to_not include(another_heading.id)
+      expect(another_investment.headings_voted_by_user(user2)).not_to include(new_york.id)
+      expect(another_investment.headings_voted_by_user(user2)).not_to include(san_franciso.id)
+      expect(another_investment.headings_voted_by_user(user2)).not_to include(another_heading.id)
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -12,7 +12,7 @@ describe Notification do
 
     it "should not be valid without a user" do
       notification.user = nil
-      expect(notification).to_not be_valid
+      expect(notification).not_to be_valid
     end
 
   end

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -304,7 +304,7 @@ describe Poll do
 
         expect(Poll.not_budget).to include(poll1)
         expect(Poll.not_budget).to include(poll2)
-        expect(Poll.not_budget).to_not include(poll3)
+        expect(Poll.not_budget).not_to include(poll3)
       end
 
     end

--- a/spec/models/valuator_spec.rb
+++ b/spec/models/valuator_spec.rb
@@ -30,7 +30,7 @@ describe Valuator do
       assigned_investment_ids = valuator.assigned_investment_ids
       expect(assigned_investment_ids).to include investment1.id
       expect(assigned_investment_ids).to include investment2.id
-      expect(assigned_investment_ids).to_not include investment3.id
+      expect(assigned_investment_ids).not_to include investment3.id
     end
 
     it "returns investments assigned to a valuator group" do
@@ -47,7 +47,7 @@ describe Valuator do
       assigned_investment_ids = valuator.assigned_investment_ids
       expect(assigned_investment_ids).to include investment1.id
       expect(assigned_investment_ids).to include investment2.id
-      expect(assigned_investment_ids).to_not include investment3.id
+      expect(assigned_investment_ids).not_to include investment3.id
     end
   end
 end

--- a/spec/support/common_actions/users.rb
+++ b/spec/support/common_actions/users.rb
@@ -79,7 +79,7 @@ module Users
     expect(find('.top-bar-right')).to have_content 'My account'
   end
 
-  def expect_to_not_be_signed_in
+  def expect_not_to_be_signed_in
     expect(find('.top-bar-right')).not_to have_content 'My account'
   end
 end


### PR DESCRIPTION
## References

**PR:** https://github.com/consul/consul/pull/3112

## Objectives

Change RSpec references of `to_not` for `not_to` and add the [corresponding Rubocop rule](https://www.rubydoc.info/gems/rubocop-rspec/1.5.0/RuboCop/Cop/RSpec/NotToNot).

## Does this PR need a Backport to CONSUL?

Nop, this comes from Upstream
