### PR TITLE
Removes arrow icon on active process phase

### DIFF
--- a/app/assets/stylesheets/legislation_process.scss
+++ b/app/assets/stylesheets/legislation_process.scss
@@ -121,14 +121,6 @@
     background: $highlight;
     position: relative;
 
-    @include breakpoint(large down) {
-
-      &::after {
-        content: '\61';
-        color: $link;
-      }
-    }
-
     @include breakpoint(large) {
       background: none;
       border: 1px solid $border;
@@ -137,11 +129,14 @@
       &::after {
         border-bottom: 1px solid #fefefe;
         bottom: -1px;
-        content: '';
         left: 0;
         position: absolute;
         width: 100%;
       }
+    }
+
+    &::after {
+      content: '';
     }
   }
 }


### PR DESCRIPTION
## Objectives

Removes arrow icon on `is-active` process phase.

## Visual Changes

**BEFORE**
![screenshot 2018-12-28 at 19 37 23](https://user-images.githubusercontent.com/631897/50524809-20bd4780-0ad8-11e9-8d9e-3d59ecc678af.png)

**AFTER**
![screenshot 2018-12-28 at 19 36 33](https://user-images.githubusercontent.com/631897/50524808-1ef38400-0ad8-11e9-9dd4-bffb98962c02.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.