### PR TITLE
[Upstream] Bring back date order translations

### DIFF
--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -97,7 +97,9 @@
       </div>
 
       <div class="small-12 medium-3 clear">
-        <%= f.submit t("verification.residence.new.verify_residence"), class: "button success expanded" %>
+        <%= f.submit t("verification.residence.new.verify_residence"),
+                     id: "new_residence_submit",
+                     class: "button success expanded" %>
       </div>
     <% end %>
   </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -22,6 +22,7 @@ data:
     ## Another gem (replace %#= with %=):
     # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
     - config/locales/custom/%{locale}/*.yml
+    - config/locales/%{locale}/rails_date_order.yml
     - config/locales/%{locale}/general.yml
     - config/locales/%{locale}/activerecord.yml
     - config/locales/%{locale}/activemodel.yml
@@ -128,6 +129,7 @@ ignore_unused:
   - 'budgets.index.section_header.*'
   - 'activerecord.*'
   - 'activemodel.*'
+  - 'date.order'
   - 'unauthorized.*'
   - 'admin.officials.level_*'
   - 'admin.comments.index.filter*'

--- a/config/locales/ar/rails_date_order.yml
+++ b/config/locales/ar/rails_date_order.yml
@@ -1,0 +1,6 @@
+ar:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/ast/rails_date_order.yml
+++ b/config/locales/ast/rails_date_order.yml
@@ -1,0 +1,6 @@
+ast:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/ca/rails_date_order.yml
+++ b/config/locales/ca/rails_date_order.yml
@@ -1,0 +1,6 @@
+ca:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/de-DE/rails_date_order.yml
+++ b/config/locales/de-DE/rails_date_order.yml
@@ -1,0 +1,6 @@
+de:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/en-GB/rails_date_order.yml
+++ b/config/locales/en-GB/rails_date_order.yml
@@ -1,0 +1,6 @@
+en-GB:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/en-US/rails_date_order.yml
+++ b/config/locales/en-US/rails_date_order.yml
@@ -1,0 +1,6 @@
+en-US:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/en/rails_date_order.yml
+++ b/config/locales/en/rails_date_order.yml
@@ -1,0 +1,6 @@
+en:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/es-AR/rails_date_order.yml
+++ b/config/locales/es-AR/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-AR:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-BO/rails_date_order.yml
+++ b/config/locales/es-BO/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-BO:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-CL/rails_date_order.yml
+++ b/config/locales/es-CL/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-CL:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-CO/rails_date_order.yml
+++ b/config/locales/es-CO/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-CO:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-CR/rails_date_order.yml
+++ b/config/locales/es-CR/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-CR:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-DO/rails_date_order.yml
+++ b/config/locales/es-DO/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-DO:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-EC/rails_date_order.yml
+++ b/config/locales/es-EC/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-EC:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-GT/rails_date_order.yml
+++ b/config/locales/es-GT/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-GT:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-HN/rails_date_order.yml
+++ b/config/locales/es-HN/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-HN:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-MX/rails_date_order.yml
+++ b/config/locales/es-MX/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-MX:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-NI/rails_date_order.yml
+++ b/config/locales/es-NI/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-NI:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-PA/rails_date_order.yml
+++ b/config/locales/es-PA/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-PA:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-PE/rails_date_order.yml
+++ b/config/locales/es-PE/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-PE:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-PR/rails_date_order.yml
+++ b/config/locales/es-PR/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-PR:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-PY/rails_date_order.yml
+++ b/config/locales/es-PY/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-PY:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-SV/rails_date_order.yml
+++ b/config/locales/es-SV/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-SV:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-UY/rails_date_order.yml
+++ b/config/locales/es-UY/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-UY:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es-VE/rails_date_order.yml
+++ b/config/locales/es-VE/rails_date_order.yml
@@ -1,0 +1,6 @@
+es-VE:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/es/rails.yml
+++ b/config/locales/es/rails.yml
@@ -48,10 +48,6 @@ es:
       - octubre
       - noviembre
       - diciembre
-    order:
-      - :day
-      - :month
-      - :year
   datetime:
     distance_in_words:
       about_x_hours:

--- a/config/locales/es/rails_date_order.yml
+++ b/config/locales/es/rails_date_order.yml
@@ -1,0 +1,6 @@
+es:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/eu-ES/rails_date_order.yml
+++ b/config/locales/eu-ES/rails_date_order.yml
@@ -1,0 +1,6 @@
+eu:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/fa-IR/rails_date_order.yml
+++ b/config/locales/fa-IR/rails_date_order.yml
@@ -1,0 +1,6 @@
+fa:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/fi-FI/rails_date_order.yml
+++ b/config/locales/fi-FI/rails_date_order.yml
@@ -1,0 +1,6 @@
+fi:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/fr/rails_date_order.yml
+++ b/config/locales/fr/rails_date_order.yml
@@ -1,0 +1,6 @@
+fr:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/gl/rails_date_order.yml
+++ b/config/locales/gl/rails_date_order.yml
@@ -1,0 +1,6 @@
+gl:
+  date:
+    order:
+      - :day
+      - :month
+      - :year

--- a/config/locales/he/rails_date_order.yml
+++ b/config/locales/he/rails_date_order.yml
@@ -1,0 +1,6 @@
+he:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/id-ID/rails_date_order.yml
+++ b/config/locales/id-ID/rails_date_order.yml
@@ -1,0 +1,6 @@
+id:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/it/rails_date_order.yml
+++ b/config/locales/it/rails_date_order.yml
@@ -1,0 +1,6 @@
+it:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/nl/rails_date_order.yml
+++ b/config/locales/nl/rails_date_order.yml
@@ -1,0 +1,6 @@
+nl:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/pap-PAP/rails_date_order.yml
+++ b/config/locales/pap-PAP/rails_date_order.yml
@@ -1,0 +1,6 @@
+pap:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/pl-PL/rails_date_order.yml
+++ b/config/locales/pl-PL/rails_date_order.yml
@@ -1,0 +1,6 @@
+pl:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/pt-BR/rails_date_order.yml
+++ b/config/locales/pt-BR/rails_date_order.yml
@@ -1,0 +1,6 @@
+pt-BR:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/ru/rails_date_order.yml
+++ b/config/locales/ru/rails_date_order.yml
@@ -1,0 +1,6 @@
+ru:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/sl-SI/rails_date_order.yml
+++ b/config/locales/sl-SI/rails_date_order.yml
@@ -1,0 +1,6 @@
+sl:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/so-SO/rails_date_order.yml
+++ b/config/locales/so-SO/rails_date_order.yml
@@ -1,0 +1,6 @@
+so:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/sq-AL/rails_date_order.yml
+++ b/config/locales/sq-AL/rails_date_order.yml
@@ -1,0 +1,6 @@
+sq:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/sv-FI/rails_date_order.yml
+++ b/config/locales/sv-FI/rails_date_order.yml
@@ -1,0 +1,6 @@
+sv-FI:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/sv-SE/rails_date_order.yml
+++ b/config/locales/sv-SE/rails_date_order.yml
@@ -1,0 +1,6 @@
+sv:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/tr-TR/rails_date_order.yml
+++ b/config/locales/tr-TR/rails_date_order.yml
@@ -1,0 +1,6 @@
+tr:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/val/rails_date_order.yml
+++ b/config/locales/val/rails_date_order.yml
@@ -1,0 +1,6 @@
+val:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/zh-CN/rails_date_order.yml
+++ b/config/locales/zh-CN/rails_date_order.yml
@@ -1,0 +1,6 @@
+zh-CN:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/config/locales/zh-TW/rails_date_order.yml
+++ b/config/locales/zh-TW/rails_date_order.yml
@@ -1,0 +1,6 @@
+zh-TW:
+  date:
+    order:
+      - :year
+      - :month
+      - :day

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,8 @@
 files:
   - source: /config/locales/custom/es/**.yml
     translation: /config/locales/custom/%locale%/%original_file_name%
+    ignore:
+      - /config/locales/**/rails_date_order.yml
     languages_mapping:
       locale:
         en: en

--- a/spec/features/verification/level_two_verification_spec.rb
+++ b/spec/features/verification/level_two_verification_spec.rb
@@ -24,4 +24,19 @@ feature 'Level two verification' do
     expect(page).to have_content 'Code correct'
   end
 
+  context "In Spanish, with no fallbacks" do
+    before do
+      skip unless I18n.available_locales.include?(:es)
+      allow(I18n.fallbacks).to receive(:[]).and_return([:es])
+    end
+
+    scenario "Works normally" do
+      user = create(:user)
+      login_as(user)
+
+      visit verification_path(locale: :es)
+      verify_residence
+    end
+  end
+
 end

--- a/spec/support/common_actions/verifications.rb
+++ b/spec/support/common_actions/verifications.rb
@@ -10,12 +10,14 @@ module Verifications
   def verify_residence
     select 'DNI', from: 'residence_document_type'
     fill_in 'residence_document_number', with: "12345678Z"
-    select_date '31-December-1980', from: 'residence_date_of_birth'
+    select_date "31-#{I18n.l(Date.current.at_end_of_year, format: "%B")}-1980",
+                from: "residence_date_of_birth"
+
     fill_in 'residence_postal_code', with: '28013'
     check 'residence_terms_of_service'
 
-    click_button 'Verify residence'
-    expect(page).to have_content 'Residence verified'
+    click_button "new_residence_submit"
+    expect(page).to have_content I18n.t("verification.residence.create.flash.success")
   end
 
   def officing_verify_residence


### PR DESCRIPTION
## References

* Brings pull request consul#3127 to Madrid
* Pull request consul#3007
* Pull request #1725

## Background

We removed the `date.order` translations because translators were ttranslating the `date.order` keys, which are supposed to have the symbols `:year`, `:month`, and `:day` and are not supposed to be translated to symbols like `:año`, `:mes` and `:día`.

However, we need those keys to be defined so forks which don't fall back to English when translations aren't available can render the residence verification form without the application crashing, so we added them for Spanish in #1725.

## Objectives

* Add `date.order` keys for every language
* Add `date.order` keys to a different file so it can be excluded from crowdin