### PR TITLE
Fix literal as condition

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -27,6 +27,9 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/LiteralAsCondition:
+  Enabled: true
+
 Lint/UselessAssignment:
   Enabled: true
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -100,7 +100,7 @@ class Budget
     scope :for_render, -> { includes(:heading) }
 
     before_save :calculate_confidence_score
-    after_save :recalculate_heading_winners if :incompatible_changed?
+    after_save :recalculate_heading_winners
     before_validation :set_responsible_name
     before_validation :set_denormalized_ids
 


### PR DESCRIPTION
## Objectives

* Remove a syntax mistake which made a condition always evaluate to `true`
* Enable a rubocop rule so we are warned when we accidentally introduce similar conditions

## Does this PR need a Backport to CONSUL?

Yes.