### PR TITLE
Migrate spending proposal delegated votes to represented user votes

### DIFF
--- a/db/migrate/20181219172416_add_delegated_to_votes.rb
+++ b/db/migrate/20181219172416_add_delegated_to_votes.rb
@@ -1,0 +1,5 @@
+class AddDelegatedToVotes < ActiveRecord::Migration
+  def change
+    add_column :votes, :delegated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181128175808) do
+ActiveRecord::Schema.define(version: 20181219172416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1705,6 +1705,7 @@ ActiveRecord::Schema.define(version: 20181128175808) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "signature_id"
+    t.boolean  "delegated",    default: false
   end
 
   add_index "votes", ["signature_id"], name: "index_votes_on_signature_id", using: :btree

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -1,0 +1,47 @@
+class Migrations::SpendingProposal::Vote
+
+  def new
+  end
+
+  def migrate_delegated_votes
+    delegated_votes.each do |delegated_vote|
+      create_vote(delegated_vote)
+    end
+  end
+
+  def create_vote(delegated_vote)
+    vote_attributes = {
+      voter: delegated_vote[:voter],
+      votable: delegated_vote[:votable],
+      delegated: true
+    }
+    Vote.create!(vote_attributes)
+  end
+
+  def delegated_votes
+    representative_votes.map do |vote|
+      represented_user_votes(vote)
+    end.flatten
+  end
+
+  def representative_votes
+    Vote.representative_votes
+  end
+
+  def represented_user_votes(vote)
+    representative = vote.voter.forum
+    spending_proposal = vote.votable
+
+    representative.represented_users.map do |represented_user|
+      represented_user_vote(represented_user, spending_proposal)
+    end.compact
+  end
+
+  def represented_user_vote(represented_user, spending_proposal)
+    unless represented_user.voted_for?(spending_proposal)
+      { voter: represented_user,
+        votable: spending_proposal }
+    end
+  end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -33,4 +33,10 @@ namespace :spending_proposals do
     Budget::Investment.where(original_spending_proposal_id: winner_spending_proposals)
                       .update_all(winner: true, selected: true)
   end
+
+  desc "Migrates delegated votes to represented user votes"
+  task migrate_delegated_votes: :environment do
+    require "migrations/spending_proposal/vote"
+    Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+  end
 end

--- a/spec/factories/custom.rb
+++ b/spec/factories/custom.rb
@@ -20,6 +20,19 @@ FactoryBot.define do
     user
   end
 
+  factory :represented_user, class: 'User' do
+    association :representative, factory: :forum
+
+    sequence(:username) { |n| "Represented#{n}" }
+    sequence(:email)    { |n| "represented#{n}@consul.dev" }
+
+    password            'vote_delegated'
+    terms_of_service    '1'
+    verified_at { Time.current }
+    document_type "1"
+    document_number
+  end
+
   factory :ballot do
     user
   end

--- a/spec/lib/migrations/spending_proposal/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposal/vote_spec.rb
@@ -1,0 +1,157 @@
+require "rails_helper"
+require "migrations/spending_proposal/vote"
+
+describe Migrations::SpendingProposal::Vote do
+
+  describe "#migrate_delegated_votes" do
+
+    it "create a represented user vote when single delegation" do
+      forum = create(:forum)
+      represented_user = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      expect(spending_proposal.votes_for.count).to eq(1)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal.votes_for.count).to eq(2)
+      expect(Vote.last.voter).to eq(represented_user)
+      expect(Vote.last.votable).to eq(spending_proposal)
+    end
+
+    it "creates represented user votes when multiple delegations" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      represented_user2 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      expect(spending_proposal.votes_for.count).to eq(1)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal.votes_for.count).to eq(3)
+    end
+
+    it "creates represented user votes when multiple delegations for mulitple spending proposals" do
+      forum1 = create(:forum)
+      forum2 = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum1)
+      represented_user2 = create(:represented_user, representative: forum2)
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal1, voter: forum1.user)
+      create(:vote, votable: spending_proposal2, voter: forum2.user)
+
+      expect(spending_proposal1.votes_for.count).to eq(1)
+      expect(spending_proposal2.votes_for.count).to eq(1)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal1.votes_for.count).to eq(2)
+      expect(spending_proposal2.votes_for.count).to eq(2)
+    end
+
+    it "creates represented user votes when existing user votes" do
+      forum = create(:forum)
+      represented_user = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      user = create(:user, :verified)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+      create(:vote, votable: spending_proposal, voter: user)
+
+      expect(spending_proposal.votes_for.count).to eq(2)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal.votes_for.count).to eq(3)
+    end
+
+  end
+
+  describe "#delegated_votes" do
+
+    it "returns delegated votes when no delegations" do
+      spending_proposal = create(:spending_proposal)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+      expect(delegated_votes.count).to eq(0)
+    end
+
+    it "returns delegated votes when one delegation for one spending proposal" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+
+      expect(delegated_votes.count).to eq(1)
+      expect(delegated_votes.first[:voter]).to eq(represented_user1)
+      expect(delegated_votes.first[:votable]).to eq(spending_proposal)
+    end
+
+    it "returns delegated votes when one delegations but represented user also voted" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+      create(:vote, votable: spending_proposal, voter: represented_user1)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+
+      expect(delegated_votes.count).to eq(0)
+    end
+
+    it "returns delegated votes when multiple delegations for one spending proposal" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      represented_user2 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+      expect(delegated_votes.count).to eq(2)
+
+      voters = delegated_votes.collect   { |vote| vote[:voter] }
+      votables = delegated_votes.collect { |vote| vote[:votable] }
+
+      expect(voters).to include(represented_user1)
+      expect(voters).to include(represented_user2)
+      expect(votables).to eq([spending_proposal, spending_proposal])
+    end
+
+    it "returns delegated votes when multiple delegations for multiple spending proposal" do
+      forum1 = create(:forum)
+      forum2 = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum1)
+      represented_user2 = create(:represented_user, representative: forum2)
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal1, voter: forum1.user)
+      create(:vote, votable: spending_proposal2, voter: forum2.user)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+      expect(delegated_votes.count).to eq(2)
+
+      voters = delegated_votes.collect   { |vote| vote[:voter] }
+      votables = delegated_votes.collect { |vote| vote[:votable] }
+
+      expect(voters).to include(represented_user1)
+      expect(voters).to include(represented_user2)
+      expect(votables).to include(spending_proposal1)
+      expect(votables).to include(spending_proposal2)
+    end
+
+  end
+end


### PR DESCRIPTION
## Context
In the first Participatory Budget we used `spending_proposals` instead of `budget_investments`. We also used vote delegation using `Forums` as representatives of many users who delegated their vote on them.

## Objectives
Migrate the delegated votes on Forums to standard votes from the represented users.

## Does this PR need a Backport to CONSUL?

No, CONSUL does not have vote delegation.

## Notes
This is one of multiple PRs to completely remove spending proposals from Madrid and CONSUL.
The upcoming ones are:
- Change spending proposal stats to take into account the migrated delegated votes
- Migrate spending proposal delegated ballots to standard ballots from represented users
- Change spending proposal results and stats to take into account the migrated delegated ballots