### PR TITLE
[Upstream] Initialize graphql after application initialization

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,7 +49,10 @@ module Consul
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'custom', '**', '*.{rb,yml}')]
 
-    config.after_initialize { Globalize.set_fallbacks_to_all_available_locales }
+    config.after_initialize do
+      Globalize.set_fallbacks_to_all_available_locales
+      GraphQLApi::Loader.setup
+    end
 
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
 

--- a/config/initializers/graphql.rb
+++ b/config/initializers/graphql.rb
@@ -1,4 +1,0 @@
-if ActiveRecord::Base.connection.tables.any?
-  api_config = YAML.load_file('./config/api.yml')
-  API_TYPE_DEFINITIONS = GraphQL::ApiTypesCreator::parse_api_config_file(api_config)
-end

--- a/config/initializers/graphql_api.rb
+++ b/config/initializers/graphql_api.rb
@@ -1,0 +1,11 @@
+module GraphQLApi
+  class Loader
+    def self.setup
+      if ActiveRecord::Base.connection.tables.any?
+        api_config = YAML.load_file('./config/api.yml')
+        GraphqlController.const_set "API_TYPE_DEFINITIONS",
+          GraphQL::ApiTypesCreator::parse_api_config_file(api_config)
+      end
+    end
+  end
+end

--- a/spec/lib/graphql_spec.rb
+++ b/spec/lib/graphql_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-api_types  = GraphQL::ApiTypesCreator.create(API_TYPE_DEFINITIONS)
+api_types  = GraphQL::ApiTypesCreator.create(GraphqlController::API_TYPE_DEFINITIONS)
 query_type = GraphQL::QueryTypeCreator.create(api_types)
 ConsulSchema = GraphQL::Schema.define do
   query query_type


### PR DESCRIPTION
## References
- **Pull Request**: https://github.com/consul/consul/pull/3159

## Objectives

Proposal, Debate and Comment "globalize_accessors" class method were
loaded before application available locales initialization because of
graphql initializer. This will cause unexpected translation errors at
any translatable classes declared at graphql api definition (api.yml).

Doing GraphQL initialization after application initialization should
solve this issue.

## Does this PR need a Backport to CONSUL?

No, this comes from CONSUL.

## Does this PR need manual testing?
Yes, tested in the staging environment for Proposals, Debates and Comments from the [GraphQL GUI](http://decidepre.madrid.es/graphiql) using a [basic call](https://github.com/consul/consul/blob/master/doc/api/api_en.md#graphql) to query for a resource of each class, for example:

```
{
  proposal(id: 100) {
    id,
    title,
    public_author {
      id,
      username
    }
  }
}
```