### PR TITLE
Use find instead of find by id

### DIFF
--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -44,11 +44,11 @@ class Admin::BudgetGroupsController < Admin::BaseController
   private
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id params[:budget_id]
     end
 
     def load_group
-      @group = @budget.groups.find_by(slug: params[:id]) || @budget.groups.find_by(id: params[:id])
+      @group = @budget.groups.find_by_slug_or_id params[:id]
     end
 
     def groups_index

--- a/app/controllers/admin/budget_headings_controller.rb
+++ b/app/controllers/admin/budget_headings_controller.rb
@@ -46,18 +46,15 @@ class Admin::BudgetHeadingsController < Admin::BaseController
   private
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id])
-      @budget ||= Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id params[:budget_id]
     end
 
     def load_group
-      @group = @budget.groups.find_by(slug: params[:group_id])
-      @group ||= @budget.groups.find_by(id: params[:group_id])
+      @group = @budget.groups.find_by_slug_or_id params[:group_id]
     end
 
     def load_heading
-      @heading = @group.headings.find_by(slug: params[:id])
-      @heading ||= @group.headings.find_by(id: params[:id])
+      @heading = @group.headings.find_by_slug_or_id params[:id]
     end
 
     def headings_index

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -89,8 +89,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
-      raise ActionController::RoutingError, 'Not Found' if @budget.blank?
+      @budget = Budget.find_by_slug_or_id params[:budget_id]
     end
 
     def load_investment

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -4,7 +4,7 @@ class Admin::BudgetsController < Admin::BaseController
 
   has_filters %w{open finished}, only: :index
 
-  before_action :load_budget
+  before_action :load_budget, except: [:index, :new, :create]
   load_and_authorize_resource
 
   def index
@@ -62,7 +62,7 @@ class Admin::BudgetsController < Admin::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+      @budget = Budget.find_by_slug_or_id params[:id]
     end
 
 end

--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -41,7 +41,7 @@ module Budgets
         end
 
         def load_budget
-          @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+          @budget = Budget.find_by_slug_or_id params[:budget_id]
         end
 
         def load_ballot

--- a/app/controllers/budgets/ballots_controller.rb
+++ b/app/controllers/budgets/ballots_controller.rb
@@ -15,7 +15,7 @@ module Budgets
     private
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
       end
 
       def load_ballot

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -25,7 +25,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+        @budget = Budget.find_by_slug_or_id params[:id]
       end
 
       def investments_by_heading_ordered_alphabetically

--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -14,11 +14,11 @@ module Budgets
     private
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id params[:budget_id]
     end
 
     def load_group
-      @group = @budget.groups.find_by(slug: params[:id]) || @budget.groups.find_by(id: params[:id])
+      @group = @budget.groups.find_by_slug_or_id params[:id]
     end
 
   end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -175,7 +175,7 @@ module Budgets
       end
 
       def load_heading_from_slug
-        @heading = @budget.headings.find_by(slug: params[:heading_id]) || @budget.headings.find_by(id: params[:heading_id])
+        @heading = @budget.headings.find_by_slug_or_id params[:heading_id]
       end
 
       def load_assigned_heading
@@ -199,8 +199,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
-        raise ActionController::RoutingError, 'Not Found' if @budget.blank?
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
       end
 
       def set_view

--- a/app/controllers/budgets/recommendations_controller.rb
+++ b/app/controllers/budgets/recommendations_controller.rb
@@ -45,7 +45,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
       end
 
       def load_phase

--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -16,7 +16,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
       end
 
   end

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -3,7 +3,7 @@ class BudgetsController < ApplicationController
   include BudgetsHelper
   feature_flag :budgets
 
-  before_action :load_budget
+  before_action :load_budget, only: :show
   load_and_authorize_resource
   before_action :set_default_budget_filter, only: :show
   has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: :show
@@ -23,7 +23,7 @@ class BudgetsController < ApplicationController
   private
 
   def load_budget
-    @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+    @budget = Budget.find_by_slug_or_id params[:id]
   end
 
 end

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -5,7 +5,6 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   load_resource :investment, through: :budget, class: 'Budget::Investment'
 
   before_action :only_verified_users, except: :print
-  before_action :load_heading, only: [:index, :show, :print]
 
   def index
     @investments = @investments.apply_filters_and_search(@budget, params).page(params[:page])
@@ -63,11 +62,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
-    end
-
-    def load_heading
-      @heading = @budget.headings.find(params[:heading_id]) if params[:heading_id].present?
+      @budget = Budget.find_by_slug_or_id params[:budget_id]
     end
 
     def load_categories

--- a/app/controllers/related_contents_controller.rb
+++ b/app/controllers/related_contents_controller.rb
@@ -31,7 +31,7 @@ class RelatedContentsController < ApplicationController
   private
 
   def score(action)
-    @related = RelatedContent.find_by(id: params[:id])
+    @related = RelatedContent.find params[:id]
     @related.send("score_#{action}", current_user)
 
     render template: 'relationable/_refresh_score_actions'

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -67,7 +67,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id params[:budget_id]
     end
 
     def load_investment

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -3,6 +3,10 @@ module Sluggable
 
   included do
     before_validation :generate_slug, if: :generate_slug?
+
+    def self.find_by_slug_or_id(slug_or_id)
+      find_by(slug: slug_or_id) || find(slug_or_id)
+    end
   end
 
   def generate_slug

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -1682,7 +1682,7 @@ feature 'Budget Investments' do
     it 'Trying to visit an investment with a wrong budget slug' do
       wrong_url = budget_investment_path(budget_id: budget.slug, id: investment.id).gsub(budget.slug, 'wrong_budget_slug')
 
-      expect { visit wrong_url }.to raise_error(ActionController::RoutingError)
+      expect { visit wrong_url }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
## Objectives
- Use `find(id)` instead of `find_by(id: id)`. It's preferable to raise a 404 HTML error than any other unexpected/unknown Exception.

- Add the method `find_by_slug_or_id` to the module `Sluggable` to make it easier to add to furure models.

## Does this PR need a Backport to CONSUL?
Yes, it would be nice to be able to `find_by_slug` also in CONSUL
But, we will probably do it in a future PR, we will have to include at least this other PR https://github.com/AyuntamientoMadrid/consul/pull/520