### PR TITLE
Use budget investments votes in public stats

### DIFF
--- a/app/controllers/spending_proposals_controller.rb
+++ b/app/controllers/spending_proposals_controller.rb
@@ -369,7 +369,7 @@ class SpendingProposalsController < ApplicationController
     end
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("spending_proposals_stats/20181227211842/#{key}", &block)
+      Rails.cache.fetch("spending_proposals_stats/20190206172205/#{key}", &block)
     end
 
 end


### PR DESCRIPTION
## References

**PR: https://github.com/AyuntamientoMadrid/consul/pull/1776**

## Objectives
Now that we have [migrated spending proposal's votes to budget investment's votes](https://github.com/AyuntamientoMadrid/consul/pull/1828) we should use them in the public stats' view to make sure the numbers are still the same.

## Does this PR need a Backport to CONSUL?

No, for CONSUL, and in Madrid soon, we should use the new [budget stats controller](https://github.com/AyuntamientoMadrid/consul/blob/master/app/controllers/budgets/stats_controller.rb), not this deprecated spending proposal's controller for stats.

## Notes
There are no passing specs for obsolete spending proposal stats. Manual testing required in staging server.
