### PR TITLE
Use find instead of find by id

### DIFF
--- a/app/controllers/admin/budget_groups_controller.rb
+++ b/app/controllers/admin/budget_groups_controller.rb
@@ -44,11 +44,11 @@ class Admin::BudgetGroupsController < Admin::BaseController
   private
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
 
     def load_group
-      @group = @budget.groups.find_by(slug: params[:id]) || @budget.groups.find_by(id: params[:id])
+      @group = @budget.groups.find_by_slug_or_id! params[:id]
     end
 
     def groups_index

--- a/app/controllers/admin/budget_headings_controller.rb
+++ b/app/controllers/admin/budget_headings_controller.rb
@@ -46,18 +46,15 @@ class Admin::BudgetHeadingsController < Admin::BaseController
   private
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id])
-      @budget ||= Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
 
     def load_group
-      @group = @budget.groups.find_by(slug: params[:group_id])
-      @group ||= @budget.groups.find_by(id: params[:group_id])
+      @group = @budget.groups.find_by_slug_or_id! params[:group_id]
     end
 
     def load_heading
-      @heading = @group.headings.find_by(slug: params[:id])
-      @heading ||= @group.headings.find_by(id: params[:id])
+      @heading = @group.headings.find_by_slug_or_id! params[:id]
     end
 
     def headings_index

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -89,8 +89,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
-      raise ActionController::RoutingError, 'Not Found' if @budget.blank?
+      @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
 
     def load_investment

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -4,7 +4,7 @@ class Admin::BudgetsController < Admin::BaseController
 
   has_filters %w{open finished}, only: :index
 
-  before_action :load_budget
+  before_action :load_budget, except: [:index, :new, :create]
   load_and_authorize_resource
 
   def index
@@ -62,7 +62,7 @@ class Admin::BudgetsController < Admin::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+      @budget = Budget.find_by_slug_or_id! params[:id]
     end
 
 end

--- a/app/controllers/budgets/ballot/lines_controller.rb
+++ b/app/controllers/budgets/ballot/lines_controller.rb
@@ -41,7 +41,7 @@ module Budgets
         end
 
         def load_budget
-          @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+          @budget = Budget.find_by_slug_or_id! params[:budget_id]
         end
 
         def load_ballot

--- a/app/controllers/budgets/ballots_controller.rb
+++ b/app/controllers/budgets/ballots_controller.rb
@@ -15,7 +15,7 @@ module Budgets
     private
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+        @budget = Budget.find_by_slug_or_id! params[:budget_id]
       end
 
       def load_ballot

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -25,7 +25,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budgetid])
+        @budget = Budget.find_by_slug_or_id params[:budget_id]
       end
 
       def investments_by_heading_ordered_alphabetically

--- a/app/controllers/budgets/executions_controller.rb
+++ b/app/controllers/budgets/executions_controller.rb
@@ -25,7 +25,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budgetid])
       end
 
       def investments_by_heading_ordered_alphabetically

--- a/app/controllers/budgets/groups_controller.rb
+++ b/app/controllers/budgets/groups_controller.rb
@@ -14,11 +14,11 @@ module Budgets
     private
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
 
     def load_group
-      @group = @budget.groups.find_by(slug: params[:id]) || @budget.groups.find_by(id: params[:id])
+      @group = @budget.groups.find_by_slug_or_id! params[:id]
     end
 
   end

--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -175,7 +175,7 @@ module Budgets
       end
 
       def load_heading_from_slug
-        @heading = @budget.headings.find_by(slug: params[:heading_id]) || @budget.headings.find_by(id: params[:heading_id])
+        @heading = @budget.headings.find_by_slug_or_id! params[:heading_id]
       end
 
       def load_assigned_heading
@@ -199,8 +199,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
-        raise ActionController::RoutingError, 'Not Found' if @budget.blank?
+        @budget = Budget.find_by_slug_or_id! params[:budget_id]
       end
 
       def set_view

--- a/app/controllers/budgets/recommendations_controller.rb
+++ b/app/controllers/budgets/recommendations_controller.rb
@@ -45,7 +45,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+        @budget = Budget.find_by_slug_or_id! params[:budget_id]
       end
 
       def load_phase

--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -13,17 +13,14 @@ module Budgets
     private
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id])
-        @budget ||= Budget.find_by(id: params[:budget_id])
-        @budget ||= Budget.first
+        @budget = Budget.find_by_slug_or_id(params[:budget_id]) || Budget.first
       end
 
       def load_heading
-        @heading = if params[:heading_id].present?
-                     @budget.headings.find_by(slug: params[:heading_id])
-                   else
-                     @heading = @budget.headings.first
-                   end
+        if @budget.present?
+          headings = @budget.headings
+          @heading = headings.find_by_slug_or_id(params[:heading_id]) || headings.first
+        end
       end
 
   end

--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -13,7 +13,9 @@ module Budgets
     private
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id]) || Budget.first
+        @budget = Budget.find_by(slug: params[:budget_id])
+        @budget ||= Budget.find_by(id: params[:budget_id])
+        @budget ||= Budget.first
       end
 
       def load_heading

--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -16,7 +16,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
       end
 
   end

--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -16,7 +16,7 @@ module Budgets
       end
 
       def load_budget
-        @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+        @budget = Budget.find_by_slug_or_id! params[:budget_id]
       end
 
   end

--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -3,7 +3,7 @@ class BudgetsController < ApplicationController
   include BudgetsHelper
   feature_flag :budgets
 
-  before_action :load_budget
+  before_action :load_budget, only: :show
   load_and_authorize_resource
   before_action :set_default_budget_filter, only: :show
   has_filters %w{not_unfeasible feasible unfeasible unselected selected}, only: :show
@@ -23,7 +23,7 @@ class BudgetsController < ApplicationController
   private
 
   def load_budget
-    @budget = Budget.find_by(slug: params[:id]) || Budget.find_by(id: params[:id])
+    @budget = Budget.find_by_slug_or_id! params[:id]
   end
 
 end

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -62,7 +62,7 @@ class Management::Budgets::InvestmentsController < Management::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
 
     def load_categories

--- a/app/controllers/management/budgets/investments_controller.rb
+++ b/app/controllers/management/budgets/investments_controller.rb
@@ -5,7 +5,6 @@ class Management::Budgets::InvestmentsController < Management::BaseController
   load_resource :investment, through: :budget, class: 'Budget::Investment'
 
   before_action :only_verified_users, except: :print
-  before_action :load_heading, only: [:index, :show, :print]
 
   def index
     @investments = @investments.apply_filters_and_search(@budget, params).page(params[:page])
@@ -64,10 +63,6 @@ class Management::Budgets::InvestmentsController < Management::BaseController
 
     def load_budget
       @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
-    end
-
-    def load_heading
-      @heading = @budget.headings.find(params[:heading_id]) if params[:heading_id].present?
     end
 
     def load_categories

--- a/app/controllers/related_contents_controller.rb
+++ b/app/controllers/related_contents_controller.rb
@@ -31,7 +31,7 @@ class RelatedContentsController < ApplicationController
   private
 
   def score(action)
-    @related = RelatedContent.find_by(id: params[:id])
+    @related = RelatedContent.find params[:id]
     @related.send("score_#{action}", current_user)
 
     render template: 'relationable/_refresh_score_actions'

--- a/app/controllers/valuation/budget_investments_controller.rb
+++ b/app/controllers/valuation/budget_investments_controller.rb
@@ -67,7 +67,7 @@ class Valuation::BudgetInvestmentsController < Valuation::BaseController
     end
 
     def load_budget
-      @budget = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      @budget = Budget.find_by_slug_or_id! params[:budget_id]
     end
 
     def load_investment

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -117,7 +117,7 @@ class Budget
     end
 
     def self.scoped_filter(params, current_filter)
-      budget  = Budget.find_by(slug: params[:budget_id]) || Budget.find_by(id: params[:budget_id])
+      budget  = Budget.find_by_slug_or_id params[:budget_id]
       results = Investment.by_budget(budget)
 
       results = results.where("cached_votes_up + physical_votes >= ?",

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -3,6 +3,10 @@ module Sluggable
 
   included do
     before_validation :generate_slug, if: :generate_slug?
+
+    def self.find_by_slug_or_id(slug_or_id)
+      find_by_slug(slug_or_id) || find_by_id(slug_or_id)
+    end
   end
 
   def generate_slug

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -7,6 +7,10 @@ module Sluggable
     def self.find_by_slug_or_id(slug_or_id)
       find_by_slug(slug_or_id) || find_by_id(slug_or_id)
     end
+
+    def self.find_by_slug_or_id!(slug_or_id)
+      find_by_slug(slug_or_id) || find(slug_or_id)
+    end
   end
 
   def generate_slug

--- a/config/routes/custom.rb
+++ b/config/routes/custom.rb
@@ -27,12 +27,12 @@ namespace :admin do
 end
 
 ### Budgets
-get 'participatory_budget',                to: 'pages#show', id: 'budgets/welcome',            as: 'participatory_budget'
-get 'presupuestos',                        to: 'budgets#index', id: 'help/budgets/welcome',    as: 'budgets_welcome'
-get "presupuestos/:id/estadisticas",       to: "budgets/stats#show", as: 'custom_budget_stats'
-get "presupuestos/:id/resultados",         to: "budgets/results#show", as: 'custom_budget_results'
-get 'presupuestos/:id/ejecuciones',        to: 'budgets/executions#show', as: 'custom_budget_executions'
-get "presupuestos/:id/resultados/:heading_id", to: "budgets/results#show", as: 'custom_budget_heading_result'
+get 'participatory_budget',                 to: 'pages#show', id: 'budgets/welcome',            as: 'participatory_budget'
+get 'presupuestos',                         to: 'budgets#index', id: 'help/budgets/welcome',    as: 'budgets_welcome'
+get "presupuestos/:budget_id/estadisticas", to: "budgets/stats#show", as: 'custom_budget_stats'
+get "presupuestos/:budget_id/resultados",   to: "budgets/results#show", as: 'custom_budget_results'
+get 'presupuestos/:budget_id/ejecuciones',  to: 'budgets/executions#show', as: 'custom_budget_executions'
+get "presupuestos/:budget_id/resultados/:heading_id", to: "budgets/results#show", as: 'custom_budget_heading_result'
 
 resources :budgets, only: [:show, :index], path: 'presupuestos' do
   resources :groups, controller: "budgets/groups", only: [:show], path: 'grupo'
@@ -178,7 +178,7 @@ get 'participatory_budget/select_district',        to: 'spending_proposals#selec
 get 'delegacion',                                  to: 'forums#index', as: 'delegation'
 get 'presupuestos-participativos-resultados',      to: 'spending_proposals#results',                    as: 'participatory_budget_results'
 get 'presupuestos-participativos-estadisticas',    to: 'spending_proposals#stats',                      as: 'participatory_budget_stats'
-get 'presupuestos-participativos-ejecuciones',     to: 'budgets/executions#show',                       as: 'participatory_budget_executions', defaults: {id: '2016'}
+get 'presupuestos-participativos-ejecuciones',     to: 'budgets/executions#show',                       as: 'participatory_budget_executions', defaults: {budget_id: '2016'}
 get 'participatory_budget_info',                   to: 'pages#show', id: 'help/budgets/info_2016', as: 'more_info_budgets_2016'
 get 'jornada-presupuestos-participativos',         to: 'budget_polls#new'
 get 'jornada-presupuestos-participativos/success', to: 'budget_polls#success'

--- a/spec/controllers/budgets/ballots/lines_controller_spec.rb
+++ b/spec/controllers/budgets/ballots/lines_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe Budgets::Ballot::LinesController do
+
+  describe "#load_budget" do
+
+    it "raises an error if budget slug is not found" do
+      controller.params[:budget_id] = "wrong_budget"
+
+      expect do
+        controller.send(:load_budget)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it "raises an error if budget id is not found" do
+      controller.params[:budget_id] = 0
+
+      expect do
+        controller.send(:load_budget)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
+end

--- a/spec/controllers/related_contents_controller_spec.rb
+++ b/spec/controllers/related_contents_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe RelatedContentsController do
+
+  describe '#score' do
+    it 'raises an error if related content does not exist' do
+      controller.params[:id] = 0
+
+      expect do
+        controller.send(:score, "action")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+end

--- a/spec/features/admin/budget_groups_spec.rb
+++ b/spec/features/admin/budget_groups_spec.rb
@@ -27,6 +27,43 @@ feature "Admin budget groups" do
 
   end
 
+  context "Load" do
+
+    let!(:budget) { create(:budget, slug: "budget_slug") }
+    let!(:group)  { create(:budget_group, slug: "group_slug", budget: budget) }
+
+    scenario "finds budget and group by slug" do
+      visit edit_admin_budget_group_path("budget_slug", "group_slug")
+      expect(page).to have_content(budget.name)
+      expect(page).to have_field "Group name", with: group.name
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit edit_admin_budget_group_path("wrong_budget", group)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit edit_admin_budget_group_path(0, group)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if group slug is not found" do
+      expect do
+        visit edit_admin_budget_group_path(budget, "wrong_group")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if group id is not found" do
+      expect do
+        visit edit_admin_budget_group_path(budget, 0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   context "Index" do
 
     scenario "Displaying no groups for budget" do

--- a/spec/features/admin/budget_headings_spec.rb
+++ b/spec/features/admin/budget_headings_spec.rb
@@ -28,6 +28,56 @@ feature "Admin budget headings" do
 
   end
 
+  context "Load" do
+
+    let!(:budget)  { create(:budget, slug: "budget_slug") }
+    let!(:group)   { create(:budget_group, slug: "group_slug", budget: budget) }
+    let!(:heading) { create(:budget_heading, slug: "heading_slug", group: group) }
+
+    scenario "finds budget, group and heading by slug" do
+      visit edit_admin_budget_group_heading_path("budget_slug", "group_slug", "heading_slug")
+      expect(page).to have_content(budget.name)
+      expect(page).to have_content(group.name)
+      expect(page).to have_field "Heading name", with: heading.name
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit edit_admin_budget_group_heading_path("wrong_budget", group, heading)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit edit_admin_budget_group_heading_path(0, group, heading)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if group slug is not found" do
+      expect do
+        visit edit_admin_budget_group_heading_path(budget, "wrong_group", heading)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if group id is not found" do
+      expect do
+        visit edit_admin_budget_group_heading_path(budget, 0, heading)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if heading slug is not found" do
+      expect do
+        visit edit_admin_budget_group_heading_path(budget, group, "wrong_heading")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if heading id is not found" do
+      expect do
+        visit edit_admin_budget_group_heading_path(budget, group, 0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
   context "Index" do
 
     scenario "Displaying no headings for group" do

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -32,6 +32,34 @@ feature 'Admin budget investments' do
 
   end
 
+  context "Load" do
+
+    let(:group)      { create(:budget_group, budget: budget) }
+    let(:heading)    { create(:budget_heading, group: group) }
+    let!(:investment) { create(:budget_investment, heading: heading) }
+
+    before { budget.update(slug: "budget_slug") }
+
+    scenario "finds investments using budget slug" do
+      visit admin_budget_budget_investments_path("budget_slug")
+
+      expect(page).to have_link investment.title
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit admin_budget_budget_investments_path("wrong_budget", investment)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit admin_budget_budget_investments_path(0, investment)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   context "Index" do
 
     scenario 'Displaying investments' do

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -23,6 +23,29 @@ feature 'Admin budgets' do
 
   end
 
+  context "Load" do
+
+    let!(:budget) { create(:budget, slug: "budget_slug") }
+
+    scenario "finds budget by slug" do
+      visit admin_budget_path("budget_slug")
+      expect(page).to have_content(budget.name)
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit admin_budget_path("wrong_budget")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit admin_budget_path(0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   context 'Index' do
 
     scenario 'Displaying no open budgets text' do

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -8,6 +8,55 @@ feature 'Ballots' do
   let!(:california) { create(:budget_heading, group: states, name: "California", price: 1000) }
   let!(:new_york)   { create(:budget_heading, group: states, name: "New York", price: 1000000) }
 
+  context "Load" do
+
+    let(:ballot) { create(:budget_ballot, user: user, budget: budget) }
+
+    before do
+      budget.update(slug: "budget_slug")
+      ballot.investments << create(:budget_investment, :selected, heading: california)
+      login_as(user)
+    end
+
+    scenario "finds ballot using budget slug" do
+      visit budget_ballot_path("budget_slug")
+
+      expect(page).to have_content("You have voted one investment")
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit budget_ballot_path("wrong_budget")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit budget_ballot_path(0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
+  context "Lines Load" do
+
+    let!(:investment) { create(:budget_investment, :selected, heading: california) }
+
+    before do
+      create(:budget_ballot, user: user, budget: budget)
+      budget.update(slug: "budget_slug")
+      login_as(user)
+    end
+
+    scenario "finds ballot lines using budget slug", :js do
+      visit budget_investments_path("budget_slug", states, california)
+      add_to_ballot(investment)
+
+      within("#sidebar") { expect(page).to have_content investment.title }
+    end
+
+  end
+
   context "Voting" do
 
     background do

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -6,6 +6,30 @@ feature 'Budgets' do
   let(:level_two_user)     { create(:user, :level_two) }
   let(:allowed_phase_list) { ['balloting', 'reviewing_ballots', 'finished'] }
 
+  context "Load" do
+
+    before { budget.update(slug: "budget_slug") }
+
+    scenario "finds budget by slug" do
+      visit budget_path("budget_slug")
+
+      expect(page).to have_content budget.name
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit budget_path("wrong_budget")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit budget_path(0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   context 'Index' do
     let(:budgets) { create_list(:budget, 3) }
     let(:last_budget) { budgets.last }

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -11,6 +11,22 @@ feature 'Executions' do
   let!(:investment4) { create(:budget_investment, :winner,       heading: heading) }
   let!(:investment3) { create(:budget_investment, :incompatible, heading: heading) }
 
+  scenario "finds budget by id or slug" do
+    budget.update(slug: "budget_slug")
+
+    visit custom_budget_executions_path("budget_slug")
+    within(".budgets-stats") { expect(page).to have_content budget.name }
+
+    visit custom_budget_executions_path(budget)
+    within(".budgets-stats") { expect(page).to have_content budget.name }
+
+    visit budget_executions_path("budget_slug")
+    within(".budgets-stats") { expect(page).to have_content budget.name }
+
+    visit budget_executions_path(budget)
+    within(".budgets-stats") { expect(page).to have_content budget.name }
+  end
+
   scenario 'only displays investments with milestones' do
     create(:milestone, milestoneable: investment1)
 

--- a/spec/features/budgets/groups_spec.rb
+++ b/spec/features/budgets/groups_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+feature "Budget Groups" do
+
+  let(:budget) { create(:budget, slug: "budget_slug") }
+  let!(:group)  { create(:budget_group, slug: "group_slug", budget: budget) }
+
+  context "Load" do
+
+    scenario "finds group using budget slug and group slug" do
+      visit budget_group_path("budget_slug", "group_slug")
+      expect(page).to have_content "Select an option"
+    end
+
+    scenario "finds group using budget id and group id" do
+      visit budget_group_path(budget, group)
+      expect(page).to have_content "Select an option"
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit budget_group_path("wrong_budget", group)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit budget_group_path(0, group)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if group slug is not found" do
+      expect do
+        visit budget_group_path(budget, "wrong_group")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if group id is not found" do
+      expect do
+        visit budget_group_path(budget, 0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
+end

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -25,6 +25,53 @@ feature 'Budget Investments' do
     it_behaves_like 'relationable', Budget::Investment
   end
 
+  context "Load" do
+
+    let(:investment) { create(:budget_investment, heading: heading) }
+
+    before do
+      budget.update(slug: "budget_slug")
+      heading.update(slug: "heading_slug")
+    end
+
+    scenario "finds investment using budget slug" do
+      visit budget_investment_path("budget_slug", investment)
+
+      expect(page).to have_content investment.title
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit budget_investment_path("wrong_budget", investment)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit budget_investment_path(0, investment)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "finds investment using heading slug" do
+      visit budget_investment_path(budget, investment, heading_id: "heading_slug")
+
+      expect(page).to have_content investment.title
+    end
+
+    scenario "raises an error if heading slug is not found" do
+      expect do
+        visit budget_investment_path(budget, investment, heading_id: "wrong_heading")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if heading id is not found" do
+      expect do
+        visit budget_investment_path(budget, investment, heading_id: 0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   scenario 'Index' do
     investments = [create(:budget_investment, heading: heading),
                    create(:budget_investment, heading: heading),
@@ -1682,7 +1729,7 @@ feature 'Budget Investments' do
     it 'Trying to visit an investment with a wrong budget slug' do
       wrong_url = budget_investment_path(budget_id: budget.slug, id: investment.id).gsub(budget.slug, 'wrong_budget_slug')
 
-      expect { visit wrong_url }.to raise_error(ActionController::RoutingError)
+      expect { visit wrong_url }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/features/budgets/recommendation_spec.rb
+++ b/spec/features/budgets/recommendation_spec.rb
@@ -2,6 +2,31 @@ require 'rails_helper'
 
 feature 'Recommendations' do
 
+  context "Load" do
+
+    let(:user)   { create(:user) }
+    let!(:budget) { create(:budget, slug: "budget_slug") }
+
+    scenario "finds budget by slug" do
+      visit budget_recommendations_path("budget_slug", user_id: user.id)
+
+      expect(page).to have_content budget.name
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit budget_recommendations_path("wrong_budget", user_id: user.id)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit budget_recommendations_path(0, user_id: user.id)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   scenario "Create by phase" do
     heading = create(:budget_heading)
     budget = heading.budget

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -52,6 +52,30 @@ feature 'Results' do
     end
   end
 
+  scenario "Does not raise error if budget (slug or id) is not found" do
+    visit custom_budget_results_path("wrong budget")
+
+    within(".budgets-stats") do
+      expect(page).to have_content "Results"
+    end
+
+    visit custom_budget_results_path(0)
+
+    within(".budgets-stats") do
+      expect(page).to have_content "Results"
+    end
+  end
+
+  scenario "Loads budget and heading by slug" do
+    visit custom_budget_results_path(budget.slug, heading.slug)
+
+    expect(page).to have_selector('a.is-active', text: heading.name)
+
+    within("#budget-investments-compatible") do
+      expect(page).to have_content investment1.title
+    end
+  end
+
   scenario "Load first budget heading if not specified" do
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -6,6 +6,30 @@ feature 'Stats' do
   let(:group)   { create(:budget_group, budget: budget) }
   let(:heading) { create(:budget_heading, group: group, price: 1000) }
 
+  context "Load" do
+
+    before { budget.update(slug: "budget_slug", phase: "finished") }
+
+    scenario "finds budget by slug" do
+      visit budget_stats_path("budget_slug")
+
+      expect(page).to have_content budget.name
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit budget_stats_path("wrong_budget")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit budget_stats_path(0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   describe "Show" do
 
     it "is not accessible to normal users if phase is not 'finished'" do

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -18,6 +18,34 @@ feature 'Budget Investments' do
                   { "budget_id": "budget_id" },
                   management = true
 
+  context "Load" do
+
+    let(:budget)     { create(:budget, slug: "budget_slug") }
+    let(:investment) { create(:budget_investment, budget: budget) }
+    let(:user)       { create(:user, :level_two) }
+
+    before { login_managed_user(user) }
+
+    scenario "finds investment using budget slug" do
+      visit management_budget_investment_path("budget_slug", investment)
+
+      expect(page).to have_content investment.title
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit management_budget_investment_path("wrong_budget", investment)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit management_budget_investment_path(0, investment)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   context "Create" do
     before { @budget.update(phase: 'accepting') }
 

--- a/spec/features/valuation/budget_investments_spec.rb
+++ b/spec/features/valuation/budget_investments_spec.rb
@@ -14,6 +14,30 @@ feature 'Valuation budget investments' do
     login_as(valuator.user)
   end
 
+  context "Load" do
+
+    before { budget.update(slug: "budget_slug") }
+
+    scenario "finds investment using budget slug" do
+      visit valuation_budget_budget_investments_path("budget_slug")
+
+      expect(page).to have_content budget.name
+    end
+
+    scenario "raises an error if budget slug is not found" do
+      expect do
+        visit valuation_budget_budget_investments_path("wrong_budget")
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "raises an error if budget id is not found" do
+      expect do
+        visit valuation_budget_budget_investments_path(0)
+      end.to raise_error ActiveRecord::RecordNotFound
+    end
+
+  end
+
   scenario 'Disabled with a feature flag' do
     Setting['feature.budgets'] = nil
     expect{

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -441,6 +441,30 @@ describe Budget::Investment do
     end
   end
 
+  describe "scoped_filter" do
+
+    let!(:budget)     { create(:budget, slug: "budget_slug") }
+    let!(:group)      { create(:budget_group, budget: budget) }
+    let!(:heading)    { create(:budget_heading, group: group) }
+    let!(:investment) { create(:budget_investment, :feasible, heading: heading) }
+
+    it "finds budget by id or slug" do
+      result = described_class.scoped_filter({budget_id: budget.id}, nil)
+      expect(result.count).to be 1
+      expect(result.first.id).to be investment.id
+
+      result = described_class.scoped_filter({budget_id: "budget_slug"}, nil)
+      expect(result.count).to be 1
+      expect(result.first.id).to be investment.id
+    end
+
+    it "does not raise error if budget is not found" do
+      result = described_class.scoped_filter({budget_id: "wrong_budget"}, nil)
+      expect(result).to be_empty
+    end
+
+  end
+
   describe "scopes" do
     describe "valuation_open" do
       it "returns all investments with false valuation_finished" do


### PR DESCRIPTION
## Objectives
- Use `find(id)` instead of `find_by(id: id)`. It's preferable to raise a 404 HTML error than any other unexpected/unknown Exception.

- Add the methods `find_by_slug_or_id` and `find_by_slug_or_id!` to the module `Sluggable` to make it easier to add these methods other models.

## Does this PR need a Backport to CONSUL?
The following commits can be backported now:
- Use correct param in controller https://github.com/AyuntamientoMadrid/consul/commit/43be16e34fe0773f2f3581686c92f4ead98f276c
- Remove unused before_action https://github.com/AyuntamientoMadrid/consul/commit/0108b257bec695d497c19327e9d63378fd61d05c
- Use find instead of find_by_id https://github.com/AyuntamientoMadrid/consul/commit/fdc298de79035fa6f3e51f15aba980ac1a303db2
- Add method find_by_slug_or_id to Sluggable module https://github.com/AyuntamientoMadrid/consul/commit/b54014b7a30a17247b37b55c9b9034b0dfbf8197
- Add method find_by_slug_or_id! to Sluggable module https://github.com/AyuntamientoMadrid/consul/commit/b2ba48980450f326131399d0bb5d7c3522b11163

The last commit https://github.com/AyuntamientoMadrid/consul/commit/1b6c1ee007207fb233741bb419fbcd8c1d2da67c, it would be nice to be able to `find_by_slug` also in CONSUL
But, we will probably do it in a future PR, we will have to include at least this other PR https://github.com/AyuntamientoMadrid/consul/pull/520