### PR TITLE
Create budget investment's votes

### DIFF
--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -41,4 +41,25 @@ class Migrations::SpendingProposal::Vote
     end
   end
 
+  def create_budget_investment_votes
+    spending_proposal_votes.each do |vote|
+      create_budget_invesment_vote(vote)
+    end
+  end
+
+  private
+
+    def spending_proposal_votes
+      Vote.where(votable: SpendingProposal.all)
+    end
+
+    def create_budget_invesment_vote(vote)
+      budget_investment = find_budget_investment(vote.votable)
+      budget_investment.vote_by(voter: vote.voter, vote: "yes")
+    end
+
+    def find_budget_investment(spending_proposal)
+      Budget::Investment.where(original_spending_proposal_id: spending_proposal.id).first
+    end
+
 end

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -55,7 +55,9 @@ class Migrations::SpendingProposal::Vote
 
     def create_budget_invesment_vote(vote)
       budget_investment = find_budget_investment(vote.votable)
-      budget_investment.vote_by(voter: vote.voter, vote: "yes")
+      if budget_investment
+        budget_investment.vote_by(voter: vote.voter, vote: "yes")
+      end
     end
 
     def find_budget_investment(spending_proposal)

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -38,6 +38,7 @@ namespace :spending_proposals do
   task migrate_delegated_votes: :environment do
     require "migrations/spending_proposal/vote"
     Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+    Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
   end
 
   desc "Migrates spending proposals attributes to corresponding budget investments attributes"

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -228,5 +228,13 @@ describe Migrations::SpendingProposal::Vote do
       expect(budget_investment2.votes_for.count).to eq(5)
     end
 
+    it "gracefully handles missing corresponding budget investment" do
+      spending_proposal = create(:spending_proposal)
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      expect{ Migrations::SpendingProposal::Vote.new.create_budget_investment_votes }
+      .not_to raise_error
+    end
+
   end
 end

--- a/spec/lib/migrations/spending_proposals/vote_spec.rb
+++ b/spec/lib/migrations/spending_proposals/vote_spec.rb
@@ -152,4 +152,39 @@ describe Migrations::SpendingProposal::Vote do
     end
 
   end
+
+  describe "#create_budget_investment_votes" do
+
+    it "creates a budget investment's vote for a corresponding spending proposal's vote" do
+      spending_proposal = create(:spending_proposal)
+      budget_investment = create(:budget_investment, original_spending_proposal_id: spending_proposal.id)
+
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      budget_investment_vote = budget_investment.votes_for.first
+
+      expect(budget_investment.votes_for.count).to eq(1)
+      expect(budget_investment_vote.voter).to eq(spending_proposal_vote.voter)
+      expect(budget_investment_vote.votable).to eq(budget_investment)
+      expect(budget_investment_vote.vote_flag).to eq(true)
+    end
+
+    it "creates budget investment's votes for all correspoding spending proposal's votes" do
+      spending_proposal1 = create(:spending_proposal)
+      spending_proposal2 = create(:spending_proposal)
+      budget_investment1 = create(:budget_investment, original_spending_proposal_id: spending_proposal1.id)
+      budget_investment2 = create(:budget_investment, original_spending_proposal_id: spending_proposal2.id)
+
+      3.times { create(:vote, votable: spending_proposal1) }
+      5.times { create(:vote, votable: spending_proposal2) }
+
+      Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+
+      expect(budget_investment1.votes_for.count).to eq(3)
+      expect(budget_investment2.votes_for.count).to eq(5)
+    end
+
+  end
 end


### PR DESCRIPTION
## References

**PR: https://github.com/AyuntamientoMadrid/consul/pull/1776**

## Context 
We already have budget investments for every spending proposal since the [partial migration](https://github.com/AyuntamientoMadrid/consul/pull/1059). But the votes where not included in this migration.
 
## Objectives
Create budget investment's votes for all corresponding spending proposal's votes.

## Does this PR need a Backport to CONSUL?
Yes, forks that still have spending proposals in their code base should run this migration.

## Notes
⚠️Run rake task:
`bin/rake spending_proposals:migrate_delegated_votes`

There is an upcoming PR deleting the obsolete spending proposal votes.

## Is manual testing needed?
Yes, comparison with the current stats page should be done in the staging server before merging, to make sure supports are still the same.