### PR TITLE
Refactor poll stats methods

### DIFF
--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -22,20 +22,16 @@ class Poll::Stats
       total_participants_web + total_participants_booth
     end
 
-    def total_participants_web
-      total_web_valid + total_web_white + total_web_null
-    end
+    %i[web booth].each do |channel|
+      define_method :"total_participants_#{channel}" do
+        send(:"total_#{channel}_valid") +
+          send(:"total_#{channel}_white") +
+          send(:"total_#{channel}_null")
+      end
 
-    def total_participants_web_percentage
-      calculate_percentage(total_participants_web, total_participants)
-    end
-
-    def total_participants_booth
-      total_booth_valid + total_booth_white + total_booth_null
-    end
-
-    def total_participants_booth_percentage
-      calculate_percentage(total_participants_booth, total_participants)
+      define_method :"total_participants_#{channel}_percentage" do
+        calculate_percentage(send(:"total_participants_#{channel}"), total_participants)
+      end
     end
 
     def total_web_valid

--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -42,10 +42,6 @@ class Poll::Stats
       voters.where(origin: 'web').count - total_web_white
     end
 
-    def valid_percentage_web
-      calculate_percentage(total_web_valid, total_valid_votes)
-    end
-
     def total_web_white
       return 0 unless poll.questions.second.present?
       double_white = (Poll::Answer.where(answer: 'En blanco', question: poll.questions.first).pluck(:author_id) & Poll::Answer.where(answer: 'En blanco', question: poll.questions.second).pluck(:author_id)).uniq.count
@@ -62,64 +58,46 @@ class Poll::Stats
       double_white + first_total + second_total
     end
 
-    def white_percentage_web
-      calculate_percentage(total_web_white, total_white_votes)
-    end
-
     def total_web_null
       0
-    end
-
-    def null_percentage_web
-      calculate_percentage(total_web_null, total_web_valid)
     end
 
     def total_booth_valid
       recounts.sum(:total_amount)
     end
 
-    def valid_percentage_booth
-      calculate_percentage(total_booth_valid, total_valid_votes)
-    end
-
     def total_booth_white
       recounts.sum(:white_amount)
-    end
-
-    def white_percentage_booth
-      calculate_percentage(total_booth_white, total_white_votes)
     end
 
     def total_booth_null
       recounts.sum(:null_amount)
     end
 
-    def null_percentage_booth
-      calculate_percentage(total_booth_null, total_null_votes)
+    def valid_percentage_web
+      calculate_percentage(total_web_valid, total_valid_votes)
     end
 
-    def total_valid_votes
-      total_web_valid + total_booth_valid
+    def white_percentage_web
+      calculate_percentage(total_web_white, total_white_votes)
     end
 
-    def total_valid_percentage
-      calculate_percentage(total_valid_votes, total_participants)
+    def null_percentage_web
+      calculate_percentage(total_web_null, total_web_valid)
     end
 
-    def total_white_votes
-      total_web_white + total_booth_white
-    end
+    %i[valid white null].each do |type|
+      define_method :"#{type}_percentage_booth" do
+        calculate_percentage(send(:"total_booth_#{type}"), send(:"total_#{type}_votes"))
+      end
 
-    def total_white_percentage
-      calculate_percentage(total_white_votes, total_participants)
-    end
+      define_method :"total_#{type}_votes" do
+        send(:"total_web_#{type}") + send(:"total_booth_#{type}")
+      end
 
-    def total_null_votes
-      total_web_null + total_booth_null
-    end
-
-    def total_null_percentage
-      calculate_percentage(total_null_votes, total_participants)
+      define_method :"total_#{type}_percentage" do
+        calculate_percentage(send(:"total_#{type}_votes"), total_participants)
+      end
     end
 
     def voters


### PR DESCRIPTION
## References

* Commit 72b02e47, commit 57618c89 and all commits done around that time

## Objectives

* Remove duplication in methods in poll stats
* Expose potential bugs due to some methods being slightly different when they should probably be identical

## Does this PR need a Backport to CONSUL?

Yes, backport alongside everything related to stats.

## Notes

There seems to be a typo in the method `null_percentage_web`.