### PR TITLE
[Improvement] CRUD budgets and content blocks

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -29,6 +29,10 @@ module AdminHelper
      "hidden_budget_investments"]
   end
 
+  def menu_budgets?
+    %w[budgets budget_groups budget_headings budget_investments].include?(controller_name)
+  end
+
   def menu_budget?
     ["spending_proposals"].include?(controller_name)
   end

--- a/app/views/admin/_menu.html.erb
+++ b/app/views/admin/_menu.html.erb
@@ -29,8 +29,7 @@
     <% end %>
 
     <% if feature?(:budgets) %>
-      <li class="section-title <%= "is-active" if controller_name == "budgets" ||
-                                                  controller_name == "milestone_statuses" %>">
+      <li class="section-title <%= "is-active" if menu_budgets? %>">
         <%= link_to admin_budgets_path do %>
           <span class="icon-budget"></span>
           <strong><%= t("admin.menu.budgets") %></strong>

--- a/app/views/admin/budget_groups/index.html.erb
+++ b/app/views/admin/budget_groups/index.html.erb
@@ -1,3 +1,7 @@
+<%= back_link_to admin_budgets_path, t("admin.budget_groups.index.back") %>
+
+<div class="clear"></div>
+
 <h2 class="inline-block"><%= @budget.name %></h2>
 
 <%= link_to t("admin.budget_groups.form.create"),

--- a/app/views/admin/budget_headings/index.html.erb
+++ b/app/views/admin/budget_headings/index.html.erb
@@ -1,4 +1,4 @@
-<%= back_link_to admin_budget_groups_path(@budget) %>
+<%= back_link_to admin_budget_groups_path(@budget), t("admin.budget_headings.index.back") %>
 
 <div class="clear"></div>
 <h2 class="inline-block"><%= "#{@budget.name} / #{@group.name}" %></h2>

--- a/app/views/admin/site_customization/content_blocks/index.html.erb
+++ b/app/views/admin/site_customization/content_blocks/index.html.erb
@@ -9,13 +9,13 @@
 <h3><%= t("admin.site_customization.content_blocks.information") %></h3>
 
 <p><%= t("admin.site_customization.content_blocks.about") %></p>
-<p><%= t("admin.site_customization.content_blocks.top_links_html") %></p>
+<p><%= t("admin.site_customization.content_blocks.html_format") %></p>
 
-<code>&lt;li&gt;&lt;a href=&quot;http://site1.com&quot;&gt;Site 1&lt;/a&gt;&lt;/li&gt;</code><br>
-<code>&lt;li&gt;&lt;a href=&quot;http://site2.com&quot;&gt;Site 2&lt;/a&gt;&lt;/li&gt;</code><br>
-<code>&lt;li&gt;&lt;a href=&quot;http://site3.com&quot;&gt;Site 3&lt;/a&gt;&lt;/li&gt;</code><br>
-
-<p class="margin-top"><%= t("admin.site_customization.content_blocks.footer_html") %></p>
+<p>
+  <code><%= '<li><a href="http://site1.com">Site 1</a></li>' %></code><br>
+  <code><%= '<li><a href="http://site2.com">Site 2</a></li>' %></code><br>
+  <code><%= '<li><a href="http://site3.com">Site 3</a></li>' %></code><br>
+</p>
 
 <% if @content_blocks.any? || @headings_content_blocks.any? %>
   <table class="cms-page-list">

--- a/app/views/budgets/investments/_content_blocks.html.erb
+++ b/app/views/budgets/investments/_content_blocks.html.erb
@@ -1,7 +1,5 @@
 <% if @heading.allow_custom_content %>
-  <br>
-
-  <ul id="content_block" class="no-bullet categories">
+  <ul class="no-bullet categories">
     <% @heading_content_blocks.each do |content_block| %>
     	<%= raw content_block.body %>
     <% end %>

--- a/app/views/custom/layouts/_footer.html.erb
+++ b/app/views/custom/layouts/_footer.html.erb
@@ -91,13 +91,10 @@
                               title: t("shared.go_to_page") + t("social.instagram", org: setting['org_name']) + t('shared.target_blank_html') %>
               </li>
             <% end %>
+            <%= raw content_block("footer", I18n.locale) %>
           </ul>
         </div>
       </div>
     </div>
-  </div>
-
-  <div class="row">
-    <%= raw content_block("footer", I18n.locale) %>
   </div>
 </footer>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -83,13 +83,10 @@
                 <% end %>
               </li>
             <% end %>
+            <%= raw content_block("footer", I18n.locale) %>
           </ul>
         </div>
       </div>
     </div>
-  </div>
-
-  <div class="row">
-    <%= raw content_block("footer", I18n.locale) %>
   </div>
 </footer>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -119,7 +119,7 @@ en:
       headings_edit: "Edit Headings"
       headings_manage: "Manage headings"
       max_votable_headings: "Maximum number of headings in which a user can vote"
-      no_groups: "No groups created yet. Each user will be able to vote in only one heading per group."
+      no_groups: "There are no groups."
       amount:
         one: "There is 1 group"
         other: "There are %{count} groups"
@@ -135,9 +135,11 @@ en:
         edit: "Edit group"
         name: "Group name"
         submit: "Save group"
+      index:
+        back: "Go back to budgets"
     budget_headings:
       name: "Name"
-      no_headings: "No headings created yet. Each user will be able to vote in only one heading per group."
+      no_headings: "There are no headings."
       amount:
         one: "There is 1 heading"
         other: "There are %{count} headings"
@@ -161,6 +163,8 @@ en:
         create: "Create new heading"
         edit: "Edit heading"
         submit: "Save heading"
+      index:
+        back: "Go back to groups"
     budget_phases:
       edit:
         start_date: Start date
@@ -1400,9 +1404,8 @@ en:
     site_customization:
       content_blocks:
         information: Information about content blocks
-        about: You can create HTML content blocks to be inserted in the header or the footer of your CONSUL.
-        top_links_html: "<strong>Header blocks (top_links)</strong> are blocks of links that must have this format:"
-        footer_html: "<strong>Footer blocks</strong> can have any format and can be used to insert Javascript, CSS or custom HTML."
+        about: "You can create HTML content blocks that can be inserted in different places of your website."
+        html_format: "A content block is a group of links, and it must have the following format:"
         no_blocks: "There are no content blocks."
         create:
           notice: Content block created successfully

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -119,7 +119,7 @@ es:
       headings_edit: "Editar Partidas"
       headings_manage: "Gestionar partidas"
       max_votable_headings: "Máximo número de partidas en que un usuario puede votar"
-      no_groups: "No hay grupos creados todavía. Cada usuario podrá votar en una sola partida de cada grupo."
+      no_groups: "No hay grupos."
       amount:
         one: "Hay 1 grupo de partidas presupuestarias"
         other: "Hay %{count} grupos de partidas presupuestarias"
@@ -135,9 +135,11 @@ es:
         edit: "Editar grupo"
         name: "Nombre del grupo"
         submit: "Guardar grupo"
+      index:
+        back: "Volver a presupuestos"
     budget_headings:
       name: "Nombre"
-      no_headings: "No hay partidas creadas todavía. Cada usuario podrá votar en una sola partida de cada grupo."
+      no_headings: "No hay partidas."
       amount:
         one: "Hay 1 partida presupuestarias"
         other: "Hay %{count} partidas presupuestarias"
@@ -161,6 +163,8 @@ es:
         create: "Crear nueva partida"
         edit: "Editar partida"
         submit: "Guardar partida"
+      index:
+        back: "Volver a grupos"
     budget_phases:
       edit:
         start_date: Fecha de Inicio
@@ -1399,10 +1403,9 @@ es:
         title: Verificaciones incompletas
     site_customization:
       content_blocks:
-        information: Información sobre los bloques de texto
-        about: Puedes crear bloques de HTML que se incrustarán en la cabecera o el pie de tu CONSUL.
-        top_links_html: "Los <strong>bloques de la cabecera (top_links)</strong> son bloques de enlaces que deben crearse con este formato:"
-        footer_html: "Los <strong>bloques del pie (footer)</strong> pueden tener cualquier formato y se pueden utilizar para guardar huellas Javascript, contenido CSS o contenido HTML personalizado."
+        information: "Información sobre los bloques de contenido"
+        about: "Puedes crear bloques de contenido HTML que se podrán incrustar en diferentes sitios de tu página."
+        html_format: "Un bloque de contenido es un grupo de enlaces, y debe de tener el siguiente formato:"
         no_blocks: "No hay bloques de texto."
         create:
           notice: Bloque creado correctamente

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -32,8 +32,7 @@ feature "Admin budget groups" do
     scenario "Displaying no groups for budget" do
       visit admin_budget_groups_path(budget)
 
-      expect(page).to have_content "No groups created yet. "
-      expect(page).to have_content "Each user will be able to vote in only one heading per group."
+      expect(page).to have_content "There are no groups."
     end
 
     scenario "Displaying groups" do

--- a/spec/features/admin/budget_headings_spec.rb
+++ b/spec/features/admin/budget_headings_spec.rb
@@ -33,8 +33,7 @@ feature "Admin budget headings" do
     scenario "Displaying no headings for group" do
       visit admin_budget_group_headings_path(budget, group)
 
-      expect(page).to have_content "No headings created yet. "
-      expect(page).to have_content "Each user will be able to vote in only one heading per group."
+      expect(page).to have_content "There are no headings."
     end
 
     scenario "Displaying headings" do


### PR DESCRIPTION
## Objectives
- Improve messages of links to go back from budget groups and headings.
- Highlight the budget section in the admin menu.
- Improve explanation texts about content blocks.
- Refactor code to make it more readable.

## Visual Changes
### BEFORE
![1](https://user-images.githubusercontent.com/942995/50687805-f3feb800-1022-11e9-9dca-330aa0c60e21.png)

### AFTER
![2](https://user-images.githubusercontent.com/942995/50965608-babac200-14d2-11e9-8683-5e427fa48b9a.png)

### BEFORE
![3](https://user-images.githubusercontent.com/942995/50687814-fe20b680-1022-11e9-9a30-292b9de7a089.png)

### AFTER
![4](https://user-images.githubusercontent.com/942995/50965622-c4dcc080-14d2-11e9-80c6-ab042cc7b298.png)

### BEFORE
![5](https://user-images.githubusercontent.com/942995/50687822-07118800-1023-11e9-84fc-087f20a80790.png)

### AFTER
![6](https://user-images.githubusercontent.com/942995/50961662-95c15180-14c8-11e9-8bb5-059824478146.png)

## Does this PR need a Backport to CONSUL?
Yes

## Notes
⚠️ From now on, content blocks are supposed to have only links. If you previously had some other HTML injected by using the content blocks feature, it might not render as it did before ☺️ . If you would like to make more specific changes to the footer or other views check out the docs on creating custom views https://consul_docs.gitbooks.io/docs/en/customization/views_and_styles.html