### PR TITLE
Use gem timecop instead of Rails travel

### DIFF
--- a/spec/features/polls/voter_spec.rb
+++ b/spec/features/polls/voter_spec.rb
@@ -212,20 +212,17 @@ feature "Voter" do
           expect(page).not_to have_link(answer_yes.title)
         end
 
-        click_link "Sign out"
-
+        Timecop.return
         # Time needs to pass between the moment we vote and the moment
         # we log in; otherwise the link to vote won't be available.
-        # It's safe to advance one second because this test isn't
-        # affected by possible date changes.
-        travel 1.second do
-          login_as user
-          visit poll_path(poll)
 
-          within("#poll_question_#{question.id}_answers") do
-            expect(page).to have_link(answer_yes.title)
-            expect(page).to have_link(answer_no.title)
-          end
+        click_link "Sign out"
+        login_as user
+        visit poll_path(poll)
+
+        within("#poll_question_#{question.id}_answers") do
+          expect(page).to have_link(answer_yes.title)
+          expect(page).to have_link(answer_no.title)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,11 +84,11 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :with_frozen_time) do
-    travel_to Time.now # TODO: use `freeze_time` after migrating to Rails 5.
+    Timecop.freeze(Time.current)
   end
 
   config.after(:each, :with_frozen_time) do
-    travel_back
+    Timecop.return
   end
 
   config.before(:each, :with_different_time_zone) do


### PR DESCRIPTION
## Objectives

For consistency, we will use only the gem `timecop` or the method `travel` of `Rails`

## Does this PR need a Backport to CONSUL?
Yes