### PR TITLE
Consider having valuator group as having valuator

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -63,7 +63,8 @@ class Budget
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
     scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }
-    scope :without_valuator,            -> { valuation_open.where(valuator_assignments_count: 0) }
+    scope :without_valuator_group,      -> { where(valuator_group_assignments_count: 0) }
+    scope :without_valuator,            -> { valuation_open.without_valuator_group.where(valuator_assignments_count: 0) }
     scope :under_valuation,             -> { valuation_open.valuating.where("administrator_id IS NOT ?", nil) }
     scope :managed,                     -> { valuation_open.where(valuator_assignments_count: 0).where("administrator_id IS NOT ?", nil) }
     scope :valuating,                   -> { valuation_open.where("valuator_assignments_count > 0 OR valuator_group_assignments_count > 0" ) }

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -309,24 +309,30 @@ feature 'Admin budget investments' do
     end
 
     scenario "Filtering by assignment status" do
-      assigned = create(:budget_investment, title: "Assigned idea", budget: budget, administrator: create(:administrator))
-      valuating = create(:budget_investment, title: "Evaluating...", budget: budget)
-      valuating.valuators.push(create(:valuator))
+      create(:budget_investment, title: "Assigned idea", budget: budget,
+             administrator: create(:administrator))
+      create(:budget_investment, title: "Evaluating...", budget: budget,
+             valuators: [create(:valuator)])
+      create(:budget_investment, title: "With group", budget: budget,
+             valuator_groups: [create(:valuator_group)])
 
       visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'valuation_open')
 
       expect(page).to have_content("Assigned idea")
       expect(page).to have_content("Evaluating...")
+      expect(page).to have_content("With group")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'without_admin')
 
       expect(page).to have_content("Evaluating...")
+      expect(page).to have_content("With group")
       expect(page).not_to have_content("Assigned idea")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'without_valuator')
 
       expect(page).to have_content("Assigned idea")
       expect(page).not_to have_content("Evaluating...")
+      expect(page).not_to have_content("With group")
     end
 
     scenario "Filtering by valuation status" do


### PR DESCRIPTION
## Objectives

Make the tab "without valuator" really mean "without valuator nor valuator group", just as expected by administrators.

## Does this PR need a Backport to CONSUL?

Yes.