### PR TITLE
Legislation process homepage phase

### DIFF
--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -18,8 +18,8 @@ class Legislation::Process < ActiveRecord::Base
   translates :homepage,           touch: true
   include Globalizable
 
-  PHASES_AND_PUBLICATIONS = %i[draft_phase debate_phase allegations_phase proposals_phase
-                               draft_publication result_publication].freeze
+  PHASES_AND_PUBLICATIONS = %i[homepage_phase draft_phase debate_phase allegations_phase
+                               proposals_phase draft_publication result_publication].freeze
 
   has_many :draft_versions, -> { order(:id) }, class_name: 'Legislation::DraftVersion',
                                                foreign_key: 'legislation_process_id',
@@ -53,6 +53,10 @@ class Legislation::Process < ActiveRecord::Base
   scope :not_in_draft, -> { where("draft_phase_enabled = false or (draft_start_date IS NOT NULL and
                                    draft_end_date IS NOT NULL and (draft_start_date > ? or
                                    draft_end_date < ?))", Date.current, Date.current) }
+
+  def homepage_phase
+    Legislation::Process::Phase.new(start_date, end_date, homepage_enabled)
+  end
 
   def draft_phase
     Legislation::Process::Phase.new(draft_start_date, draft_end_date, draft_phase_enabled)

--- a/app/views/legislation/processes/_header.html.erb
+++ b/app/views/legislation/processes/_header.html.erb
@@ -34,6 +34,30 @@
         url: legislation_process_url(@process),
         description: @process.title
       } %>
+
+      <% if process.draft_publication.enabled? %>
+        <div class="sidebar-divider"></div>
+        <p class="sidebar-title">
+          <%= t("legislation.processes.shared.draft_publication_date") %>
+        </p>
+        <p>
+          <%= link_to draft_publication_legislation_process_path(@process) do %>
+            <strong><%= format_date(process.draft_publication_date) %></strong>
+          <% end %>
+        </p>
+      <% end %>
+
+      <% if process.result_publication.enabled? %>
+        <div class="sidebar-divider"></div>
+        <p class="sidebar-title">
+          <%= t("legislation.processes.shared.result_publication_date") %>
+        </p>
+        <p>
+          <%= link_to result_publication_legislation_process_path(@process) do %>
+            <strong><%= format_date(process.result_publication_date) %></strong>
+          <% end %>
+        </p>
+      <% end %>
     </aside>
   </div>
 </div>

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -6,6 +6,15 @@
       <% end %>
 
       <ul class="key-dates">
+        <% if process.homepage_enabled? && process.homepage.present? %>
+          <li <%= 'class=is-active' if phase.to_sym == :homepage %>>
+            <%= link_to legislation_process_path(process) do %>
+              <h4><%= t("legislation.processes.shared.homepage") %></h4>
+              <br>
+            <% end %>
+          </li>
+        <% end %>
+
         <% if process.debate_phase.enabled? %>
           <li <%= 'class=is-active' if phase.to_sym == :debate_phase %>>
             <%= link_to debate_legislation_process_path(process) do %>

--- a/app/views/legislation/processes/_key_dates.html.erb
+++ b/app/views/legislation/processes/_key_dates.html.erb
@@ -33,29 +33,11 @@
           </li>
         <% end %>
 
-        <% if process.draft_publication.enabled? %>
-          <li <%= 'class=is-active' if phase.to_sym == :draft_publication %>>
-            <%= link_to draft_publication_legislation_process_path(process) do %>
-              <h4><%= t("legislation.processes.shared.draft_publication_date") %></h4>
-              <span><%= format_date(process.draft_publication_date) %></span>
-            <% end %>
-          </li>
-        <% end %>
-
         <% if process.allegations_phase.enabled? %>
           <li <%= 'class=is-active' if phase.to_sym == :allegations_phase %>>
             <%= link_to allegations_legislation_process_path(process) do %>
               <h4><%= t("legislation.processes.shared.allegations_dates") %></h4>
               <span><%= format_date(process.allegations_start_date) %> - <%= format_date(process.allegations_end_date) %></span>
-            <% end %>
-          </li>
-        <% end %>
-
-        <% if process.result_publication.enabled? %>
-          <li <%= 'class=is-active' if phase.to_sym == :result_publication %>>
-            <%= link_to result_publication_legislation_process_path(process) do %>
-              <h4><%= t("legislation.processes.shared.result_publication_date") %></h4>
-              <span><%= format_date(process.result_publication_date) %></span>
             <% end %>
           </li>
         <% end %>

--- a/app/views/legislation/processes/show.html.erb
+++ b/app/views/legislation/processes/show.html.erb
@@ -4,9 +4,9 @@
 
 <%= render 'documents/additional_documents', documents: @process.documents %>
 
-<%= render 'key_dates', process: @process, phase: :debate_phase %>
+<%= render 'key_dates', process: @process, phase: :homepage %>
 
-<div class="row">
+<div class="row margin-top">
   <div class="small-12 medium-9 column">
     <%= AdminWYSIWYGSanitizer.new.sanitize(@process.homepage) %>
   </div>

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -83,6 +83,7 @@ en:
         see_latest_comments_title: Comment on this process
       shared:
         key_dates: Participation phases
+        homepage: Homepage
         debate_dates: Debate
         draft_publication_date: Draft publication
         allegations_dates: Comments

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -83,6 +83,7 @@ es:
         see_latest_comments_title: Aportar a este proceso
       shared:
         key_dates: Fases de participación
+        homepage: Inicio
         debate_dates: Debate previo
         draft_publication_date: Publicación borrador
         allegations_dates: Comentarios

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -149,8 +149,7 @@ feature 'Legislation' do
       scenario 'show view has document present on all phases' do
         process = create(:legislation_process)
         document = create(:document, documentable: process)
-        phases = ["Debate", "Proposals", "Draft publication",
-                  "Comments", "Final result publication"]
+        phases = ["Debate", "Proposals", "Comments"]
 
         visit legislation_process_path(process)
 
@@ -160,6 +159,31 @@ feature 'Legislation' do
           end
 
           expect(page).to have_content(document.title)
+        end
+      end
+
+      scenario 'show draft publication and final result publication dates' do
+        process = create(:legislation_process, draft_publication_date: Date.new(2019, 01, 10),
+                                               result_publication_date: Date.new(2019, 01, 20))
+
+        visit legislation_process_path(process)
+
+        within("aside") do
+          expect(page).to have_content("Draft publication")
+          expect(page).to have_content("10 Jan 2019")
+          expect(page).to have_content("Final result publication")
+          expect(page).to have_content("20 Jan 2019")
+        end
+      end
+
+      scenario 'do not show draft publication and final result publication dates if are empty' do
+        process = create(:legislation_process, :empty)
+
+        visit legislation_process_path(process)
+
+        within("aside") do
+          expect(page).not_to have_content("Draft publication")
+          expect(page).not_to have_content("Final result publication")
         end
       end
 

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -198,6 +198,10 @@ feature 'Legislation' do
 
         visit legislation_process_path(process)
 
+        within(".key-dates") do
+          expect(page).to have_content("Homepage")
+        end
+
         expect(page).to     have_content("This is the process homepage")
         expect(page).not_to have_content("Participate in the debate")
       end
@@ -209,6 +213,10 @@ feature 'Legislation' do
                                                debate_end_date: Date.current + 2.days)
 
         visit legislation_process_path(process)
+
+        within(".key-dates") do
+          expect(page).not_to have_content("Homepage")
+        end
 
         expect(page).to have_content("This phase is not open yet")
         expect(page).not_to have_content("This is the process homepage")


### PR DESCRIPTION
## Objectives

- Adds **homepage phase** and tab to legislation processes show.
- Moves **draft publication** and **final result publication** dates from tabs to sidebar: these dates aren't a phase, only a date that redirects to "Comments" phase.

## Visual Changes
**New homepage tab**
![homepage_tab](https://user-images.githubusercontent.com/631897/50896576-aeb6fd80-1409-11e9-801c-effea6a0edd6.png)

**Now "Draft publication" and "Final result publication" dates appear on header's sidebar**
![sidebar_dates](https://user-images.githubusercontent.com/631897/50971467-57399000-14e4-11e9-8de7-baeeea8d7e58.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.