### PR TITLE
Add rubocop rule to indent private methods

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -18,6 +18,9 @@ AllCops:
 Layout/IndentationConsistency:
   EnforcedStyle: rails
 
+Layout/IndentationWidth:
+  Enabled: true
+
 Layout/EndOfLine:
   EnforcedStyle: lf
 


### PR DESCRIPTION
## Objectives

Make the `EnforncedStyle: rails` defined in `Layout/IndentationConsistency` work properly.

## Does this PR need a Backport to CONSUL?

Yes.