### PR TITLE
[Upstream] Add legislation homepage

### DIFF
--- a/app/controllers/admin/legislation/homepages_controller.rb
+++ b/app/controllers/admin/legislation/homepages_controller.rb
@@ -1,0 +1,36 @@
+class Admin::Legislation::HomepagesController < Admin::Legislation::BaseController
+  include Translatable
+
+  load_and_authorize_resource :process, class: "Legislation::Process"
+
+  def edit
+  end
+
+  def update
+    if @process.update(process_params)
+      link = legislation_process_path(@process).html_safe
+      redirect_to :back, notice: t('admin.legislation.processes.update.notice', link: link)
+    else
+      flash.now[:error] = t('admin.legislation.processes.update.error')
+      render :edit
+    end
+  end
+
+  private
+
+    def process_params
+      params.require(:legislation_process).permit(allowed_params)
+    end
+
+    def allowed_params
+      [
+        :homepage,
+        :homepage_enabled,
+        translation_params(::Legislation::Process)
+      ]
+    end
+
+    def resource
+      @process || ::Legislation::Process.find(params[:id])
+    end
+end

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -16,7 +16,9 @@ class Legislation::ProcessesController < Legislation::BaseController
     draft_version = @process.draft_versions.published.last
     allegations_phase = @process.allegations_phase
 
-    if  allegations_phase.enabled? && allegations_phase.started? && draft_version.present?
+    if @process.homepage_enabled? && @process.homepage.present?
+      render :show
+    elsif  allegations_phase.enabled? && allegations_phase.started? && draft_version.present?
       redirect_to legislation_process_draft_version_path(@process, draft_version)
     elsif @process.debate_phase.enabled?
       redirect_to debate_legislation_process_path(@process)

--- a/app/helpers/legislation_helper.rb
+++ b/app/helpers/legislation_helper.rb
@@ -34,6 +34,7 @@ module LegislationHelper
   def legislation_process_tabs(process)
     {
       "info"           => edit_admin_legislation_process_path(process),
+      "homepage"       => edit_admin_legislation_process_homepage_path(process),
       "questions"      => admin_legislation_process_questions_path(process),
       "proposals"      => admin_legislation_process_proposals_path(process),
       "draft_versions" => admin_legislation_process_draft_versions_path(process),

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -15,6 +15,7 @@ class Legislation::Process < ActiveRecord::Base
   translates :description,        touch: true
   translates :additional_info,    touch: true
   translates :milestones_summary, touch: true
+  translates :homepage,           touch: true
   include Globalizable
 
   PHASES_AND_PUBLICATIONS = %i[draft_phase debate_phase allegations_phase proposals_phase

--- a/app/views/admin/legislation/homepages/_form.html.erb
+++ b/app/views/admin/legislation/homepages/_form.html.erb
@@ -1,0 +1,47 @@
+<%= render "admin/shared/globalize_locales", resource: @process  %>
+
+<%= translatable_form_for [:admin, @process], url: url, html: {data: {watch_changes: true}} do |f| %>
+
+  <% if @process.errors.any? %>
+
+  <div id="error_explanation" data-alert class="callout alert" data-closable>
+    <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+
+    <strong>
+      <%= @process.errors.count %>
+      <%= t("admin.legislation.processes.errors.form.error", count: @process.errors.count) %>
+    </strong>
+  </div>
+
+  <% end %>
+
+  <div class="small-12 column margin-top">
+    <%= f.check_box :homepage_enabled, checked: @process.homepage_enabled?, label: t("admin.legislation.processes.form.homepage_enabled") %>
+  </div>
+
+  <div class="ckeditor small-12 column">
+    <label><%= t("admin.legislation.processes.form.homepage") %></label>
+    <p class="help-text"><%= t("admin.legislation.processes.form.homepage_description") %></p>
+    <%= f.cktext_area :homepage,
+                      label: false,
+                      ckeditor: { language: I18n.locale, height: 500, toolbar: 'admin' } %>
+  </div>
+
+  <div class="small-12 column">
+    <hr>
+  </div>
+
+  <%= f.translatable_fields do |translations_form| %>
+    <div class="small-12 column end">
+      <%= translations_form.cktext_area :homepage,
+                                        ckeditor: { height: 500, toolbar: 'admin' },
+                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+    </div>
+  <% end %>
+
+  <div class="small-12 medium-3 column clear end">
+    <%= f.submit(class: "button success expanded", value: t("admin.legislation.processes.#{admin_submit_action(@process)}.submit_button")) %>
+  </div>
+<% end %>

--- a/app/views/admin/legislation/homepages/_form.html.erb
+++ b/app/views/admin/legislation/homepages/_form.html.erb
@@ -1,43 +1,24 @@
-<%= render "admin/shared/globalize_locales", resource: @process  %>
+<%= render "admin/shared/globalize_tabs",
+           resource: @process,
+           display_style: lambda { |locale| enable_translation_style(@process, locale) } %>
 
 <%= translatable_form_for [:admin, @process], url: url, html: {data: {watch_changes: true}} do |f| %>
 
-  <% if @process.errors.any? %>
-
-  <div id="error_explanation" data-alert class="callout alert" data-closable>
-    <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
-      <span aria-hidden="true">&times;</span>
-    </button>
-
-    <strong>
-      <%= @process.errors.count %>
-      <%= t("admin.legislation.processes.errors.form.error", count: @process.errors.count) %>
-    </strong>
-  </div>
-
-  <% end %>
+  <%= render "shared/errors", resource: @process %>
 
   <div class="small-12 column margin-top">
-    <%= f.check_box :homepage_enabled, checked: @process.homepage_enabled?, label: t("admin.legislation.processes.form.homepage_enabled") %>
-  </div>
-
-  <div class="ckeditor small-12 column">
-    <label><%= t("admin.legislation.processes.form.homepage") %></label>
-    <p class="help-text"><%= t("admin.legislation.processes.form.homepage_description") %></p>
-    <%= f.cktext_area :homepage,
-                      label: false,
-                      ckeditor: { language: I18n.locale, height: 500, toolbar: 'admin' } %>
-  </div>
-
-  <div class="small-12 column">
-    <hr>
+    <%= f.check_box :homepage_enabled, label: t("admin.legislation.processes.form.homepage_enabled") %>
   </div>
 
   <%= f.translatable_fields do |translations_form| %>
     <div class="small-12 column end">
-      <%= translations_form.cktext_area :homepage,
-                                        ckeditor: { height: 500, toolbar: 'admin' },
-                                        hint: t("admin.legislation.processes.form.use_markdown") %>
+      <div class="ckeditor">
+        <%= translations_form.cktext_area :homepage,
+                                          language: I18n.locale,
+                                          label: t("admin.legislation.processes.form.homepage"),
+                                          ckeditor: { height: 500, toolbar: 'admin' },
+                                          hint: t("admin.legislation.processes.form.homepage_description") %>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/admin/legislation/homepages/edit.html.erb
+++ b/app/views/admin/legislation/homepages/edit.html.erb
@@ -1,0 +1,13 @@
+<% provide :title do %>
+  <%= t("admin.header.title") %> - <%= t("admin.menu.legislation") %> - <%= @process.title %> - <%= t("admin.legislation.homepage.edit.title") %>
+<% end %>
+
+<div class="legislation-admin legislation-process-edit">
+  <%= back_link_to admin_legislation_processes_path, t("admin.legislation.processes.edit.back") %>
+
+  <h2><%= @process.title %></h2>
+
+  <%= render 'admin/legislation/processes/subnav', process: @process, active: 'homepage' %>
+
+  <%= render 'form', url: admin_legislation_process_homepage_path(@process) %>
+</div>

--- a/app/views/legislation/processes/show.html.erb
+++ b/app/views/legislation/processes/show.html.erb
@@ -8,6 +8,6 @@
 
 <div class="row">
   <div class="small-12 medium-9 column">
-    <%= @process.homepage.html_safe %>
+    <%= AdminWYSIWYGSanitizer.new.sanitize(@process.homepage) %>
   </div>
 </div>

--- a/app/views/legislation/processes/show.html.erb
+++ b/app/views/legislation/processes/show.html.erb
@@ -1,0 +1,13 @@
+<% provide :title do %><%= @process.title %><% end %>
+
+<%= render 'legislation/processes/header', process: @process, header: :full %>
+
+<%= render 'documents/additional_documents', documents: @process.documents %>
+
+<%= render 'key_dates', process: @process, phase: :debate_phase %>
+
+<div class="row">
+  <div class="small-12 medium-9 column">
+    <%= @process.homepage.html_safe %>
+  </div>
+</div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -407,6 +407,9 @@ en:
           summary_placeholder: Short summary of the description
           description_placeholder: Add a description of the process
           additional_info_placeholder: Add an additional information you consider useful
+          homepage: Description
+          homepage_description: Here you can explain the content of the process
+          homepage_enabled: Homepage enabled
         index:
           create: New process
           delete: Delete
@@ -436,10 +439,14 @@ en:
           status_planned: Planned
         subnav:
           info: Information
+          homepage: Homepage
           draft_versions: Drafting
           questions: Debate
           proposals: Proposals
           milestones: Following
+      homepage:
+        edit:
+          title: Configure your process homepage
       proposals:
         index:
           title: Proposals

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -407,6 +407,9 @@ es:
           summary_placeholder: Resumen corto de la descripción
           description_placeholder: Añade una descripción del proceso
           additional_info_placeholder: Añade cualquier información adicional que pueda ser de interés
+          homepage: Descripción
+          homepage_description: Aquí puedes explicar el contenido del proceso
+          homepage_enabled: Homepage activada
         index:
           create: Nuevo proceso
           delete: Borrar
@@ -436,10 +439,14 @@ es:
           status_planned: Próximamente
         subnav:
           info: Información
+          homepage: Homepage
           draft_versions: Redacción
           questions: Debate
           proposals: Propuestas
           milestones: Seguimiento
+      homepage:
+        edit:
+          title: Configura la homepage del proceso
       proposals:
         index:
           title: Título

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -209,6 +209,7 @@ namespace :admin do
       end
       resources :draft_versions
       resources :milestones
+      resource :homepage, only: [:edit, :update]
     end
   end
 

--- a/db/migrate/20181206153510_add_home_page_to_legislation_processes.rb
+++ b/db/migrate/20181206153510_add_home_page_to_legislation_processes.rb
@@ -1,6 +1,5 @@
 class AddHomePageToLegislationProcesses < ActiveRecord::Migration
   def change
-    add_column :legislation_processes, :homepage, :text
     add_column :legislation_processes, :homepage_enabled, :boolean, default: false
 
     reversible do |dir|

--- a/db/migrate/20181206153510_add_home_page_to_legislation_processes.rb
+++ b/db/migrate/20181206153510_add_home_page_to_legislation_processes.rb
@@ -1,0 +1,16 @@
+class AddHomePageToLegislationProcesses < ActiveRecord::Migration
+  def change
+    add_column :legislation_processes, :homepage, :text
+    add_column :legislation_processes, :homepage_enabled, :boolean, default: false
+
+    reversible do |dir|
+      dir.up do
+        Legislation::Process.add_translation_fields! homepage: :text
+      end
+
+      dir.down do
+        remove_column :legislation_process_translations, :homepage
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -719,7 +719,6 @@ ActiveRecord::Schema.define(version: 20181206153510) do
     t.date     "draft_start_date"
     t.date     "draft_end_date"
     t.boolean  "draft_phase_enabled",        default: false
-    t.text     "homepage"
     t.boolean  "homepage_enabled",           default: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181128175808) do
+ActiveRecord::Schema.define(version: 20181206153510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -684,6 +684,7 @@ ActiveRecord::Schema.define(version: 20181128175808) do
     t.text     "description"
     t.text     "additional_info"
     t.text     "milestones_summary"
+    t.text     "homepage"
   end
 
   add_index "legislation_process_translations", ["legislation_process_id"], name: "index_199e5fed0aca73302243f6a1fca885ce10cdbb55", using: :btree
@@ -718,6 +719,8 @@ ActiveRecord::Schema.define(version: 20181128175808) do
     t.date     "draft_start_date"
     t.date     "draft_end_date"
     t.boolean  "draft_phase_enabled",        default: false
+    t.text     "homepage"
+    t.boolean  "homepage_enabled",           default: false
   end
 
   add_index "legislation_processes", ["allegations_end_date"], name: "index_legislation_processes_on_allegations_end_date", using: :btree

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -175,7 +175,7 @@ feature 'Legislation' do
         visit legislation_process_path(process)
 
         expect(page).to     have_content("This is the process homepage")
-        expect(page).to_not have_content("Participate in the debate")
+        expect(page).not_to have_content("Participate in the debate")
       end
 
       scenario 'disabled', :with_frozen_time do
@@ -187,7 +187,7 @@ feature 'Legislation' do
         visit legislation_process_path(process)
 
         expect(page).to have_content("This phase is not open yet")
-        expect(page).to_not have_content("This is the process homepage")
+        expect(page).not_to have_content("This is the process homepage")
       end
     end
 

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -165,6 +165,32 @@ feature 'Legislation' do
       end
     end
 
+    context 'homepage' do
+      scenario 'enabled' do
+        process = create(:legislation_process, homepage_enabled: true,
+                                               homepage: 'This is the process homepage',
+                                               debate_start_date: Date.current + 1.day,
+                                               debate_end_date: Date.current + 2.days)
+
+        visit legislation_process_path(process)
+
+        expect(page).to     have_content("This is the process homepage")
+        expect(page).to_not have_content("Participate in the debate")
+      end
+
+      scenario 'disabled', :with_frozen_time do
+        process = create(:legislation_process, homepage_enabled: false,
+                                               homepage: 'This is the process homepage',
+                                               debate_start_date: Date.current + 1.day,
+                                               debate_end_date: Date.current + 2.days)
+
+        visit legislation_process_path(process)
+
+        expect(page).to have_content("This phase is not open yet")
+        expect(page).to_not have_content("This is the process homepage")
+      end
+    end
+
     context 'debate phase' do
       scenario 'not open', :with_frozen_time do
         process = create(:legislation_process, debate_start_date: Date.current + 1.day, debate_end_date: Date.current + 2.days)


### PR DESCRIPTION
## References

**PR:** https://github.com/consul/consul/pull/3091

Objectives
===================
> Added new tab in admin section for legislative processes, to enable a default homepage for each process

Visual Changes
===================
> Admin:

![admin](https://user-images.githubusercontent.com/153806/49654096-3094bf00-fa37-11e8-90c0-53c8fc55aeab.png)

> Front:
![front](https://user-images.githubusercontent.com/153806/49654115-3be7ea80-fa37-11e8-907e-43b6c52e26df.png)


## Does this PR need a Backport to CONSUL?

No, this PR comes from Upstream
