### PR TITLE
[Upstream] Fix crash in valuation when there are no budgets 

### DIFF
--- a/app/controllers/valuation/budgets_controller.rb
+++ b/app/controllers/valuation/budgets_controller.rb
@@ -8,8 +8,9 @@ class Valuation::BudgetsController < Valuation::BaseController
     @budget = current_budget
     valuator = current_user.valuator
     if @budget.present? && valuator.present?
-      @assigned_investments_count = @budget.investments.accesible_by_valuator(valuator)
-                                           .valuation_open.count
+      @investments = @budget.investments
+                            .accesible_by_valuator(valuator)
+                            .valuation_open
     end
   end
 end

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -1,30 +1,36 @@
 <h2 class="inline-block"><%= t("valuation.budgets.index.title") %></h2>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= t("valuation.budgets.index.table_name") %></th>
-      <th><%= t("valuation.budgets.index.table_phase") %></th>
-      <th><%= t("valuation.budgets.index.table_assigned_investments_valuation_open") %></th>
-      <th><%= t("valuation.budgets.index.table_actions") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr id="<%= dom_id(@budget) %>" class="budget">
-      <td>
-        <%= @budget.name %>
-      </td>
-      <td>
-        <%= t("budgets.phase.#{@budget.phase}") %>
-      </td>
-      <td>
-        <%= @investments.count %>
-      </td>
-      <td>
-        <%= link_to t("valuation.budgets.index.evaluate"),
-                    valuation_budget_budget_investments_path(budget_id: @budget.id),
-                    class: "button hollow expanded" %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<% if @budget.present? %>
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("valuation.budgets.index.table_name") %></th>
+        <th><%= t("valuation.budgets.index.table_phase") %></th>
+        <th><%= t("valuation.budgets.index.table_assigned_investments_valuation_open") %></th>
+        <th><%= t("valuation.budgets.index.table_actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr id="<%= dom_id(@budget) %>" class="budget">
+        <td>
+          <%= @budget.name %>
+        </td>
+        <td>
+          <%= t("budgets.phase.#{@budget.phase}") %>
+        </td>
+        <td>
+          <%= @investments.count %>
+        </td>
+        <td>
+          <%= link_to t("valuation.budgets.index.evaluate"),
+                      valuation_budget_budget_investments_path(budget_id: @budget.id),
+                      class: "button hollow expanded" %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+<% else %>
+  <div class="callout primary clear">
+    <%= t("valuation.budgets.index.no_budgets") %>
+  </div>
+<% end %>

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -18,7 +18,7 @@
         <%= t("budgets.phase.#{@budget.phase}") %>
       </td>
       <td>
-        <%= @assigned_investments_count %>
+        <%= @investments.count %>
       </td>
       <td>
         <%= link_to t("valuation.budgets.index.evaluate"),

--- a/app/views/valuation/budgets/index.html.erb
+++ b/app/views/valuation/budgets/index.html.erb
@@ -19,7 +19,7 @@
           <%= t("budgets.phase.#{@budget.phase}") %>
         </td>
         <td>
-          <%= @investments.count %>
+          <%= @investments&.count %>
         </td>
         <td>
           <%= link_to t("valuation.budgets.index.evaluate"),

--- a/config/locales/en/valuation.yml
+++ b/config/locales/en/valuation.yml
@@ -17,6 +17,7 @@ en:
         table_assigned_investments_valuation_open: Investment projects assigned with valuation open
         table_actions: Actions
         evaluate: Evaluate
+        no_budgets: "There are no budgets"
     budget_investments:
       index:
         headings_filter_all: All headings

--- a/config/locales/es/valuation.yml
+++ b/config/locales/es/valuation.yml
@@ -17,6 +17,7 @@ es:
         table_assigned_investments_valuation_open: Prop. Inv. asignadas en evaluación
         table_actions: Acciones
         evaluate: Evaluar
+        no_budgets: "No hay presupuestos"
     budget_investments:
       index:
         headings_filter_all: Todas las partidas

--- a/spec/features/valuation/budgets_spec.rb
+++ b/spec/features/valuation/budgets_spec.rb
@@ -67,6 +67,11 @@ feature 'Valuation budgets' do
       expect(page).to have_content(budget3.name)
     end
 
+    scenario "With no budgets" do
+      visit valuation_budgets_path
+
+      expect(page).to have_content "There are no budgets"
+    end
   end
 
 end


### PR DESCRIPTION
## References

* Brings pull request consul#3128 to Madrid
* The code is different because we haven't backported #1359 yet

## Objectives

Fix a crash in the valuation section when there are no budgets.