### PR TITLE
Migrate spending proposal

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -8,6 +8,7 @@ module Budgets
     def show
       authorize! :read_results, @budget
       @investments = Budget::Result.new(@budget, @heading).investments
+      @headings = @budget.headings.sort_by_name
     end
 
     private
@@ -18,9 +19,12 @@ module Budgets
 
       def load_heading
         if @budget.present?
-          headings = @budget.headings
-          @heading = headings.find_by_slug_or_id(params[:heading_id]) || headings.first
+          @heading = @budget.headings.find_by_slug_or_id(params[:heading_id]) || default_heading
         end
+      end
+
+      def default_heading
+        @budget.city_heading || @budget.headings.first
       end
 
   end

--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -7,6 +7,7 @@ module Budgets
     def show
       authorize! :read_stats, @budget
       @stats = load_stats
+      @headings = @budget.headings.sort_by_name
     end
 
     private

--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -369,7 +369,7 @@ class SpendingProposalsController < ApplicationController
     end
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("spending_proposals_stats/20181227211842/#{key}", &block)
+      Rails.cache.fetch("spending_proposals_stats/20190206172205/#{key}", &block)
     end
 
 end

--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -94,11 +94,9 @@ class SpendingProposalsController < ApplicationController
   def results
     @geozone = daily_cache("geozone_geozone_#{params[:geozone_id]}") { params[:geozone_id].blank? || params[:geozone_id] == 'all' ? nil : Geozone.find(params[:geozone_id]) }
     @delegated_ballots = daily_cache("delegated_geozone_#{params[:geozone_id]}") { Forum.delegated_ballots }
-    @spending_proposals = daily_cache("sps_geozone_#{params[:geozone_id]}") { SpendingProposal.feasible.compatible.valuation_finished.by_geozone(params[:geozone_id]) }
-    @spending_proposals = daily_cache("sorted_sps_geozone_#{params[:geozone_id]}") { SpendingProposal.sort_by_delegated_ballots_and_price(@spending_proposals, @delegated_ballots) }
-
-    @initial_budget = daily_cache("initial_budget_geozone_#{params[:geozone_id]}") { Ballot.initial_budget(@geozone) }
-    @incompatibles = daily_cache("incompatibles_geozone_#{params[:geozone_id]}") { SpendingProposal.incompatible.by_geozone(params[:geozone_id]) }
+    @spending_proposals = daily_cache("sorted_sps_geozone_#{params[:geozone_id]}") { Budget::Result.new(budget_2016, heading_for_geozone(params[:geozone_id])).investments }
+    @initial_budget = daily_cache("initial_budget_geozone_#{params[:geozone_id]}") { heading_for_geozone(params[:geozone_id]).price }
+    @incompatibles = daily_cache("incompatibles_geozone_#{params[:geozone_id]}") { budget_2016.investments.incompatible.by_heading(heading_for_geozone(params[:geozone_id])) }
   end
 
   private
@@ -197,22 +195,22 @@ class SpendingProposalsController < ApplicationController
 
     def total_supports
       stats_cache('total_supports') do
-        spending_proposal_supports.count
+        budget_investment_supports.count
       end
     end
 
     def total_votes
       stats_cache('total_votes') do
-        BallotLine.count
+        budget_2016.lines.count
       end
     end
 
     def authors
-      stats_cache('authors') { SpendingProposal.pluck(:author_id) }
+      stats_cache('authors') { budget_2016.investments.pluck(:author_id) }
     end
 
     def voters
-      stats_cache("voters") { spending_proposal_supports.pluck(:voter_id) }
+      stats_cache("voters") { budget_investment_supports.pluck(:voter_id) }
     end
 
     def voters_by_geozone(geozone_id)
@@ -226,18 +224,18 @@ class SpendingProposalsController < ApplicationController
 
     def balloters
       stats_cache('balloters') do
-        Ballot.where('ballot_lines_count > ?', 0).pluck(:user_id)
+        budget_2016.ballots.where("ballot_lines_count > ?", 0).pluck(:user_id)
       end
     end
 
     def balloters_by_geozone(geozone_id)
       stats_cache("balloters_geozone_#{geozone_id}") do
-        Ballot.where('ballot_lines_count > ? AND geozone_id = ?', 0, geozone_id).pluck(:user_id)
+        budget_2016.lines.where(heading_id: heading_for_geozone(geozone_id).id).pluck(:user_id).uniq
       end
     end
 
     def total_spending_proposals
-      stats_cache('total_spending_proposals') { SpendingProposal.count }
+      stats_cache('total_spending_proposals') { budget_2016.investments.count }
     end
 
     def paper_spending_proposals
@@ -245,11 +243,11 @@ class SpendingProposalsController < ApplicationController
     end
 
     def total_feasible_spending_proposals
-      stats_cache('total_feasible_spending_proposals') { SpendingProposal.feasible.count }
+      stats_cache('total_feasible_spending_proposals') { budget_2016.investments.feasible.count }
     end
 
     def total_unfeasible_spending_proposals
-      stats_cache('total_unfeasible_spending_proposals') { SpendingProposal.unfeasible.count }
+      stats_cache('total_unfeasible_spending_proposals') { budget_2016.investments.unfeasible.count }
     end
 
     def total_male_participants
@@ -359,17 +357,21 @@ class SpendingProposalsController < ApplicationController
       Budget.where(slug: "2016").first
     end
 
-    def spending_proposal_supports
+    def budget_investment_supports
       ActsAsVotable::Vote.where(votable: budget_2016.investments)
     end
 
     def heading_for_geozone(geozone_id)
-      geozone = Geozone.find(geozone_id)
-      budget_2016.headings.where(name: geozone.name).first
+      if geozone_id == nil
+        budget_2016.headings.where(name: "Toda la ciudad").first
+      else
+        geozone = Geozone.find(geozone_id)
+        budget_2016.headings.where(name: geozone.name).first
+      end
     end
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("spending_proposals_stats/20190206172205/#{key}", &block)
+      Rails.cache.fetch("spending_proposals_stats/20190206172211/#{key}", &block)
     end
 
 end

--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -178,7 +178,7 @@ class SpendingProposalsController < ApplicationController
 
     def participants
       stats_cache('participants') do
-        users = (authors + voters + balloters + delegators).uniq
+        users = (authors + voters + balloters).uniq
         User.where(id: users)
       end
     end
@@ -231,10 +231,6 @@ class SpendingProposalsController < ApplicationController
       stats_cache("balloters_geozone_#{geozone_id}") do
         Ballot.where('ballot_lines_count > ? AND geozone_id = ?', 0, geozone_id).pluck(:user_id)
       end
-    end
-
-    def delegators
-      stats_cache('delegators') { User.where.not(representative_id: nil).pluck(:id) }
     end
 
     def total_spending_proposals
@@ -357,7 +353,7 @@ class SpendingProposalsController < ApplicationController
     end
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("spending_proposals_stats/201607131316/#{key}", &block)
+      Rails.cache.fetch("spending_proposals_stats/20181227211842/#{key}", &block)
     end
 
 end

--- a/app/models/budget/ballot/line.rb
+++ b/app/models/budget/ballot/line.rb
@@ -16,7 +16,7 @@ class Budget
       scope :by_investment, ->(investment_id) { where(investment_id: investment_id) }
 
       before_validation :set_denormalized_ids
-      after_save :store_user_heading
+      #after_save :store_user_heading
 
       def check_sufficient_funds
         errors.add(:money, "insufficient funds") if ballot.amount_available(investment.heading) < investment.price.to_i

--- a/app/models/budget/ballot/line.rb
+++ b/app/models/budget/ballot/line.rb
@@ -31,13 +31,13 @@ class Budget
         errors.add(:investment, "unselected investment") unless investment.selected?
       end
 
-      private
+      def set_denormalized_ids
+        self.heading_id ||= investment.try(:heading_id)
+        self.group_id   ||= investment.try(:group_id)
+        self.budget_id  ||= investment.try(:budget_id)
+      end
 
-        def set_denormalized_ids
-          self.heading_id ||= investment.try(:heading_id)
-          self.group_id   ||= investment.try(:group_id)
-          self.budget_id  ||= investment.try(:budget_id)
-        end
+      private
 
         def store_user_heading
           return if heading.city_heading?

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -149,6 +149,6 @@ class Budget::Stats
     stats_cache :voters, :participants, :authors, :balloters, :poll_ballot_voters
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v11", &block)
+      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v12", &block)
     end
 end

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -149,6 +149,6 @@ class Budget::Stats
     stats_cache :voters, :participants, :authors, :balloters, :poll_ballot_voters
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v12", &block)
+      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v13", &block)
     end
 end

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -149,6 +149,6 @@ class Budget::Stats
     stats_cache :voters, :participants, :authors, :balloters, :poll_ballot_voters
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v10", &block)
+      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v11", &block)
     end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,7 +20,7 @@ class Comment < ActiveRecord::Base
 
   validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
 
-  validate :validate_body_length
+  validate :validate_body_length, unless: -> { valuation }
   validate :comment_valuation, if: -> { valuation }
 
   belongs_to :commentable, -> { with_hidden }, polymorphic: true, counter_cache: true

--- a/app/models/spending_proposal.rb
+++ b/app/models/spending_proposal.rb
@@ -151,23 +151,7 @@ class SpendingProposal < ActiveRecord::Base
   end
 
   def total_votes
-    cached_votes_up + physical_votes + delegated_votes - forum_votes
-  end
-
-  def delegated_votes
-    count = 0
-    representative_voters.each do |voter|
-      count += voter.forum.represented_users.select { |u| !u.voted_for?(self) }.count
-    end
-    return count
-  end
-
-  def representative_voters
-    Vote.representative_votes.for_spending_proposals(self).collect(&:voter)
-  end
-
-  def forum_votes
-    Vote.representative_votes.for_spending_proposals(self).count
+    cached_votes_up + physical_votes
   end
 
   def code

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -49,8 +49,8 @@
     <h3 class="margin-bottom">
       <%= t("budgets.results.heading_selection_title") %>
     </h3>
-    <ul class="menu vertical no-margin-top no-padding-top">
-      <% @budget.headings.order('id ASC').each do |heading| %>
+    <ul id="headings" class="menu vertical no-margin-top no-padding-top">
+      <% @headings.each do |heading| %>
         <li>
           <%= link_to heading.name,
                       custom_budget_heading_result_path(@budget, heading_id: heading.to_param),

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -201,8 +201,8 @@
               <th scope="col" class="tiny"><%= t("budgets.stats.percent_heading_census_html") %></th>
             </tr>
           </thead>
-          <tbody>
-            <% @budget.headings.order('id ASC').each do |heading| %>
+          <tbody id="headings">
+            <% @headings.each do |heading| %>
               <tr id="<%= heading.name.parameterize %>">
                 <td class="border-left">
                   <strong><%= heading.name %></strong>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -162,15 +162,10 @@
                     </div>
                     <div class="small-12 medium-6 column table" data-equalizer-watch>
                       <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
-                        <% if budget.name == "Presupuestos Participativos 2016" %>
-                          <%= link_to t("budgets.index.see_results"),
-                                      participatory_budget_results_path,
-                                      class: "button" %>
-                        <% else %>
-                          <%= link_to t("budgets.index.see_results"),
-                                      custom_budget_results_path(budget),
-                                      class: "button" %>
-                        <% end %>
+                        <%= link_to t("budgets.index.see_results"),
+                                    custom_budget_results_path(budget),
+                                    class: "button" %>
+                        
                         <% unless budget.name == "Presupuestos Participativos 2018" %>
                           <%= link_to t("budgets.index.milestones"),
                                       custom_budget_executions_path(budget, status: 1),

--- a/db/migrate/20190116152624_add_delegated_to_votes.rb
+++ b/db/migrate/20190116152624_add_delegated_to_votes.rb
@@ -1,0 +1,5 @@
+class AddDelegatedToVotes < ActiveRecord::Migration
+  def change
+    add_column :votes, :delegated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1785,6 +1785,7 @@ ActiveRecord::Schema.define(version: 20190131122858) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "signature_id"
+    t.boolean  "delegated",    default: false
   end
 
   add_index "votes", ["signature_id"], name: "index_votes_on_signature_id", using: :btree

--- a/lib/migrations/log.rb
+++ b/lib/migrations/log.rb
@@ -1,0 +1,7 @@
+module Migrations::Log
+
+  def log(message)
+    print message unless Rails.env.test?
+  end
+
+end

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -67,6 +67,8 @@ class Migrations::SpendingProposal::Ballot
 
     def ballot_line_saved?(ballot_line)
       return true if ballot_line_exists?(ballot_line)
+
+      ballot_line.set_denormalized_ids
       ballot_line.save(validate: false)
     end
 

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -2,6 +2,8 @@ require_dependency "budget"
 require_dependency "budget/ballot"
 
 class Migrations::SpendingProposal::Ballot
+  include Migrations::Log
+
   attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
 
   def initialize(spending_proposal_ballot, represented_user=nil)
@@ -12,11 +14,11 @@ class Migrations::SpendingProposal::Ballot
 
   def migrate_ballot
     if budget_investment_ballot_valid?
-      puts "."
+      log(".")
 
       migrate_ballot_lines
     else
-      puts "Error creating budget investment ballot from spending proposal ballot #{spending_proposal_ballot.id}\n"
+      log("\nError creating budget investment ballot from spending proposal ballot #{spending_proposal_ballot.id}\n")
     end
   end
 
@@ -26,9 +28,9 @@ class Migrations::SpendingProposal::Ballot
 
       ballot_line = new_ballot_line(budget_investment)
       if ballot_line_valid?(ballot_line) && ballot_line.save
-        print "."
+        log(".")
       else
-        puts "Error adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n"
+        log("\nError adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n")
       end
     end
   end

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -13,7 +13,9 @@ class Migrations::SpendingProposal::Ballot
   end
 
   def migrate_ballot
-    if budget_investment_ballot_saved?
+    return if user_already_voted?
+
+    if budget_investment_ballot.save
       log(".")
       migrate_ballot_lines
     else
@@ -61,8 +63,8 @@ class Migrations::SpendingProposal::Ballot
       budget_investment_ballot.lines.where(attributes).first_or_initialize
     end
 
-    def budget_investment_ballot_saved?
-      budget_investment_ballot.new_record? && budget_investment_ballot.save
+    def user_already_voted?
+      budget_investment_ballot.ballot_lines_count > 0 && represented_user
     end
 
     def ballot_line_saved?(ballot_line)
@@ -78,13 +80,13 @@ class Migrations::SpendingProposal::Ballot
 
     def budget_investment_ballot_attributes
       {
-        budget: budget,
-        user: user
+        budget_id: budget.id,
+        user_id: user_id
       }
     end
 
-    def user
-      represented_user || spending_proposal_ballot.user
+    def user_id
+      represented_user.try(:id) || spending_proposal_ballot.user_id
     end
 
 end

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -1,3 +1,6 @@
+require_dependency "budget"
+require_dependency "budget/ballot"
+
 class Migrations::SpendingProposal::Ballot
   attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
 

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -8,7 +8,7 @@ class Migrations::SpendingProposal::Ballot
   end
 
   def migrate_ballot
-    if budget_investment_ballot.save
+    if budget_investment_ballot_valid?
       puts "."
 
       migrate_ballot_lines
@@ -42,6 +42,10 @@ class Migrations::SpendingProposal::Ballot
 
     def find_or_initialize_budget_investment_ballot
       Budget::Ballot.find_or_initialize_by(budget_investment_ballot_attributes)
+    end
+
+    def budget_investment_ballot_valid?
+      budget_investment_ballot.new_record? && budget_investment_ballot.save
     end
 
     def new_ballot_line(budget_investment)

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -21,7 +21,7 @@ class Migrations::SpendingProposal::Ballot
       budget_investment = find_budget_investment(spending_proposal)
 
       ballot_line = new_ballot_line(budget_investment)
-      if ballot_line && ballot_line.save
+      if ballot_line_valid?(ballot_line) && ballot_line.save
         print "."
       else
         puts "Error adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n"
@@ -47,6 +47,14 @@ class Migrations::SpendingProposal::Ballot
       if budget_investment
         budget_investment_ballot.lines.new(investment: budget_investment)
       end
+    end
+
+    def ballot_line_valid?(ballot_line)
+      ballot_line && ballot_line_does_not_exist?(ballot_line)
+    end
+
+    def ballot_line_does_not_exist?(ballot_line)
+      budget_investment_ballot.investments.exclude?(ballot_line.investment)
     end
 
     def budget_investment_ballot_attributes

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -1,7 +1,8 @@
 class Migrations::SpendingProposal::Ballot
-  attr_accessor :spending_proposal_ballot, :budget_investment_ballot
+  attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
 
-  def initialize(spending_proposal_ballot)
+  def initialize(spending_proposal_ballot, represented_user=nil)
+    @represented_user = represented_user
     @spending_proposal_ballot = spending_proposal_ballot
     @budget_investment_ballot = find_or_initialize_budget_investment_ballot
   end
@@ -60,8 +61,12 @@ class Migrations::SpendingProposal::Ballot
     def budget_investment_ballot_attributes
       {
         budget: budget,
-        user: spending_proposal_ballot.user
+        user: user
       }
+    end
+
+    def user
+      represented_user || spending_proposal_ballot.user
     end
 
 end

--- a/lib/migrations/spending_proposal/ballots.rb
+++ b/lib/migrations/spending_proposal/ballots.rb
@@ -1,0 +1,21 @@
+class Migrations::SpendingProposal::Ballots
+  attr_accessor :spending_proposal_ballots
+
+  def initialize
+    @spending_proposal_ballots = load_ballots
+  end
+
+  def migrate_all
+    spending_proposal_ballots.each do |spending_proposal_ballot|
+      budget_investment_ballot = Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot)
+      budget_investment_ballot.migrate_ballot
+    end
+  end
+
+  private
+
+    def load_ballots
+      ::Ballot.all
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -1,0 +1,159 @@
+require_dependency "spending_proposal"
+
+class Migrations::SpendingProposal::Budget
+  attr_accessor :budget
+
+  def initialize
+    @budget = find_budget
+  end
+
+  def pre_rake_tasks
+    update_heading_price
+    update_heading_population
+    update_selected_investments
+  end
+
+  def post_rake_tasks
+    remove_forum_votes
+    remove_forum_ballots
+    update_cached_votes
+    update_cached_ballots
+    calculate_winners
+  end
+
+  private
+
+    def update_heading_price
+      update_city_heading_price
+      update_district_heading_price
+    end
+
+    def update_city_heading_price
+      budget.headings.where(name: "Toda la ciudad").first&.update(price: 24000000)
+    end
+
+    def update_district_heading_price
+      price_by_heading.each do |heading_name, price|
+        budget.headings.where(name: heading_name).first&.update(price: price)
+      end
+    end
+
+    def price_by_heading
+      {
+        "Arganzuela"          => 1556169,
+        "Barajas"             => 433589,
+        "Carabanchel"         => 3247830,
+        "Centro"              => 1353966,
+        "Chamartín"           => 1313747,
+        "Chamberí"            => 1259587,
+        "Ciudad Lineal"       => 2287757,
+        "Fuencarral-El Pardo" => 2441608,
+        "Hortaleza"           => 1827228,
+        "Latina"              => 2927200,
+        "Moncloa-Aravaca"     => 1129851,
+        "Moratalaz"           => 1067341,
+        "Puente de Vallecas"  => 3349186,
+        "Retiro"              => 1075155,
+        "Salamanca"           => 1286657,
+        "San Blas-Canillejas" => 1712043,
+        "Tetuán"              => 1677256,
+        "Usera"               => 1923216,
+        "Vicálvaro"           => 879529,
+        "Villa de Vallecas"   => 1220810,
+        "Villaverde"          => 2030275
+      }
+    end
+
+    def update_heading_population
+      update_city_heading_population
+      update_district_heading_population
+    end
+
+    def update_city_heading_population
+      budget.headings.where(name: "Toda la ciudad").first&.update(population: city_population)
+    end
+
+    def update_district_heading_population
+      population_by_heading.each do |heading_name, population|
+        budget.headings.where(name: heading_name).first&.update(population: population)
+      end
+    end
+
+    def city_population
+      population_by_heading.collect {|district, population| population}.sum
+    end
+
+    def population_by_heading
+      {
+        "Arganzuela"          => 131429,
+        "Barajas"             =>  37725,
+        "Carabanchel"         => 205197,
+        "Centro"              => 120867,
+        "Chamartín"           => 123099,
+        "Chamberí"            => 122280,
+        "Ciudad Lineal"       => 184285,
+        "Fuencarral-El Pardo" => 194232,
+        "Hortaleza"           => 146471,
+        "Latina"              => 204427,
+        "Moncloa-Aravaca"     =>  99274,
+        "Moratalaz"           =>  82741,
+        "Puente de Vallecas"  => 194314,
+        "Retiro"              => 103666,
+        "Salamanca"           => 126699,
+        "San Blas-Canillejas" => 127800,
+        "Tetuán"              => 133972,
+        "Usera"               => 112158,
+        "Vicálvaro"           =>  55783,
+        "Villa de Vallecas"   =>  82504,
+        "Villaverde"          => 117478
+      }
+    end
+
+    def update_selected_investments
+      ::SpendingProposal.feasible.valuation_finished.each do |spending_proposal|
+        find_budget_investment(spending_proposal)&.update(selected: true)
+      end
+    end
+
+    def remove_forum_votes
+      forums.each do |forum|
+        forum.user.votes.where(votable: budget.investments).destroy_all
+      end
+    end
+
+    def remove_forum_ballots
+      forums.each do |forum|
+        Budget::Ballot.where(user: forum.user).first&.destroy
+      end
+    end
+
+    def update_cached_votes
+      budget.investments.map(&:update_cached_votes)
+    end
+
+    def update_cached_ballots
+      budget.investments.each do |investment|
+        ballot_lines_count = budget.lines.where(investment: investment).count
+        investment.update(ballot_lines_count: ballot_lines_count)
+      end
+    end
+
+    def calculate_winners
+      budget.headings.each do |heading|
+        Budget::Result.new(budget, heading).calculate_winners
+      end
+    end
+
+    def forums
+      Forum.all
+    end
+
+    def find_budget_investment(spending_proposal)
+      budget.investments.where(original_spending_proposal_id: spending_proposal.id).first
+    end
+
+    def find_budget
+      ::Budget.where(slug: 2016).first
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -1,0 +1,31 @@
+class Migrations::SpendingProposal::BudgetInvestment
+  attr_accessor :spending_proposal, :budget_investment
+
+  def initialize(spending_proposal)
+    @spending_proposal = spending_proposal
+    @budget_investment = find_or_initialize_budget_investment
+  end
+
+  def update
+    if budget_investment.update(budget_investment_attributes)
+      print "."
+    else
+      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}"
+    end
+  end
+
+  private
+
+    def budget
+      Budget.where(slug: "2016").first
+    end
+
+    def find_or_initialize_budget_investment
+      budget.investments.where(original_spending_proposal_id: spending_proposal.id).first
+    end
+
+    def budget_investment_attributes
+      { unfeasibility_explanation: spending_proposal.feasible_explanation }
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -7,7 +7,7 @@ class Migrations::SpendingProposal::BudgetInvestment
   end
 
   def update
-    if budget_investment.update(budget_investment_attributes)
+    if budget_investment && budget_investment.update(budget_investment_attributes)
       print "."
     else
       puts "Error updating budget investment from spending proposal: #{spending_proposal.id}"

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -59,6 +59,7 @@ class Migrations::SpendingProposal::BudgetInvestment
       comment = new_valuation_comment
       if comment.save
         log(".")
+        return true
       else
         log("Error creating comment for budget investment: #{budget_investment.id}\n")
         log(comment.errors.messages)

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -3,7 +3,7 @@ class Migrations::SpendingProposal::BudgetInvestment
 
   def initialize(spending_proposal)
     @spending_proposal = spending_proposal
-    @budget_investment = find_or_initialize_budget_investment
+    @budget_investment = find_budget_investment
   end
 
   def update
@@ -20,7 +20,7 @@ class Migrations::SpendingProposal::BudgetInvestment
       Budget.where(slug: "2016").first
     end
 
-    def find_or_initialize_budget_investment
+    def find_budget_investment
       budget.investments.where(original_spending_proposal_id: spending_proposal.id).first
     end
 

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -10,7 +10,7 @@ class Migrations::SpendingProposal::BudgetInvestment
     if budget_investment && budget_investment.update(budget_investment_attributes)
       print "."
     else
-      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}"
+      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}\n"
     end
   end
 
@@ -25,7 +25,17 @@ class Migrations::SpendingProposal::BudgetInvestment
     end
 
     def budget_investment_attributes
-      { unfeasibility_explanation: spending_proposal.feasible_explanation }
+      { unfeasibility_explanation: field_with_unfeasibility_explanation }
+    end
+
+    def field_with_unfeasibility_explanation
+      if spending_proposal.unfeasible?
+        spending_proposal.feasible_explanation.presence ||
+        spending_proposal.price_explanation.presence ||
+        spending_proposal.internal_comments
+      else
+        spending_proposal.feasible_explanation
+      end
     end
 
 end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -58,8 +58,12 @@ class Migrations::SpendingProposal::BudgetInvestment
     def valuation_comment_attributes
       {
         body: spending_proposal.internal_comments,
-        user: spending_proposal.administrator.user
+        user: spending_proposal_administrator
       }
+    end
+
+    def spending_proposal_administrator
+      spending_proposal.administrator.try(&:user) || Administrator.first.user
     end
 
 end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -1,4 +1,6 @@
 class Migrations::SpendingProposal::BudgetInvestment
+  include Migrations::Log
+
   attr_accessor :spending_proposal, :budget_investment
 
   def initialize(spending_proposal)
@@ -8,9 +10,9 @@ class Migrations::SpendingProposal::BudgetInvestment
 
   def update
     if updated?
-      print "."
+      log(".")
     else
-      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}\n"
+      log("\nError updating budget investment from spending proposal: #{spending_proposal.id}\n")
     end
   end
 

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -51,16 +51,14 @@ class Migrations::SpendingProposal::BudgetInvestment
 
     def create_valuation_comments
       if spending_proposal.internal_comments.present?
-        budget_investment.comments.create!(valuation_comment_attributes)
+        budget_investment.valuations.first_or_create!(valuation_comment_attributes)
       end
     end
 
     def valuation_comment_attributes
       {
         body: spending_proposal.internal_comments,
-        user: spending_proposal.administrator.user,
-        commentable: budget_investment,
-        valuation: true
+        user: spending_proposal.administrator.user
       }
     end
 

--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -15,7 +15,7 @@ class Migrations::SpendingProposal::BudgetInvestments
   private
 
     def load_spending_proposals
-      SpendingProposal.all
+      ::SpendingProposal.all
     end
 
 end

--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -1,0 +1,21 @@
+class Migrations::SpendingProposal::BudgetInvestments
+  attr_accessor :spending_proposals
+
+  def initialize
+    @spending_proposals = load_spending_proposals
+  end
+
+  def update_all
+    spending_proposals.each do |spending_proposal|
+      budget_investment = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      budget_investment.update
+    end
+  end
+
+  private
+
+    def load_spending_proposals
+      SpendingProposal.all
+    end
+
+end

--- a/lib/migrations/spending_proposal/delegated_ballot.rb
+++ b/lib/migrations/spending_proposal/delegated_ballot.rb
@@ -1,0 +1,28 @@
+class Migrations::SpendingProposal::DelegatedBallot
+  attr_accessor :delegated_ballot
+
+  def initialize(delegated_ballot)
+    @delegated_ballot = delegated_ballot
+  end
+
+  def migrate_delegated_ballot
+    represented_users.each do |represented_user|
+      migrate_ballot(represented_user)
+    end
+  end
+
+  private
+
+    def represented_users
+      forum.represented_users
+    end
+
+    def forum
+      delegated_ballot.user.forum
+    end
+
+    def migrate_ballot(represented_user)
+      Migrations::SpendingProposal::Ballot.new(delegated_ballot, represented_user).migrate_ballot
+    end
+
+end

--- a/lib/migrations/spending_proposal/delegated_ballots.rb
+++ b/lib/migrations/spending_proposal/delegated_ballots.rb
@@ -1,0 +1,25 @@
+class Migrations::SpendingProposal::DelegatedBallots
+  attr_accessor :delegated_ballots
+
+  def initialize
+    @delegated_ballots = load_delegated_ballots
+  end
+
+  def migrate_all
+    delegated_ballots.each do |ballot|
+      migrate_delegated_ballot(ballot)
+    end
+  end
+
+  private
+
+    def load_delegated_ballots
+      Ballot.where(user: User.forums)
+    end
+
+
+    def migrate_delegated_ballot(ballot)
+      Migrations::SpendingProposal::DelegatedBallot.new(ballot).migrate_delegated_ballot
+    end
+
+end

--- a/lib/migrations/spending_proposal/delegated_ballots.rb
+++ b/lib/migrations/spending_proposal/delegated_ballots.rb
@@ -14,7 +14,7 @@ class Migrations::SpendingProposal::DelegatedBallots
   private
 
     def load_delegated_ballots
-      Ballot.where(user: User.forums)
+      ::Ballot.where(user: User.forums)
     end
 
 

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -1,0 +1,44 @@
+class Migrations::SpendingProposal::Vote
+
+  def migrate_delegated_votes
+    delegated_votes.each do |delegated_vote|
+      create_vote(delegated_vote)
+    end
+  end
+
+  def create_vote(delegated_vote)
+    vote_attributes = {
+      voter: delegated_vote[:voter],
+      votable: delegated_vote[:votable],
+      delegated: true
+    }
+    Vote.create!(vote_attributes)
+  end
+
+  def delegated_votes
+    representative_votes.map do |vote|
+      represented_user_votes(vote)
+    end.flatten
+  end
+
+  def representative_votes
+    Vote.representative_votes
+  end
+
+  def represented_user_votes(vote)
+    representative = vote.voter.forum
+    spending_proposal = vote.votable
+
+    representative.represented_users.map do |represented_user|
+      represented_user_vote(represented_user, spending_proposal)
+    end.compact
+  end
+
+  def represented_user_vote(represented_user, spending_proposal)
+    unless represented_user.voted_for?(spending_proposal)
+      { voter: represented_user,
+        votable: spending_proposal }
+    end
+  end
+
+end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -1,4 +1,5 @@
 class Migrations::SpendingProposal::Vote
+  include Migrations::Log
 
   def migrate_delegated_votes
     delegated_votes.each do |delegated_vote|
@@ -13,6 +14,7 @@ class Migrations::SpendingProposal::Vote
       delegated: true
     }
     Vote.create!(vote_attributes)
+    log(".")
   end
 
   def delegated_votes
@@ -44,6 +46,7 @@ class Migrations::SpendingProposal::Vote
   def create_budget_investment_votes
     spending_proposal_votes.each do |vote|
       create_budget_invesment_vote(vote)
+      log(".")
     end
   end
 

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -41,4 +41,25 @@ class Migrations::SpendingProposal::Vote
     end
   end
 
+  def create_budget_investment_votes
+    spending_proposal_votes.each do |vote|
+      create_budget_invesment_vote(vote)
+    end
+  end
+
+  private
+
+    def spending_proposal_votes
+      Vote.where(votable: SpendingProposal.all)
+    end
+
+    def create_budget_invesment_vote(vote)
+      budget_investment = find_budget_investment(vote.votable)
+      budget_investment.vote_by(voter: vote.voter, vote: "yes")
+    end
+
+    def find_budget_investment(spending_proposal)
+      Budget::Investment.where(original_spending_proposal_id: spending_proposal.id).first
+    end
+
 end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -25,15 +25,4 @@ class Migrations::SpendingProposal::Vote
       end
     end
 
-    def vote_with_hidden_user(voter_id, budget_investment)
-      vote_attributes = {
-        voter_id: voter_id,
-        votable: budget_investment,
-        vote_flag: true
-      }
-
-      vote = Vote.where(vote_attributes).first_or_create
-      vote.save(validate: false)
-    end
-
 end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -1,48 +1,6 @@
 class Migrations::SpendingProposal::Vote
   include Migrations::Log
 
-  def migrate_delegated_votes
-    delegated_votes.each do |delegated_vote|
-      create_vote(delegated_vote)
-    end
-  end
-
-  def create_vote(delegated_vote)
-    vote_attributes = {
-      voter: delegated_vote[:voter],
-      votable: delegated_vote[:votable],
-      delegated: true
-    }
-    Vote.create!(vote_attributes)
-    log(".")
-  end
-
-  def delegated_votes
-    representative_votes.map do |vote|
-      represented_user_votes(vote)
-    end.flatten
-  end
-
-  def representative_votes
-    Vote.representative_votes
-  end
-
-  def represented_user_votes(vote)
-    representative = vote.voter.forum
-    spending_proposal = vote.votable
-
-    representative.represented_users.map do |represented_user|
-      represented_user_vote(represented_user, spending_proposal)
-    end.compact
-  end
-
-  def represented_user_vote(represented_user, spending_proposal)
-    unless represented_user.voted_for?(spending_proposal)
-      { voter: represented_user,
-        votable: spending_proposal }
-    end
-  end
-
   def create_budget_investment_votes
     spending_proposal_votes.each do |vote|
       create_budget_invesment_vote(vote)
@@ -56,6 +14,10 @@ class Migrations::SpendingProposal::Vote
       Vote.where(votable: SpendingProposal.all)
     end
 
+    def find_budget_investment(spending_proposal)
+      Budget::Investment.where(original_spending_proposal_id: spending_proposal.id).first
+    end
+
     def create_budget_invesment_vote(vote)
       budget_investment = find_budget_investment(vote.votable)
       if budget_investment
@@ -63,8 +25,15 @@ class Migrations::SpendingProposal::Vote
       end
     end
 
-    def find_budget_investment(spending_proposal)
-      Budget::Investment.where(original_spending_proposal_id: spending_proposal.id).first
+    def vote_with_hidden_user(voter_id, budget_investment)
+      vote_attributes = {
+        voter_id: voter_id,
+        votable: budget_investment,
+        vote_flag: true
+      }
+
+      vote = Vote.where(vote_attributes).first_or_create
+      vote.save(validate: false)
     end
 
 end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -4,7 +4,6 @@ class Migrations::SpendingProposal::Vote
   def create_budget_investment_votes
     spending_proposal_votes.each do |vote|
       create_budget_invesment_vote(vote)
-      log(".")
     end
   end
 
@@ -20,9 +19,27 @@ class Migrations::SpendingProposal::Vote
 
     def create_budget_invesment_vote(vote)
       budget_investment = find_budget_investment(vote.votable)
-      if budget_investment
+      return false unless budget_investment
+
+      if vote.voter
         budget_investment.vote_by(voter: vote.voter, vote: "yes")
+        log(".")
+      elsif vote_with_hidden_user(vote.voter_id, budget_investment)
+        log(".")
+      else
+        log("\nError creating budget investment vote from spending proposal vote: #{vote.id}\n")
       end
+    end
+
+    def vote_with_hidden_user(voter_id, budget_investment)
+      vote_attributes = {
+        voter_id: voter_id,
+        votable: budget_investment,
+        vote_flag: true
+      }
+
+      vote = Vote.where(vote_attributes).first_or_create
+      vote.save(validate: false)
     end
 
 end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -55,7 +55,9 @@ class Migrations::SpendingProposal::Vote
 
     def create_budget_invesment_vote(vote)
       budget_investment = find_budget_investment(vote.votable)
-      budget_investment.vote_by(voter: vote.voter, vote: "yes")
+      if budget_investment
+        budget_investment.vote_by(voter: vote.voter, vote: "yes")
+      end
     end
 
     def find_budget_investment(spending_proposal)

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -33,4 +33,10 @@ namespace :spending_proposals do
     Budget::Investment.where(original_spending_proposal_id: winner_spending_proposals)
                       .update_all(winner: true, selected: true)
   end
+
+  desc "Migrates delegated votes to represented user votes"
+  task migrate_delegated_votes: :environment do
+    require "migrations/spending_proposal/vote"
+    Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+  end
 end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -34,6 +34,14 @@ namespace :spending_proposals do
                       .update_all(winner: true, selected: true)
   end
 
+  desc "Migrates all necessary data from spending proposals to budget investments"
+  task migrate: [
+    "spending_proposals:migrate_attributes",
+    "spending_proposals:migrate_delegated_votes",
+    "spending_proposals:migrate_ballots",
+    "spending_proposals:migrate_delegated_ballots",
+  ]
+
   desc "Migrates delegated votes to represented user votes"
   task migrate_delegated_votes: :environment do
     require "migrations/spending_proposal/vote"

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -39,4 +39,13 @@ namespace :spending_proposals do
     require "migrations/spending_proposal/vote"
     Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
   end
+
+  desc "Migrates spending proposals attributes to corresponding budget investments attributes"
+  task migrate_attributes_to_budget_investments: :environment do
+    require "migrations/spending_proposal/budget_investments"
+
+    puts "Starting to migration attributes from spending proposals to budget investments"
+    Migrations::SpendingProposal::BudgetInvestments.new.update_all
+    puts "Finished"
+  end
 end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -45,15 +45,21 @@ namespace :spending_proposals do
   desc "Migrates delegated votes to represented user votes"
   task migrate_delegated_votes: :environment do
     require "migrations/spending_proposal/vote"
+
+    puts "Starting to migrate delegated votes"
     Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+    puts "Finished"
+
+    puts "Starting to migrate votes"
     Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+    puts "Finished"
   end
 
   desc "Migrates spending proposals attributes to corresponding budget investments attributes"
-  task migrate_attributes_to_budget_investments: :environment do
+  task migrate_attributes: :environment do
     require "migrations/spending_proposal/budget_investments"
 
-    puts "Starting to migration attributes from spending proposals to budget investments"
+    puts "Starting to migrate attributes"
     Migrations::SpendingProposal::BudgetInvestments.new.update_all
     puts "Finished"
   end
@@ -62,7 +68,7 @@ namespace :spending_proposals do
   task migrate_ballots: :environment do
     require "migrations/spending_proposal/ballots"
 
-    puts "Starting to migrate spending proposal ballots"
+    puts "Starting to migrate ballots"
     Migrations::SpendingProposal::Ballots.new.migrate_all
     puts "Finished"
   end
@@ -72,7 +78,7 @@ namespace :spending_proposals do
   task migrate_delegated_ballots: :environment do
     require "migrations/spending_proposal/delegated_ballots"
 
-    puts "Starting to migrate spending proposals delegated ballots"
+    puts "Starting to migrate delegated ballots"
     Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
     puts "Finished"
   end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -38,6 +38,7 @@ namespace :spending_proposals do
   task migrate_delegated_votes: :environment do
     require "migrations/spending_proposal/vote"
     Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+    Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
   end
 
   desc "Migrates spending proposals attributes to corresponding budget investments attributes"

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -37,11 +37,22 @@ namespace :spending_proposals do
 
   desc "Migrates all necessary data from spending proposals to budget investments"
   task migrate: [
+    "spending_proposals:pre_migrate",
     "spending_proposals:migrate_attributes",
     "spending_proposals:migrate_votes",
     "spending_proposals:migrate_ballots",
     "spending_proposals:migrate_delegated_ballots",
+    "spending_proposals:post_migrate",
   ]
+
+  desc "Run the required actions before the migration"
+  task pre_migrate: :environment do
+    require "migrations/spending_proposal/budget"
+
+    puts "Starting pre rake tasks"
+    Migrations::SpendingProposal::Budget.new.pre_rake_tasks
+    puts "Finished"
+  end
 
   desc "Migrates spending proposals attributes to budget investments attributes"
   task migrate_attributes: :environment do
@@ -76,6 +87,15 @@ namespace :spending_proposals do
 
     puts "Starting to migrate delegated ballots"
     Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+    puts "Finished"
+  end
+
+  desc "Run the required actions after the migration"
+  task post_migrate: :environment do
+    require "migrations/spending_proposal/budget"
+
+    puts "Starting post rake tasks"
+    Migrations::SpendingProposal::Budget.new.post_rake_tasks
     puts "Finished"
   end
 

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -61,7 +61,7 @@ namespace :spending_proposals do
 
 
   desc "Migrates spending proposals delegated ballots to budget investments ballots"
-  task migrate_ballots: :environment do
+  task migrate_delegated_ballots: :environment do
     require "migrations/spending_proposal/delegated_ballots"
 
     puts "Starting to migrate spending proposals delegated ballots"

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -49,4 +49,14 @@ namespace :spending_proposals do
     Migrations::SpendingProposal::BudgetInvestments.new.update_all
     puts "Finished"
   end
+
+  desc "Migrates spending proposals ballots to budget investments ballots"
+  task migrate_ballots: :environment do
+    require "migrations/spending_proposal/ballots"
+
+    puts "Starting to migrate spending proposal ballots"
+    Migrations::SpendingProposal::Ballots.new.migrate_all
+    puts "Finished"
+  end
+
 end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -1,4 +1,5 @@
 namespace :spending_proposals do
+
   desc "Migrates Existing 2016 Spending Proposals to Budget Investments (PARTIALLY)"
   task migrate_to_budgets: :environment do
     puts "We have #{SpendingProposal.count} spending proposals"
@@ -37,30 +38,26 @@ namespace :spending_proposals do
   desc "Migrates all necessary data from spending proposals to budget investments"
   task migrate: [
     "spending_proposals:migrate_attributes",
-    "spending_proposals:migrate_delegated_votes",
+    "spending_proposals:migrate_votes",
     "spending_proposals:migrate_ballots",
     "spending_proposals:migrate_delegated_ballots",
   ]
 
-  desc "Migrates delegated votes to represented user votes"
-  task migrate_delegated_votes: :environment do
-    require "migrations/spending_proposal/vote"
-
-    puts "Starting to migrate delegated votes"
-    Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-    puts "Finished"
-
-    puts "Starting to migrate votes"
-    Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
-    puts "Finished"
-  end
-
-  desc "Migrates spending proposals attributes to corresponding budget investments attributes"
+  desc "Migrates spending proposals attributes to budget investments attributes"
   task migrate_attributes: :environment do
     require "migrations/spending_proposal/budget_investments"
 
     puts "Starting to migrate attributes"
     Migrations::SpendingProposal::BudgetInvestments.new.update_all
+    puts "Finished"
+  end
+
+  desc "Migrates spending proposl votes to budget investment votes"
+  task migrate_votes: :environment do
+    require "migrations/spending_proposal/vote"
+
+    puts "Starting to migrate votes"
+    Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
     puts "Finished"
   end
 
@@ -72,7 +69,6 @@ namespace :spending_proposals do
     Migrations::SpendingProposal::Ballots.new.migrate_all
     puts "Finished"
   end
-
 
   desc "Migrates spending proposals delegated ballots to budget investments ballots"
   task migrate_delegated_ballots: :environment do

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -59,4 +59,14 @@ namespace :spending_proposals do
     puts "Finished"
   end
 
+
+  desc "Migrates spending proposals delegated ballots to budget investments ballots"
+  task migrate_ballots: :environment do
+    require "migrations/spending_proposal/delegated_ballots"
+
+    puts "Starting to migrate spending proposals delegated ballots"
+    Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+    puts "Finished"
+  end
+
 end

--- a/spec/factories/custom.rb
+++ b/spec/factories/custom.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
     user
   end
 
+  factory :represented_user, parent: :user, traits: [:level_three] do
+    association :representative, factory: :forum
+  end
+
   factory :ballot do
     user
   end

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -241,6 +241,8 @@ feature 'Executions' do
     let!(:budget) { create(:budget, :finished, slug: '2016') }
 
     scenario 'can navigate from spending proposal Results page to Executions page' do
+      skip "Deprecated"
+
       create(:milestone, milestoneable: investment1)
 
       visit participatory_budget_results_path
@@ -255,6 +257,8 @@ feature 'Executions' do
     end
 
     scenario 'renders spending proposal navigation when accessing 2016 budget' do
+      skip "Deprecated"
+
       create(:milestone, milestoneable: investment1)
 
       visit participatory_budget_executions_path

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -76,9 +76,28 @@ feature 'Results' do
     end
   end
 
-  scenario "Load first budget heading if not specified" do
+  scenario "Load city heading if not specified" do
+    city_heading = create(:budget_heading, group: group)
+    city_investment = create(:budget_investment, :winner, heading: city_heading)
+
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)
+
+    allow_any_instance_of(Budget).to receive(:city_heading).and_return(city_heading)
+
+    visit custom_budget_results_path(budget)
+
+    within("#budget-investments-compatible") do
+      expect(page).to have_content city_investment.title
+      expect(page).not_to have_content other_investment.title
+    end
+  end
+
+  scenario "Load first budget heading if not specified and city heading does not exist" do
+    other_heading = create(:budget_heading, group: group)
+    other_investment = create(:budget_investment, :winner, heading: other_heading)
+
+    allow_any_instance_of(Budget).to receive(:city_heading).and_return(nil)
 
     visit custom_budget_results_path(budget)
 
@@ -144,6 +163,28 @@ feature 'Results' do
       expect(page).to have_content "Results"
     end
 
-  end
+    context "headings" do
 
+      scenario "Displays headings ordered by name with city heading first" do
+        budget.update(phase: "finished")
+
+        district_group = create(:budget_group, budget: budget)
+        create(:budget_heading, group: district_group, name: "Brooklyn")
+        create(:budget_heading, group: district_group, name: "Queens")
+        create(:budget_heading, group: district_group, name: "Manhattan")
+
+        city_group = create(:budget_group, budget: budget)
+        city_heading = create(:budget_heading, group: city_group, name: "City of New York")
+
+        visit budget_results_path(budget)
+
+        within("#headings") do
+          expect("City of New York").to appear_before("Brooklyn")
+          expect("Brooklyn").to appear_before("Manhattan")
+          expect("Manhattan").to appear_before("Queens")
+        end
+      end
+    end
+
+  end
 end

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -56,6 +56,28 @@ feature 'Stats' do
       expect(page).to have_content "Stats"
     end
 
-  end
+    context "headings" do
 
+      scenario "Displays headings ordered by name with city heading first" do
+        budget.update(phase: "finished")
+
+        district_group = create(:budget_group, budget: budget)
+        create(:budget_heading, group: district_group, name: "Brooklyn")
+        create(:budget_heading, group: district_group, name: "Queens")
+        create(:budget_heading, group: district_group, name: "Manhattan")
+
+        city_group = create(:budget_group, budget: budget)
+        city_heading = create(:budget_heading, group: city_group, name: "City of New York")
+
+        visit budget_stats_path(budget)
+
+        within("#headings") do
+          expect("City of New York").to appear_before("Brooklyn")
+          expect("Brooklyn").to appear_before("Manhattan")
+          expect("Manhattan").to appear_before("Queens")
+        end
+      end
+    end
+
+  end
 end

--- a/spec/features/spending_proposals_spec.rb
+++ b/spec/features/spending_proposals_spec.rb
@@ -463,6 +463,8 @@ feature 'Spending proposals' do
       end
 
       scenario "Spending proposals with no geozone" do
+        skip "Deprecated"
+
         visit participatory_budget_results_path
 
         within("#results-container") do
@@ -488,6 +490,8 @@ feature 'Spending proposals' do
       end
 
       scenario "Geozoned spending proposals", :js do
+        skip "Deprecated"
+
         visit participatory_budget_results_path(geozone_id: @california.id)
         click_link "Show all"
 
@@ -508,6 +512,8 @@ feature 'Spending proposals' do
       context "Compatible spending proposals" do
 
         scenario "Include compatible spending proposals in results" do
+          skip "Deprecated"
+
           compatible_proposal1 = create(:spending_proposal, :finished, :feasible, price: 10, compatible: true)
           compatible_proposal2 = create(:spending_proposal, :finished, :feasible, price: 10, compatible: true)
 
@@ -524,6 +530,8 @@ feature 'Spending proposals' do
         end
 
         scenario "Display incompatible spending proposals after results", :js do
+          skip "Deprecated"
+
           incompatible_proposal1 = create(:spending_proposal, :finished, :feasible, price: 10, compatible: false)
           incompatible_proposal2 = create(:spending_proposal, :finished, :feasible, price: 10, compatible: false)
 
@@ -541,6 +549,8 @@ feature 'Spending proposals' do
         end
 
         scenario "Incompatible and not winners are hidden by default", :js do
+          skip "Deprecated"
+
           centro = create(:geozone, name: "Centro") #budget: 1353966
           proposal1 = create(:spending_proposal, :finished, :feasible, price: 1000000, ballot_lines_count: 999, geozone: centro)
           proposal2 = create(:spending_proposal, :finished, :feasible, price:  900000, ballot_lines_count: 888, geozone: centro)
@@ -567,6 +577,8 @@ feature 'Spending proposals' do
       end
 
       scenario "Delegated votes affecting the result" do
+        skip "Deprecated"
+
         forum = create(:forum)
         create_list(:user, 30, :level_two, representative: forum)
         forum.ballot.spending_proposals << @proposal3
@@ -587,6 +599,8 @@ feature 'Spending proposals' do
     end
 
     scenario "Displays only finished feasible spending proposals", :js do
+      skip "Deprecated"
+
       california = create(:geozone)
 
       proposal1 = create(:spending_proposal, :finished, :feasible, price: 10, ballot_lines_count: 20, geozone: california)
@@ -606,6 +620,8 @@ feature 'Spending proposals' do
     end
 
     scenario "Highlights winner candidates (within budget), if tied most expensive first", :js do
+      skip "Deprecated"
+
       centro = create(:geozone, name: "Centro") #budget: 1353966
 
       proposal1 = create(:spending_proposal, :finished, :feasible, price: 1000000, ballot_lines_count: 999, geozone: centro)

--- a/spec/lib/migrations/spending_proposals/ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/ballot_spec.rb
@@ -82,6 +82,19 @@ describe Migrations::SpendingProposal::Ballot do
         expect(budget_investment_ballot.investments).not_to include(budget_investment3)
       end
 
+      it "verifies that the ballot line does not exist" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments.count).to eq(1)
+      end
+
       it "gracefully handles missing corresponding budget investment" do
         spending_proposal = create(:spending_proposal, feasible: true)
         spending_proposal_ballot.spending_proposals << spending_proposal

--- a/spec/lib/migrations/spending_proposals/ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/ballot_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+require "migrations/spending_proposal/ballot"
+
+describe Migrations::SpendingProposal::Ballot do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let!(:spending_proposal_ballot) { create(:ballot) }
+
+  describe "#initialize" do
+
+    it "initializes the spending proposal ballot and corresponding budget investment ballot" do
+      migration = Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot)
+
+      expect(migration.spending_proposal_ballot.class).to eq(Ballot)
+      expect(migration.spending_proposal_ballot).to eq(spending_proposal_ballot)
+
+      expect(migration.budget_investment_ballot.class).to eq(Budget::Ballot)
+      expect(migration.budget_investment_ballot.budget).to eq(budget)
+      expect(migration.budget_investment_ballot.user).to eq(spending_proposal_ballot.user)
+    end
+
+  end
+
+  describe "#migrate_ballot" do
+
+    context "ballot" do
+
+      it "migrates the ballot" do
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.budget).to eq(budget)
+        expect(budget_investment_ballot.user).to eq(spending_proposal_ballot.user)
+      end
+
+      it "verifies if ballot has already been created" do
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates a single ballot line" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments).to eq([budget_investment])
+      end
+
+      it "migrates multiple ballot lines" do
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        spending_proposal_ballot.spending_proposals << spending_proposal1
+        spending_proposal_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+
+        expect(budget_investment_ballot.investments).to include(budget_investment1)
+        expect(budget_investment_ballot.investments).to include(budget_investment2)
+        expect(budget_investment_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "gracefully handles missing corresponding budget investment" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        expect{ Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot }
+        .not_to raise_error
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposals/ballots_spec.rb
+++ b/spec/lib/migrations/spending_proposals/ballots_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+require "migrations/spending_proposal/ballots"
+
+describe Migrations::SpendingProposal::Ballots do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let!(:spending_proposal_ballot1) { create(:ballot) }
+  let!(:spending_proposal_ballot2) { create(:ballot) }
+
+  describe "#initialize" do
+
+    it "initializes all spending proposal ballots" do
+      migration = Migrations::SpendingProposal::Ballots.new
+
+      expect(migration.spending_proposal_ballots.count).to eq(2)
+      expect(migration.spending_proposal_ballots).to include(spending_proposal_ballot1)
+      expect(migration.spending_proposal_ballots).to include(spending_proposal_ballot2)
+    end
+
+  end
+
+  describe "#migrate_all" do
+
+    context "ballot" do
+
+      it "migrates all ballots" do
+        Migrations::SpendingProposal::Ballots.new.migrate_all
+
+        expect(Budget::Ballot.count).to eq(2)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates ballot lines for all ballots" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot1.spending_proposals << spending_proposal
+        spending_proposal_ballot2.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballots.new.migrate_all
+
+        expect(Budget::Ballot::Line.count).to eq(2)
+
+        budget_investment_ballot1 = Budget::Ballot.first
+        expect(budget_investment_ballot1.investments).to eq([budget_investment])
+
+        budget_investment_ballot2 = Budget::Ballot.second
+        expect(budget_investment_ballot2.investments).to eq([budget_investment])
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -82,6 +82,14 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(budget_investment.unfeasibility_explanation).to eq("")
     end
 
+    it "gracefully handles missing corresponding budget investment" do
+      budget_investment.destroy
+
+      expect{ migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal);
+              migration.update }
+      .not_to raise_error
+    end
+
   end
 
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget_investment"
+
+describe Migrations::SpendingProposal::BudgetInvestment do
+
+  let!(:budget)            { create(:budget, slug: "2016") }
+
+  let!(:spending_proposal) { create(:spending_proposal) }
+
+  let!(:budget_investment) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal.id) }
+
+  describe "#initialize" do
+
+    it "initializes the spending proposal and corresponding budget investment" do
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+
+      expect(migration.spending_proposal).to eq(spending_proposal)
+      expect(migration.budget_investment).to eq(budget_investment)
+    end
+
+  end
+
+  describe "#update" do
+
+    it "updates the attribute unfeasibility_explanation" do
+      explanation = "This project is not feasible because it is too expensive"
+      spending_proposal.update(feasible_explanation: explanation)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+
+      expect(budget_investment.unfeasibility_explanation).to eq(explanation)
+    end
+
+  end
+
+end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -36,6 +36,52 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(budget_investment.unfeasibility_explanation).to eq(explanation)
     end
 
+    it "uses the price explanation attribute if unfeasibility explanation is not present" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.price_explanation = "price explanation saying it is too expensive"
+
+      spending_proposal.feasible = false
+      spending_proposal.valuation_finished = true
+
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("price explanation saying it is too expensive")
+    end
+
+    it "uses the internal comments if unfeasibility explanation is not present" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.internal_comments = "Internal comment with explanation"
+
+      spending_proposal.feasible = false
+      spending_proposal.valuation_finished = true
+
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("Internal comment with explanation")
+    end
+
+    it "does not use other attributes if investment is feasible" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.price_explanation = "price explanation saying it is too expensive"
+
+      spending_proposal.feasible = true
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("")
+    end
+
   end
 
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -112,6 +112,23 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(comment.valuation).to eq(true)
     end
 
+    it "migrates internal comments with a body larger than the standard comment limit" do
+      allow(Comment).to receive(:body_max_length).and_return(20)
+
+      internal_comment = "This project will last 2 years"
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      comment = Comment.first
+      expect(Comment.count).to eq(1)
+      expect(comment.body).to eq(internal_comment)
+      expect(comment.commentable).to eq(budget_investment)
+      expect(comment.valuation).to eq(true)
+    end
+
     it "does not create a comment if internal_comments is blank" do
       migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
       migration.update

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -118,5 +118,18 @@ describe Migrations::SpendingProposal::BudgetInvestment do
 
       expect(Comment.count).to eq(0)
     end
+
+    it "verifies if the comment already exists" do
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+
+      expect(Comment.count).to eq(1)
+    end
+
   end
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -58,6 +58,7 @@ describe Migrations::SpendingProposal::BudgetInvestment do
 
       spending_proposal.feasible = false
       spending_proposal.valuation_finished = true
+      spending_proposal.update(administrator: create(:administrator))
 
       spending_proposal.save(validate: false)
 

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -131,5 +131,16 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(Comment.count).to eq(1)
     end
 
+    it "assigns the first administrator if a spending proposal does not have one" do
+      first_admin = create(:administrator).user
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+
+      expect(Comment.first.author).to eq(first_admin)
+    end
+
   end
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -92,4 +92,30 @@ describe Migrations::SpendingProposal::BudgetInvestment do
 
   end
 
+  context "internal comments" do
+
+    it "migrates internal_comments string to a comment object" do
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      comment = Comment.first
+      expect(Comment.count).to eq(1)
+      expect(comment.body).to eq(internal_comment)
+      expect(comment.author).to eq(spending_proposal.administrator.user)
+      expect(comment.commentable).to eq(budget_investment)
+      expect(comment.valuation).to eq(true)
+    end
+
+    it "does not create a comment if internal_comments is blank" do
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      expect(Comment.count).to eq(0)
+    end
+  end
 end

--- a/spec/lib/migrations/spending_proposals/budget_investments_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investments_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget_investments"
+
+describe Migrations::SpendingProposal::BudgetInvestments do
+
+  let!(:budget)            { create(:budget, slug: "2016") }
+
+  let!(:spending_proposal1) { create(:spending_proposal) }
+  let!(:spending_proposal2) { create(:spending_proposal) }
+
+  let!(:budget_investment1) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal1.id) }
+
+  let!(:budget_investment2) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal2.id) }
+
+  describe "#initialize" do
+
+    it "initializes all spending proposals" do
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+
+      expect(migration.spending_proposals.count).to eq(2)
+      expect(migration.spending_proposals).to include(spending_proposal1)
+      expect(migration.spending_proposals).to include(spending_proposal2)
+    end
+
+  end
+
+  describe "#update_all" do
+
+    it "updates all budget investments with their corresponding spending proposal attributes" do
+      explanation1 = "This project is not feasible because it is too expensive"
+      explanation2 = "This project is not feasible because it out of the governments jurisdiction"
+
+      spending_proposal1.update(feasible_explanation: explanation1)
+      spending_proposal2.update(feasible_explanation: explanation2)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.update_all
+
+      budget_investment1.reload
+      budget_investment2.reload
+
+      expect(budget_investment1.unfeasibility_explanation).to eq(explanation1)
+      expect(budget_investment2.unfeasibility_explanation).to eq(explanation2)
+    end
+
+  end
+
+end

--- a/spec/lib/migrations/spending_proposals/budget_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_spec.rb
@@ -1,0 +1,203 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget"
+
+describe Migrations::SpendingProposal::Budget do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+
+  describe "#initialize" do
+
+    it "initializes the budget to be migrated" do
+      migration = Migrations::SpendingProposal::Budget.new
+
+      expect(migration.budget).to eq(budget)
+    end
+
+  end
+
+  describe "#pre_rake_tasks" do
+
+    let!(:city_group)   { create(:budget_group, budget: budget) }
+    let!(:city_heading) { create(:budget_heading, group: city_group, name: "Toda la ciudad") }
+
+    let!(:district_group)    { create(:budget_group, budget: budget) }
+    let!(:district_heading1) { create(:budget_heading, group: district_group, name: "Arganzuela") }
+    let!(:district_heading2) { create(:budget_heading, group: district_group, name: "Barajas") }
+
+    context "heading price" do
+
+      it "updates the city heading's price" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        city_heading.reload
+        expect(city_heading.price).to eq(24000000)
+      end
+
+      it "updates the district headings' price" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        district_heading1.reload
+        district_heading2.reload
+        expect(district_heading1.price).to eq(1556169)
+        expect(district_heading2.price).to eq(433589)
+      end
+    end
+
+    context "heading population" do
+
+      it "updates the city heading's population" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        city_heading.reload
+        expect(city_heading.population).to eq(2706401)
+      end
+
+      it "updates the district headings' population" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        district_heading1.reload
+        district_heading2.reload
+        expect(district_heading1.population).to eq(131429)
+        expect(district_heading2.population).to eq(37725)
+      end
+
+    end
+
+    context "selected investments" do
+
+      let!(:spending_proposal1) { create(:spending_proposal, feasible: true, valuation_finished: true) }
+      let!(:spending_proposal2) { create(:spending_proposal, feasible: true, valuation_finished: true) }
+      let!(:spending_proposal3) { create(:spending_proposal, feasible: true, valuation_finished: false) }
+      let!(:spending_proposal4) { create(:spending_proposal, feasible: false, valuation_finished: true) }
+
+      let!(:budget_investment1) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal1.id) }
+      let!(:budget_investment2) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal2.id) }
+      let!(:budget_investment3) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal3.id) }
+      let!(:budget_investment4) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal4.id) }
+
+      it "marks feasible and valuation finished investments as selected" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        budget_investment1.reload
+        budget_investment2.reload
+        budget_investment3.reload
+        budget_investment4.reload
+
+        expect(budget_investment1.selected).to eq(true)
+        expect(budget_investment2.selected).to eq(true)
+        expect(budget_investment3.selected).to eq(false)
+        expect(budget_investment4.selected).to eq(false)
+      end
+
+    end
+  end
+
+  describe "#post_rake_tasks" do
+
+    let!(:group)   { create(:budget_group, budget: budget) }
+    let!(:heading) { create(:budget_heading, group: group, price: 99999999) }
+
+    it "Destros all forum votes" do
+      forum1 = create(:forum)
+      forum2 = create(:forum)
+      investment = create(:budget_investment, heading: heading)
+
+      forum1_vote = create(:vote, voter: forum1.user, votable: investment)
+      forum2_vote = create(:vote, voter: forum2.user, votable: investment)
+      user_vote = create(:vote, votable: investment)
+
+      migration = Migrations::SpendingProposal::Budget.new
+      migration.post_rake_tasks
+
+      expect(Vote.count).to eq(1)
+      expect(Vote.all).to include(user_vote)
+    end
+
+    it "Destros all forum ballots" do
+      forum1 = create(:forum)
+      forum2 = create(:forum)
+      investment = create(:budget_investment, :selected, heading: heading)
+
+      forum1_ballot = create(:budget_ballot, budget: budget, user: forum1.user)
+      forum2_ballot = create(:budget_ballot, budget: budget, user: forum2.user)
+      user_ballot   = create(:budget_ballot, budget: budget)
+
+      create(:budget_ballot_line, ballot: forum1_ballot, investment: investment)
+      create(:budget_ballot_line, ballot: forum2_ballot, investment: investment)
+      create(:budget_ballot_line, ballot: user_ballot,   investment: investment)
+
+      migration = Migrations::SpendingProposal::Budget.new
+      migration.post_rake_tasks
+
+      expect(Budget::Ballot.count).to eq(1)
+      expect(Budget::Ballot.all).to include(user_ballot)
+
+      expect(Budget::Ballot::Line.count).to eq(1)
+      expect(Budget::Ballot::Line.all).to include(user_ballot.lines.first)
+    end
+
+    it "Updates cached votes" do
+      investment = create(:budget_investment, :selected, heading: heading)
+
+      create(:vote, votable: investment)
+      create(:vote, votable: investment)
+
+      investment.update(cached_votes_up: 3)
+
+      investment.reload
+      expect(investment.cached_votes_up).to eq(3)
+
+      migration = Migrations::SpendingProposal::Budget.new
+      migration.post_rake_tasks
+
+      investment.reload
+      expect(investment.cached_votes_up).to eq(2)
+    end
+
+    it "Updates cached ballot lines" do
+      investment = create(:budget_investment, :selected, heading: heading)
+
+      ballot1 = create(:budget_ballot, budget: budget)
+      ballot2 = create(:budget_ballot, budget: budget)
+
+      create(:budget_ballot_line, ballot: ballot1, investment: investment)
+      create(:budget_ballot_line, ballot: ballot2, investment: investment)
+
+      investment.update(ballot_lines_count: 3)
+
+      investment.reload
+      expect(investment.ballot_lines_count).to eq(3)
+
+      migration = Migrations::SpendingProposal::Budget.new
+      migration.post_rake_tasks
+
+      investment.reload
+      expect(investment.ballot_lines_count).to eq(2)
+    end
+
+    it "Calculates winners" do
+      ballot = create(:budget_ballot, budget: budget)
+
+      investment1 = create(:budget_investment, :selected, heading: heading)
+      investment2 = create(:budget_investment, :selected, heading: heading)
+      investment3 = create(:budget_investment, :selected, heading: heading)
+
+      create(:budget_ballot_line, ballot: ballot, investment: investment1)
+      create(:budget_ballot_line, ballot: ballot, investment: investment2)
+
+      results = Budget::Result.new(budget, heading)
+      expect(results.winners.count).to eq(0)
+
+      migration = Migrations::SpendingProposal::Budget.new
+      migration.post_rake_tasks
+
+      expect(results.winners.count).to eq(3)
+    end
+
+  end
+end

--- a/spec/lib/migrations/spending_proposals/delegated_ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/delegated_ballot_spec.rb
@@ -1,0 +1,218 @@
+require "rails_helper"
+require "migrations/spending_proposal/delegated_ballot"
+
+describe Migrations::SpendingProposal::DelegatedBallot do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+
+  describe "#initialize" do
+
+    it "initializes a delegated spending proposal ballot" do
+      forum = create(:forum)
+      delegated_ballot = create(:ballot, user: forum.user)
+
+      migration = Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot)
+
+      expect(migration.delegated_ballot.class).to eq(Ballot)
+      expect(migration.delegated_ballot.user).to eq(forum.user)
+    end
+
+  end
+
+  describe "#migrate_delegated_ballot" do
+
+    context "ballot" do
+
+      it "migrates a delegated ballot for a single represented user" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_ballot = Budget::Ballot.first
+        expect(budget_ballot.user).to eq(represented_user)
+      end
+
+      it "migrates a delegated ballot for each represented user" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user1 = create(:represented_user, representative: forum)
+        represented_user2 = create(:represented_user, representative: forum)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(2)
+
+        budget_ballot_users = Budget::Ballot.all.map(&:user)
+        expect(budget_ballot_users).to include(represented_user1)
+        expect(budget_ballot_users).to include(represented_user2)
+      end
+
+      it "only creates delegated ballots if there are represented users" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(0)
+      end
+
+      it "verifies if represented user also created a ballot" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user = create(:represented_user, representative: forum)
+        represented_user_ballot = create(:budget_ballot, user: represented_user, budget: budget)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_ballot = Budget::Ballot.first
+        expect(budget_ballot.user).to eq(represented_user)
+      end
+
+      it "verifies if delegated ballot has already been migrated" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_ballot = Budget::Ballot.first
+        expect(budget_ballot.user).to eq(represented_user)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates a single delegated ballot line" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        spending_proposal = create(:spending_proposal, feasible: true)
+        delegated_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments).to eq([budget_investment])
+      end
+
+      it "migrates all delegated ballot lines for a ballot" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot.spending_proposals << spending_proposal1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+
+        expect(budget_investment_ballot.investments).to include(budget_investment1)
+        expect(budget_investment_ballot.investments).to include(budget_investment2)
+        expect(budget_investment_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "migrates all delegated ballot lines for each represented user" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user1 = create(:represented_user, representative: forum)
+        represented_user2 = create(:represented_user, representative: forum)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot.spending_proposals << spending_proposal1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        represented_user1_ballot = Budget::Ballot.where(user: represented_user1).first
+        expect(represented_user1_ballot.investments).to include(budget_investment1)
+        expect(represented_user1_ballot.investments).to include(budget_investment2)
+        expect(represented_user1_ballot.investments).not_to include(budget_investment3)
+
+        represented_user2_ballot = Budget::Ballot.where(user: represented_user2).first
+        expect(represented_user2_ballot.investments).to include(budget_investment1)
+        expect(represented_user2_ballot.investments).to include(budget_investment2)
+        expect(represented_user2_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "verifies if represented user already has ballot lines" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user = create(:represented_user, representative: forum)
+        represented_user_ballot = create(:budget_ballot, user: represented_user, budget: budget)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+
+        represented_user_ballot.investments << budget_investment1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(represented_user_ballot.user).to eq(represented_user)
+
+        expect(represented_user_ballot.investments).to include(budget_investment1)
+        expect(represented_user_ballot.investments).not_to include(budget_investment2)
+      end
+
+      it "verifies if delegated ballot lines have already been migrated" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        spending_proposal = create(:spending_proposal, feasible: true)
+        delegated_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot::Line.count).to eq(1)
+        expect(Budget::Ballot::Line.first.investment).to eq(budget_investment)
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposals/delegated_ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/delegated_ballot_spec.rb
@@ -169,6 +169,31 @@ describe Migrations::SpendingProposal::DelegatedBallot do
         expect(represented_user2_ballot.investments).not_to include(budget_investment3)
       end
 
+      it "migrates ballot lines if represented user had a ballot with no ballot lines" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user = create(:represented_user, representative: forum)
+        represented_user_ballot = create(:budget_ballot, user: represented_user, budget: budget)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot.spending_proposals << spending_proposal1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(represented_user_ballot.investments).to include(budget_investment1)
+        expect(represented_user_ballot.investments).to include(budget_investment2)
+        expect(represented_user_ballot.investments).not_to include(budget_investment3)
+      end
+
       it "verifies if represented user already has ballot lines" do
         forum = create(:forum)
         delegated_ballot = create(:ballot, user: forum.user)

--- a/spec/lib/migrations/spending_proposals/delegated_ballots_spec.rb
+++ b/spec/lib/migrations/spending_proposals/delegated_ballots_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+require "migrations/spending_proposal/delegated_ballots"
+
+describe Migrations::SpendingProposal::DelegatedBallots do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+
+  describe "#initialize" do
+
+    it "initializes all delegated spending proposal ballots" do
+      forum1 = create(:forum)
+      delegated_ballot1 = create(:ballot, user: forum1.user)
+
+      forum2 = create(:forum)
+      delegated_ballot2 = create(:ballot, user: forum2.user)
+
+      non_delegated_ballot = create(:ballot)
+
+      migration = Migrations::SpendingProposal::DelegatedBallots.new
+
+      expect(migration.delegated_ballots.count).to eq(2)
+      expect(migration.delegated_ballots).to include(delegated_ballot1)
+      expect(migration.delegated_ballots).to include(delegated_ballot2)
+      expect(migration.delegated_ballots).not_to include(non_delegated_ballot)
+    end
+
+  end
+
+  describe "#migrate_all" do
+
+    context "ballot" do
+
+      it "migrates all delegated spending proposal ballots to budget investment ballots" do
+        forum1 = create(:forum)
+        represented_user1 = create(:represented_user, representative: forum1)
+        delegated_ballot1 = create(:ballot, user: forum1.user)
+
+        forum2 = create(:forum)
+        represented_user2 = create(:represented_user, representative: forum2)
+        delegated_ballot2 = create(:ballot, user: forum2.user)
+
+        Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+
+        expect(Budget::Ballot.count).to eq(2)
+
+        budget_ballot_users = Budget::Ballot.all.map(&:user)
+        expect(budget_ballot_users).to include(represented_user1)
+        expect(budget_ballot_users).to include(represented_user2)
+      end
+
+    end
+
+    context "ballot line" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates all delegated spending proposal ballot lines to budget investment ballot lines" do
+        forum1 = create(:forum)
+        represented_user1 = create(:represented_user, representative: forum1)
+        delegated_ballot1 = create(:ballot, user: forum1.user)
+
+        forum2 = create(:forum)
+        represented_user2 = create(:represented_user, representative: forum2)
+        delegated_ballot2 = create(:ballot, user: forum2.user)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot1.spending_proposals << spending_proposal1
+        delegated_ballot1.spending_proposals << spending_proposal2
+
+        delegated_ballot2.spending_proposals << spending_proposal1
+
+        Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+
+        represented_user_ballot1 = Budget::Ballot.where(user: represented_user1).first
+
+        expect(represented_user_ballot1.investments).to include(budget_investment1)
+        expect(represented_user_ballot1.investments).to include(budget_investment2)
+        expect(represented_user_ballot1.investments).not_to include(budget_investment3)
+
+        represented_user_ballot2 = Budget::Ballot.where(user: represented_user2).first
+
+        expect(represented_user_ballot2.investments).to include(budget_investment1)
+        expect(represented_user_ballot2.investments).not_to include(budget_investment2)
+        expect(represented_user_ballot2.investments).not_to include(budget_investment3)
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -36,24 +36,6 @@ describe Migrations::SpendingProposal::Vote do
       expect(budget_investment2.votes_for.count).to eq(5)
     end
 
-    it "creates a budget investment's vote for a hidden user" do
-      spending_proposal = create(:spending_proposal)
-      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
-
-      spending_proposal_vote = create(:vote, votable: spending_proposal)
-
-      spending_proposal_vote.voter.hide
-
-      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
-
-      budget_investment_vote = budget_investment.votes_for.first
-
-      expect(budget_investment.votes_for.count).to eq(1)
-      expect(budget_investment_vote.voter_id).to eq(spending_proposal_vote.voter_id)
-      expect(budget_investment_vote.votable).to eq(budget_investment)
-      expect(budget_investment_vote.vote_flag).to eq(true)
-    end
-
     it "verifies if user has already voted" do
       spending_proposal = create(:spending_proposal)
       budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -36,11 +36,42 @@ describe Migrations::SpendingProposal::Vote do
       expect(budget_investment2.votes_for.count).to eq(5)
     end
 
+    it "creates a budget investment's vote for a hidden user" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      spending_proposal_vote.voter.hide
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      budget_investment_vote = budget_investment.votes_for.first
+
+      expect(budget_investment.votes_for.count).to eq(1)
+      expect(budget_investment_vote.voter_id).to eq(spending_proposal_vote.voter_id)
+      expect(budget_investment_vote.votable).to eq(budget_investment)
+      expect(budget_investment_vote.vote_flag).to eq(true)
+    end
+
     it "verifies if user has already voted" do
       spending_proposal = create(:spending_proposal)
       budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
 
       spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment.votes_for.count).to eq(1)
+    end
+
+    it "verifies if hidden user has already voted" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+      spending_proposal_vote.voter.hide
 
       Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
       Migrations::SpendingProposal::Vote.new.create_budget_investment_votes

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -228,5 +228,13 @@ describe Migrations::SpendingProposal::Vote do
       expect(budget_investment2.votes_for.count).to eq(5)
     end
 
+    it "gracefully handles missing corresponding budget investment" do
+      spending_proposal = create(:spending_proposal)
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      expect{ Migrations::SpendingProposal::Vote.new.create_budget_investment_votes }
+      .not_to raise_error
+    end
+
   end
 end

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -152,4 +152,39 @@ describe Migrations::SpendingProposal::Vote do
     end
 
   end
+
+  describe "#create_budget_investment_votes" do
+
+    it "creates a budget investment's vote for a corresponding spending proposal's vote" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      budget_investment_vote = budget_investment.votes_for.first
+
+      expect(budget_investment.votes_for.count).to eq(1)
+      expect(budget_investment_vote.voter).to eq(spending_proposal_vote.voter)
+      expect(budget_investment_vote.votable).to eq(budget_investment)
+      expect(budget_investment_vote.vote_flag).to eq(true)
+    end
+
+    it "creates budget investment's votes for all correspoding spending proposal's votes" do
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+      budget_investment1 = create(:budget_investment, original_spending_proposal_id: spending_proposal1.id)
+      budget_investment2 = create(:budget_investment, original_spending_proposal_id: spending_proposal2.id)
+
+      3.times { create(:vote, votable: spending_proposal1) }
+      5.times { create(:vote, votable: spending_proposal2) }
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment1.votes_for.count).to eq(3)
+      expect(budget_investment2.votes_for.count).to eq(5)
+    end
+
+  end
 end

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -3,186 +3,6 @@ require "migrations/spending_proposal/vote"
 
 describe Migrations::SpendingProposal::Vote do
 
-  describe "#migrate_delegated_votes" do
-
-    it "create a represented user vote when single delegation" do
-      forum = create(:forum)
-      represented_user = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-
-      expect(spending_proposal.votes_for.count).to eq(1)
-
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-
-      expect(spending_proposal.votes_for.count).to eq(2)
-      expect(Vote.last.voter).to eq(represented_user)
-      expect(Vote.last.votable).to eq(spending_proposal)
-    end
-
-    it "creates represented user votes when multiple delegations" do
-      forum = create(:forum)
-      represented_user1 = create(:represented_user, representative: forum)
-      represented_user2 = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-
-      expect(spending_proposal.votes_for.count).to eq(1)
-
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-
-      expect(spending_proposal.votes_for.count).to eq(3)
-    end
-
-    it "creates represented user votes when multiple delegations for mulitple spending proposals" do
-      forum1 = create(:forum)
-      forum2 = create(:forum)
-      represented_user1 = create(:represented_user, representative: forum1)
-      represented_user2 = create(:represented_user, representative: forum2)
-      spending_proposal1 = create(:spending_proposal)
-      spending_proposal2 = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal1, voter: forum1.user)
-      create(:vote, votable: spending_proposal2, voter: forum2.user)
-
-      expect(spending_proposal1.votes_for.count).to eq(1)
-      expect(spending_proposal2.votes_for.count).to eq(1)
-
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-
-      expect(spending_proposal1.votes_for.count).to eq(2)
-      expect(spending_proposal2.votes_for.count).to eq(2)
-    end
-
-    it "creates represented user votes when existing user votes" do
-      forum = create(:forum)
-      represented_user = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      user = create(:user, :verified)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-      create(:vote, votable: spending_proposal, voter: user)
-
-      expect(spending_proposal.votes_for.count).to eq(2)
-
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-
-      expect(spending_proposal.votes_for.count).to eq(3)
-    end
-
-    it "verifies if represented user already voted" do
-      forum = create(:forum)
-      represented_user = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-      create(:vote, votable: spending_proposal, voter: represented_user)
-
-      expect(spending_proposal.votes_for.count).to eq(2)
-
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-
-      expect(spending_proposal.votes_for.count).to eq(2)
-    end
-
-    it "verifies if delegated vote has already been created" do
-      forum = create(:forum)
-      represented_user = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-
-      expect(spending_proposal.votes_for.count).to eq(1)
-
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
-
-      expect(spending_proposal.votes_for.count).to eq(2)
-    end
-
-  end
-
-  describe "#delegated_votes" do
-
-    it "returns delegated votes when no delegations" do
-      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
-      expect(delegated_votes.count).to eq(0)
-    end
-
-    it "returns delegated votes when one delegation for one spending proposal" do
-      forum = create(:forum)
-      represented_user1 = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-
-      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
-
-      expect(delegated_votes.count).to eq(1)
-      expect(delegated_votes.first[:voter]).to eq(represented_user1)
-      expect(delegated_votes.first[:votable]).to eq(spending_proposal)
-    end
-
-    it "returns delegated votes when one delegations but represented user also voted" do
-      forum = create(:forum)
-      represented_user1 = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-      create(:vote, votable: spending_proposal, voter: represented_user1)
-
-      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
-
-      expect(delegated_votes.count).to eq(0)
-    end
-
-    it "returns delegated votes when multiple delegations for one spending proposal" do
-      forum = create(:forum)
-      represented_user1 = create(:represented_user, representative: forum)
-      represented_user2 = create(:represented_user, representative: forum)
-      spending_proposal = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal, voter: forum.user)
-
-      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
-      expect(delegated_votes.count).to eq(2)
-
-      voters = delegated_votes.collect   { |vote| vote[:voter] }
-      votables = delegated_votes.collect { |vote| vote[:votable] }
-
-      expect(voters).to include(represented_user1)
-      expect(voters).to include(represented_user2)
-      expect(votables).to eq([spending_proposal, spending_proposal])
-    end
-
-    it "returns delegated votes when multiple delegations for multiple spending proposal" do
-      forum1 = create(:forum)
-      forum2 = create(:forum)
-      represented_user1 = create(:represented_user, representative: forum1)
-      represented_user2 = create(:represented_user, representative: forum2)
-      spending_proposal1 = create(:spending_proposal)
-      spending_proposal2 = create(:spending_proposal)
-
-      create(:vote, votable: spending_proposal1, voter: forum1.user)
-      create(:vote, votable: spending_proposal2, voter: forum2.user)
-
-      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
-      expect(delegated_votes.count).to eq(2)
-
-      voters = delegated_votes.collect   { |vote| vote[:voter] }
-      votables = delegated_votes.collect { |vote| vote[:votable] }
-
-      expect(voters).to include(represented_user1)
-      expect(voters).to include(represented_user2)
-      expect(votables).to include(spending_proposal1)
-      expect(votables).to include(spending_proposal2)
-    end
-
-  end
-
   describe "#create_budget_investment_votes" do
 
     it "creates a budget investment's vote for a corresponding spending proposal's vote" do
@@ -201,18 +21,6 @@ describe Migrations::SpendingProposal::Vote do
       expect(budget_investment_vote.vote_flag).to eq(true)
     end
 
-    it "verifies if user has already voted" do
-      spending_proposal = create(:spending_proposal)
-      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
-
-      spending_proposal_vote = create(:vote, votable: spending_proposal)
-
-      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
-      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
-
-      expect(budget_investment.votes_for.count).to eq(1)
-    end
-
     it "creates budget investment's votes for all correspoding spending proposal's votes" do
       spending_proposal1 = create(:spending_proposal)
       spending_proposal2 = create(:spending_proposal)
@@ -226,6 +34,49 @@ describe Migrations::SpendingProposal::Vote do
 
       expect(budget_investment1.votes_for.count).to eq(3)
       expect(budget_investment2.votes_for.count).to eq(5)
+    end
+
+    it "creates a budget investment's vote for a hidden user" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      spending_proposal_vote.voter.hide
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      budget_investment_vote = budget_investment.votes_for.first
+
+      expect(budget_investment.votes_for.count).to eq(1)
+      expect(budget_investment_vote.voter_id).to eq(spending_proposal_vote.voter_id)
+      expect(budget_investment_vote.votable).to eq(budget_investment)
+      expect(budget_investment_vote.vote_flag).to eq(true)
+    end
+
+    it "verifies if user has already voted" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment.votes_for.count).to eq(1)
+    end
+
+    it "verifies if hidden user has already voted" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+      spending_proposal_vote.voter.hide
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment.votes_for.count).to eq(1)
     end
 
     it "gracefully handles missing corresponding budget investment" do

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+require "migrations/spending_proposal/vote"
+
+describe Migrations::SpendingProposal::Vote do
+
+  describe "#migrate_delegated_votes" do
+
+    it "create a represented user vote when single delegation" do
+      forum = create(:forum)
+      represented_user = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      expect(spending_proposal.votes_for.count).to eq(1)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal.votes_for.count).to eq(2)
+      expect(Vote.last.voter).to eq(represented_user)
+      expect(Vote.last.votable).to eq(spending_proposal)
+    end
+
+    it "creates represented user votes when multiple delegations" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      represented_user2 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      expect(spending_proposal.votes_for.count).to eq(1)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal.votes_for.count).to eq(3)
+    end
+
+    it "creates represented user votes when multiple delegations for mulitple spending proposals" do
+      forum1 = create(:forum)
+      forum2 = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum1)
+      represented_user2 = create(:represented_user, representative: forum2)
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal1, voter: forum1.user)
+      create(:vote, votable: spending_proposal2, voter: forum2.user)
+
+      expect(spending_proposal1.votes_for.count).to eq(1)
+      expect(spending_proposal2.votes_for.count).to eq(1)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal1.votes_for.count).to eq(2)
+      expect(spending_proposal2.votes_for.count).to eq(2)
+    end
+
+    it "creates represented user votes when existing user votes" do
+      forum = create(:forum)
+      represented_user = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      user = create(:user, :verified)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+      create(:vote, votable: spending_proposal, voter: user)
+
+      expect(spending_proposal.votes_for.count).to eq(2)
+
+      Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+
+      expect(spending_proposal.votes_for.count).to eq(3)
+    end
+
+  end
+
+  describe "#delegated_votes" do
+
+    it "returns delegated votes when no delegations" do
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+      expect(delegated_votes.count).to eq(0)
+    end
+
+    it "returns delegated votes when one delegation for one spending proposal" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+
+      expect(delegated_votes.count).to eq(1)
+      expect(delegated_votes.first[:voter]).to eq(represented_user1)
+      expect(delegated_votes.first[:votable]).to eq(spending_proposal)
+    end
+
+    it "returns delegated votes when one delegations but represented user also voted" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+      create(:vote, votable: spending_proposal, voter: represented_user1)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+
+      expect(delegated_votes.count).to eq(0)
+    end
+
+    it "returns delegated votes when multiple delegations for one spending proposal" do
+      forum = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum)
+      represented_user2 = create(:represented_user, representative: forum)
+      spending_proposal = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal, voter: forum.user)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+      expect(delegated_votes.count).to eq(2)
+
+      voters = delegated_votes.collect   { |vote| vote[:voter] }
+      votables = delegated_votes.collect { |vote| vote[:votable] }
+
+      expect(voters).to include(represented_user1)
+      expect(voters).to include(represented_user2)
+      expect(votables).to eq([spending_proposal, spending_proposal])
+    end
+
+    it "returns delegated votes when multiple delegations for multiple spending proposal" do
+      forum1 = create(:forum)
+      forum2 = create(:forum)
+      represented_user1 = create(:represented_user, representative: forum1)
+      represented_user2 = create(:represented_user, representative: forum2)
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+
+      create(:vote, votable: spending_proposal1, voter: forum1.user)
+      create(:vote, votable: spending_proposal2, voter: forum2.user)
+
+      delegated_votes = Migrations::SpendingProposal::Vote.new.delegated_votes
+      expect(delegated_votes.count).to eq(2)
+
+      voters = delegated_votes.collect   { |vote| vote[:voter] }
+      votables = delegated_votes.collect { |vote| vote[:votable] }
+
+      expect(voters).to include(represented_user1)
+      expect(voters).to include(represented_user2)
+      expect(votables).to include(spending_proposal1)
+      expect(votables).to include(spending_proposal2)
+    end
+
+  end
+end

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -66,19 +66,6 @@ describe Migrations::SpendingProposal::Vote do
       expect(budget_investment.votes_for.count).to eq(1)
     end
 
-    it "verifies if hidden user has already voted" do
-      spending_proposal = create(:spending_proposal)
-      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
-
-      spending_proposal_vote = create(:vote, votable: spending_proposal)
-      spending_proposal_vote.voter.hide
-
-      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
-      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
-
-      expect(budget_investment.votes_for.count).to eq(1)
-    end
-
     it "gracefully handles missing corresponding budget investment" do
       spending_proposal = create(:spending_proposal)
       spending_proposal_vote = create(:vote, votable: spending_proposal)

--- a/spec/models/budget/ballot/line_spec.rb
+++ b/spec/models/budget/ballot/line_spec.rb
@@ -47,6 +47,8 @@ describe Budget::Ballot::Line do
   describe "#store_user_heading" do
 
     it "stores the heading where the user has voted" do
+      skip "Temporarily skipping until spending proposals migration is complete"
+
       user = create(:user, :level_two)
       investment = create(:budget_investment, :selected)
       ballot = create(:budget_ballot, user: user, budget: investment.budget)

--- a/spec/models/spending_proposal_spec.rb
+++ b/spec/models/spending_proposal_spec.rb
@@ -528,48 +528,6 @@ describe SpendingProposal do
       expect(sp.total_votes).to eq(2)
     end
 
-    it "does not take into account forum votes" do
-      forum = create(:forum)
-      sp = create(:spending_proposal)
-
-      sp.register_vote(forum.user, true)
-      expect(sp.total_votes).to eq(0)
-    end
-  end
-
-  describe "#delegated_votes" do
-    before(:each) do
-      Setting["feature.spending_proposal_features.voting_allowed"] = true
-    end
-
-    it "counts delegated votes" do
-      forum = create(:forum)
-      user1 = create(:user, representative: forum)
-      user2 = create(:user, representative: forum)
-      sp = create(:spending_proposal)
-
-      sp.register_vote(forum.user, true)
-      expect(sp.delegated_votes).to eq(2)
-    end
-
-    it "does not count delegated votes if user has also voted" do
-      forum = create(:forum)
-      user = create(:user, :level_two, representative: forum)
-      sp = create(:spending_proposal)
-
-      sp.register_vote(forum.user, true)
-      sp.register_vote(user, true)
-
-      expect(sp.delegated_votes).to eq(0)
-    end
-
-    it "does not count forum votes" do
-      forum = create(:forum)
-      sp = create(:spending_proposal)
-
-      sp.register_vote(forum.user, true)
-      expect(sp.delegated_votes).to eq(0)
-    end
   end
 
   describe "#with_supports" do

--- a/spec/support/common_actions/budgets.rb
+++ b/spec/support/common_actions/budgets.rb
@@ -10,4 +10,14 @@ module Budgets
       expect(page).to have_content "Remove"
     end
   end
+
+  def budget_invesment_for(spending_proposal, options={})
+    attributes = {
+      original_spending_proposal_id: spending_proposal.id,
+      selected: true
+    }.merge(options)
+
+    create(:budget_investment, attributes)
+  end
+
 end


### PR DESCRIPTION
### References

**PR:** https://github.com/AyuntamientoMadrid/consul/pull/1059
**PR:** https://github.com/AyuntamientoMadrid/consul/pull/1589
**PR:** https://github.com/AyuntamientoMadrid/consul/pull/1770
**PR:** https://github.com/AyuntamientoMadrid/consul/pull/1771
Add more related PRs 😌

## Objectives

This is a conglomerate of PRs to fully migrate Spendings Proposals to Budget Investment.

## Does this PR need a Backport to CONSUL?

No, we are not going to take the migration to CONSUL, only the deletion of spending proposals.

## Notes
Add instructions about what should be changed to run the migration in another fork 😌

To migrate spending proposals and all it's associated data run this rake task:

```
bin/rake spending_proposals:migrate
```