### PR TITLE
Fix typo in probe option specs

### DIFF
--- a/spec/features/custom/probe_option_comments_spec.rb
+++ b/spec/features/custom/probe_option_comments_spec.rb
@@ -267,7 +267,7 @@ feature 'Commenting Probe Options' do
     comment = create(:comment, commentable: probe_option)
 
     login_as(user)
-    visit probe_probe_option_path(probe_id: probe.codename, id: probe.id)
+    visit probe_probe_option_path(probe_id: probe.codename, id: probe_option.id)
 
     within "#comment_#{comment.id}" do
       page.find("#flag-expand-comment-#{comment.id}").click


### PR DESCRIPTION
## References

* [Travis build 10666, job 5](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/469944587)


## Objectives

Fix a test which was using the probe id instead of the probe option id as the URL param to visit a probe option, causing the test `Commenting Probe Options Flagging turbolinks sanity check` to fail sometimes.

## Does this PR need a Backport to CONSUL?

No, probe options don't exist in CONSUL.