### PR TITLE
Enable double quotes rubocop rule

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -41,3 +41,6 @@ Metrics/LineLength:
 
 RSpec/NotToNot:
   Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
## Objectives
Enable rubocop rule to always check for double quotes.

## Does this PR need a Backport to CONSUL?
Yes