### PR TITLE
[Upstream] Fix typo in investment default order spec

### DIFF
--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -660,7 +660,7 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       expect('D Fourth Investment').to appear_before('B First Investment')
-      expect('D Fourth Investment').to appear_before('A Second Investment')
+      expect('B First Investment').to appear_before('A Second Investment')
       expect('A Second Investment').to appear_before('C Third Investment')
     end
 


### PR DESCRIPTION
## References

* Pull request consul#3151
* Commit consul@7c06320f3

## Objectives

* Fix a typo in a spec checking the default order for budget investments
* Keep the code in this repository as synchronized with CONSUL's repository as possible

## Does this PR need a Backport to CONSUL?

No, the code is already in CONSUL.