### PR TITLE
Enable useless assignment rubocop rule

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -27,5 +27,8 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/UselessAssignment:
+  Enabled: true
+
 RSpec/NotToNot:
   Enabled: true


### PR DESCRIPTION
## Objectives

Help developers who don't run the ruby syntax check locally realize they might be involuntarily assigning a value to a local variable which is never used, and so they might want to check whether they need to refactor the code a bit.

## Does this PR need a Backport to CONSUL?

Yes.