### PR TITLE
Fix random proposals order in the same session

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -3,6 +3,7 @@ module Budgets
     include FeatureFlags
     include CommentableActions
     include FlagActions
+    include RandomSeed
 
     PER_PAGE = 10
 
@@ -123,17 +124,6 @@ module Budgets
         @investment_votes = current_user ? current_user.budget_investment_votes(investments) : {}
       end
 
-      def set_random_seed
-        if params[:order] == 'random' || params[:order].blank?
-          seed = params[:random_seed] || session[:random_seed] || rand
-          params[:random_seed] = seed
-          session[:random_seed] = params[:random_seed]
-        else
-          session[:random_seed] = nil
-          params[:random_seed] = nil
-        end
-      end
-
       def investment_params
         params.require(:budget_investment)
               .permit(:title, :description, :heading_id, :tag_list,
@@ -200,7 +190,7 @@ module Budgets
       def investments
         if @current_order == 'random'
           @budget.investments.apply_filters_and_search(@budget, params, @current_filter)
-                             .send("sort_by_#{@current_order}", params[:random_seed])
+                             .sort_by_random(session[:random_seed])
         else
           @budget.investments.apply_filters_and_search(@budget, params, @current_filter)
                              .send("sort_by_#{@current_order}")

--- a/app/controllers/concerns/random_seed.rb
+++ b/app/controllers/concerns/random_seed.rb
@@ -1,0 +1,10 @@
+module RandomSeed
+  extend ActiveSupport::Concern
+
+  def set_random_seed
+    seed = (params[:random_seed] || session[:random_seed] || rand(10_000_000)).to_i
+
+    session[:random_seed] = seed
+    params[:random_seed] = seed
+  end
+end

--- a/app/controllers/human_rights_controller.rb
+++ b/app/controllers/human_rights_controller.rb
@@ -2,6 +2,7 @@ class HumanRightsController < ApplicationController
   skip_authorization_check
 
   include CommentableActions
+  include RandomSeed
 
   before_action :set_random_seed,             only: :index
   before_action :parse_search_terms,          only: :index
@@ -71,21 +72,10 @@ class HumanRightsController < ApplicationController
   end
 
   def order_results
-    @proposals = @proposals.send("sort_by_#{@current_order}")
-  end
-
-  def set_random_seed
-    if params[:order] == 'random' || params[:order].blank?
-      session[:random_seed] ||= rand(99) / 100.0
-      seed = begin
-               Float(params[:random_seed])
-             rescue
-               0
-             end
-      seed = (-1..1).cover?(seed) ? seed : 1
-      Proposal.connection.execute "select setseed(#{seed})"
+    if @current_order == "random"
+      @proposals = @proposals.sort_by_random(session[:random_seed])
     else
-      session[:random_seed] = nil
+      @proposals = @proposals.send("sort_by_#{@current_order}")
     end
   end
 

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -107,7 +107,7 @@ class Legislation::ProcessesController < Legislation::BaseController
     @current_filter = "winners" if params[:filter].blank? && @proposals.winners.any?
 
     if @current_filter == "random"
-      @proposals = @proposals.send(@current_filter, session[:random_seed]).page(params[:page])
+      @proposals = @proposals.sort_by_random(session[:random_seed]).page(params[:page])
     else
       @proposals = @proposals.send(@current_filter).page(params[:page])
     end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -1,4 +1,6 @@
 class Legislation::ProcessesController < Legislation::BaseController
+  include RandomSeed
+
   has_filters %w[open past], only: :index
   has_filters %w[random winners], only: :proposals
 
@@ -127,12 +129,5 @@ class Legislation::ProcessesController < Legislation::BaseController
     def set_process
       return if member_method?
       @process = ::Legislation::Process.find(params[:process_id])
-    end
-
-    def set_random_seed
-      seed = (params[:random_seed] || session[:random_seed] || rand(10_000_000)).to_i
-
-      session[:random_seed] = seed
-      params[:random_seed] = seed
     end
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -25,6 +25,7 @@ class Budget
     include Filterable
     include Flaggable
     include Milestoneable
+    include Randomizable
 
     belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
     belongs_to :heading
@@ -55,7 +56,6 @@ class Budget
     scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc, id: :desc) }
     scope :sort_by_ballots,          -> { reorder(ballot_lines_count: :desc, id: :desc) }
     scope :sort_by_price,            -> { reorder(price: :desc, confidence_score: :desc, id: :desc) }
-    scope :sort_by_random,           ->(seed) { reorder("budget_investments.id % #{seed.to_f.nonzero? ? seed.to_f : 1}, budget_investments.id") }
 
     scope :sort_by_id, -> { order("id DESC") }
     scope :sort_by_title, -> { order("title ASC") }

--- a/app/models/concerns/randomizable.rb
+++ b/app/models/concerns/randomizable.rb
@@ -2,7 +2,7 @@ module Randomizable
   extend ActiveSupport::Concern
 
   class_methods do
-    def sort_by_random(seed)
+    def sort_by_random(seed = rand(10_000_000))
       ids = pluck(:id).shuffle(random: Random.new(seed))
 
       return all if ids.empty?
@@ -12,7 +12,5 @@ module Randomizable
       joins("LEFT JOIN (VALUES #{ids_with_order}) AS ids(id, ordering) ON #{table_name}.id = ids.id")
         .order("ids.ordering")
     end
-
-    alias_method :random, :sort_by_random
   end
 end

--- a/app/models/concerns/randomizable.rb
+++ b/app/models/concerns/randomizable.rb
@@ -1,0 +1,18 @@
+module Randomizable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def sort_by_random(seed)
+      ids = pluck(:id).shuffle(random: Random.new(seed))
+
+      return all if ids.empty?
+
+      ids_with_order = ids.map.with_index { |id, order| "(#{id}, #{order})" }.join(", ")
+
+      joins("LEFT JOIN (VALUES #{ids_with_order}) AS ids(id, ordering) ON #{table_name}.id = ids.id")
+        .order("ids.ordering")
+    end
+
+    alias_method :random, :sort_by_random
+  end
+end

--- a/app/models/custom/probe_option.rb
+++ b/app/models/custom/probe_option.rb
@@ -1,4 +1,5 @@
 class ProbeOption < ActiveRecord::Base
+  include Randomizable
 
   belongs_to :probe
   belongs_to :debate

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -12,6 +12,7 @@ class Debate < ActiveRecord::Base
   include Graphqlable
   include Relationable
   include Notifiable
+  include Randomizable
 
   acts_as_votable
   acts_as_paranoid column: :hidden_at
@@ -40,7 +41,6 @@ class Debate < ActiveRecord::Base
   scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
   scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
   scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
-  scope :sort_by_random,           -> { reorder("RANDOM()") }
   scope :sort_by_relevance,        -> { all }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :sort_by_recommendations,  -> { order(cached_votes_total: :desc) }

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -54,12 +54,22 @@ class Legislation::Proposal < ActiveRecord::Base
   scope :sort_by_title,            -> { reorder(title: :asc) }
   scope :sort_by_id,               -> { reorder(id: :asc) }
   scope :sort_by_supports,         -> { reorder(cached_votes_score: :desc) }
-  scope :sort_by_random,           -> { reorder("RANDOM()") }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :last_week,                -> { where("proposals.created_at >= ?", 7.days.ago)}
   scope :selected,                 -> { where(selected: true) }
-  scope :random,                   -> { sort_by_random }
+  scope :random,                   -> (seed) { sort_by_random(seed) }
   scope :winners,                  -> { selected.sort_by_confidence_score }
+
+  def self.sort_by_random(seed)
+    ids = pluck(:id).shuffle(random: Random.new(seed))
+
+    return all if ids.empty?
+
+    ids_with_order = ids.map.with_index { |id, order| "(#{id}, #{order})" }.join(", ")
+
+    joins("LEFT JOIN (VALUES #{ids_with_order}) AS ids(id, ordering) ON #{table_name}.id = ids.id")
+      .order("ids.ordering")
+  end
 
   def to_param
     "#{id}-#{title}".parameterize

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -22,6 +22,7 @@ class Proposal < ActiveRecord::Base
   include EmbedVideosHelper
   include Relationable
   include Milestoneable
+  include Randomizable
 
   acts_as_votable
   acts_as_paranoid column: :hidden_at
@@ -60,7 +61,6 @@ class Proposal < ActiveRecord::Base
   scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
   scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
   scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
-  scope :sort_by_random,           -> { reorder("RANDOM()") }
   scope :sort_by_relevance,        -> { all }
   scope :sort_by_flags,            -> { order(flags_count: :desc, updated_at: :desc) }
   scope :sort_by_archival_date,    -> { archived.sort_by_confidence_score }

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -731,16 +731,16 @@ feature 'Budget Investments' do
       expect(current_url).to include('page=1')
     end
 
-    scenario 'Each user has a different and consistent random budget investment order when random_seed is disctint' do
+    scenario "Each user has a different and consistent random budget investment order" do
       (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
-        visit budget_investments_path(budget, heading: heading, random_seed: rand)
+        visit budget_investments_path(budget, heading: heading)
         @first_user_investments_order = investments_order
       end
 
       in_browser(:two) do
-        visit budget_investments_path(budget, heading: heading, random_seed: rand)
+        visit budget_investments_path(budget, heading: heading)
         @second_user_investments_order = investments_order
       end
 


### PR DESCRIPTION
## References

* Issue #1196 
* Issue #1659 
* Issue #1191
* Issue consul#2155
* Pull request #1660 
* Pull request consul#3076

## Objectives

* Consistently maintain the random legislation proposals order for the same user session
* Use the same code to set and order by a random seed in all affected controllers
* Fix the flaky specs that appeared in `spec/features/legislation/proposals_spec.rb:34` ("Legislation Proposals Each user as a different and consistent random proposals order"), `spec/features/legislation/proposals_spec.rb:60` ("Legislation Proposals Random order maintained with pagination"), and `spec/features/budgets/investments_spec.rb:611` ("Budget Investments Orders Each user has a different and consistent random budget investment order when random_seed is disctint")

### Explain why the test is flaky, or under which conditions/scenario it fails randomly

Quoting from the commit message:

> Using `setseed` and ordering by `RAND()` doesn't always return the same results because, although the generated random numbers will always be the same, PostgreSQL doesn't guarantee the order of the rows it will apply those random numbers to, similar to the way it doesn't guarantee an order when the `ORDER BY` clause isn't specified.

### Explain why your PR fixes it

Sorting the affected IDs using `Array#shuffle` with a seed stored in the session and returning the records in that order solves the issue.

## Does this PR need a Backport to CONSUL?

Yes.

## Notes

* Using something like `reorder("legislation_proposals.id % #{seed}")`, like we do in budget investments, is certainly more elegant but it makes the test checking two users get different results fail sometimes, so that approach might need some adjustments in order to make the results more random.