### PR TITLE
LegacyLegislation processes annotations migration (second phase)

### DIFF
--- a/lib/migrations/legacy_legislation/annotation.rb
+++ b/lib/migrations/legacy_legislation/annotation.rb
@@ -1,0 +1,90 @@
+class Migrations::LegacyLegislation::Annotation
+
+  def migrate_annotations
+    processes_info.each do |process|
+      draft = draft_for process[:new_id]
+
+      old_annotations_for(process[:old_id]).each do |old_annotation|
+        new_annotation_params = {
+          quote: old_annotation.quote,
+          ranges: old_annotation.ranges,
+          text: old_annotation.text,
+          author_id: old_annotation.user_id,
+          created_at: old_annotation.created_at,
+          updated_at: old_annotation.created_at,
+          range_start: old_annotation.ranges.first['start'],
+          range_start_offset: old_annotation.ranges.first['startOffset'],
+          range_end: old_annotation.ranges.first['end'],
+          range_end_offset: old_annotation.ranges.first['endOffset'],
+          context: "<span class=annotator-hl>#{old_annotation.quote}</span>"
+        }
+        draft.annotations.create!(new_annotation_params) if new_annotation_params[:quote].present?
+      end
+
+      last_update_date = draft.annotations.maximum(:created_at)
+      new_process_for(process[:new_id]).update_columns(end_date: last_update_date,
+                                                       allegations_end_date: last_update_date,
+                                                       updated_at: last_update_date)
+    end
+  end
+
+  def undo_migrate_data
+    processes_info.each do |process|
+      draft = draft_for process[:new_id]
+      draft.annotations.each { |annotation| annotation.really_destroy! }
+    end
+  end
+
+  def old_annotations_for(process_id)
+    ::LegacyLegislation.find(process_id).annotations
+  end
+
+  def draft_for(process_id)
+    new_process_for(process_id).draft_versions.first
+  end
+
+  def new_process_for(process_id)
+    ::Legislation::Process.find process_id
+  end
+
+  def processes_info
+    [
+      {
+        old_id: 9,
+        title: "Registro de lobbies del Ayuntamiento de Madrid",
+        new_id: 86
+      },
+      {
+        old_id: 8,
+        title: "Alianza para el Gobierno Abierto",
+        new_id: 87
+      },
+      {
+        old_id: 6,
+        title: "Carta de Servicios del Centro de Prevención del Deterioro Cognitivo",
+        new_id: 89
+      },
+      {
+        old_id: 5,
+        title: "Carta de Servicios del Servicio de Teleasistencia Domiciliaria",
+        new_id: 93
+      },
+      {
+        old_id: 4,
+        title: "Carta de Servicios de Centros Municipales de Mayores",
+        new_id: 92
+      },
+      {
+        old_id: 3,
+        title: "Carta de Servicios de los Centros de Día",
+        new_id: 91
+      },
+      {
+        old_id: 2,
+        title: "Carta de Servicios del Servicio de Ayuda a Domicilio",
+        new_id: 90
+      }
+    ]
+  end
+
+end

--- a/lib/tasks/legacy_legislation.rake
+++ b/lib/tasks/legacy_legislation.rake
@@ -6,4 +6,10 @@ namespace :legacy_legislation do
     Migrations::LegacyLegislation::Process.new.migrate_processes
   end
 
+  desc "Migrates LegacyLegislation annotations to Legislation::Annotation"
+  task migrate_annotations: :environment do
+    require "migrations/legacy_legislation/annotation"
+    Migrations::LegacyLegislation::Annotation.new.migrate_annotations
+  end
+
 end

--- a/spec/lib/migrations/legacy_legislation/annotation_spec.rb
+++ b/spec/lib/migrations/legacy_legislation/annotation_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+require 'migrations/legacy_legislation/annotation'
+
+describe Migrations::LegacyLegislation::Annotation do
+
+  let(:migration) { Migrations::LegacyLegislation::Annotation.new }
+  let(:info) do
+    [
+      { old_id: 1, new_id: 10 },
+      { old_id: 2, new_id: 20 }
+    ]
+  end
+
+  before do
+    (1..2).each do |n|
+      old_process = create :legacy_legislation, id: n
+      3.times do
+        create :annotation, legacy_legislation: old_process, user: create(:user)
+      end
+
+      new_process = create :legislation_process, id: n * 10
+      create :legislation_draft_version, process: new_process
+    end
+
+    allow(migration).to receive(:processes_info).and_return(info)
+  end
+
+  scenario "Migrate all annotations from old processes to new processes" do
+    migration.migrate_annotations
+
+    expect(Legislation::Process.count).to be 2
+    expect(Legislation::Annotation.count).to be 6
+
+    info.each do |info|
+      old_process = LegacyLegislation.find info[:old_id]
+      new_process = Legislation::Process.find info[:new_id]
+      new_draft = new_process.draft_versions.first
+
+      expect(new_draft.annotations.count).to eq old_process.annotations.count
+
+      old_annotation = old_process.annotations.order(:id).last
+      new_annotation = new_draft.annotations.order(:id).last
+      expect(new_annotation.quote).to eq old_annotation.quote
+      expect(new_annotation.ranges).to eq old_annotation.ranges
+      expect(new_annotation.text).to eq old_annotation.text
+      expect(new_annotation.author_id).to eq old_annotation.user_id
+      expect(new_annotation.created_at).to eq old_annotation.created_at
+      expect(new_annotation.updated_at).to eq old_annotation.updated_at
+      expect(new_annotation.comments_count).to be 1
+      expect(new_annotation.range_start).to eq old_annotation.ranges.first['start']
+      expect(new_annotation.range_start_offset).to eq old_annotation.ranges.first['startOffset']
+      expect(new_annotation.range_end).to eq old_annotation.ranges.first['end']
+      expect(new_annotation.range_end_offset).to eq old_annotation.ranges.first['endOffset']
+      expect(new_annotation.context).to eq "<span class=annotator-hl>#{old_annotation.quote}</span>"
+
+      expect(new_process.end_date). to eq new_annotation.created_at.to_date
+      expect(new_process.allegations_end_date). to eq new_annotation.created_at.to_date
+      expect(new_process.updated_at). to eq new_annotation.created_at
+    end
+  end
+
+  scenario "Undo migrate all annotations" do
+    migration.migrate_annotations
+    expect(Legislation::Annotation.count).to be 6
+
+    migration.undo_migrate_data
+    expect(Legislation::Annotation.all).to be_empty
+  end
+
+end


### PR DESCRIPTION
## Objectives

Migrate the old annotations in `Annotation` to the new class `Legislation::Annotation`

## Visual Changes
**BEFORE**
![captura de pantalla 2018-12-27 a las 13 15 28](https://user-images.githubusercontent.com/942995/50480033-e8374400-09d9-11e9-9c82-be126a0a0b69.png)

**AFTER**
![captura de pantalla 2018-12-27 a las 13 16 53](https://user-images.githubusercontent.com/942995/50480038-f08f7f00-09d9-11e9-8af3-910616041f68.png)

## Does this PR need a Backport to CONSUL?
NO

## Notes
To migrate the legislation processes run this rake task:
`bin/rake legacy_legislation:migrate_annotations RAILS_ENV=production`