### PR TITLE
Allow admins delete poll answer documents

### DIFF
--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -100,6 +100,7 @@ module Abilities
       cannot :comment_as_moderator, [::Legislation::Question, Legislation::Annotation, ::Legislation::Proposal]
 
       can [:create], Document
+      can [:destroy], Document, documentable_type: "Poll::Question::Answer"
       can [:create, :destroy], DirectUpload
 
       can [:deliver], Newsletter, hidden_at: nil

--- a/app/views/admin/poll/questions/answers/documents.html.erb
+++ b/app/views/admin/poll/questions/answers/documents.html.erb
@@ -14,18 +14,12 @@
 
     <%= render 'shared/errors', resource: @answer %>
 
-    <div class="row">
-      <div class="small-12 column">
-        <div class="documents small-12">
-          <%= render 'documents/nested_documents', documentable: @answer, f: f %>
-        </div>
+    <div class="documents">
+      <%= render 'documents/nested_documents', documentable: @answer, f: f %>
+    </div>
 
-        <div class="row">
-          <div class="actions small-12 medium-4 margin-top">
-            <%= f.submit(class: "button expanded", value: t("shared.save")) %>
-          </div>
-        </div>
-      </div>
+    <div class="small-12 medium-6 large-2">
+      <%= f.submit(class: "button expanded", value: t("shared.save")) %>
     </div>
   <% end %>
 
@@ -42,11 +36,17 @@
             <%= link_to document.title, document.attachment.url %>
           </td>
           <td class="text-right">
-            <%= link_to t('documents.buttons.download_document'),
+            <%= link_to t("documents.buttons.download_document"),
                         document.attachment.url,
                         target: "_blank",
                         rel: "nofollow",
-                        class: 'button hollow' %>
+                        class: "button hollow" %>
+
+            <%= link_to t("admin.shared.delete"),
+                          document_path(document),
+                          method: :delete,
+                          class: "button hollow alert",
+                          data: { confirm: t("admin.actions.confirm") } %>
           </td>
         </tr>
       <% end %>

--- a/spec/features/admin/poll/questions/answers/documents/documents_spec.rb
+++ b/spec/features/admin/poll/questions/answers/documents/documents_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+feature "Documents" do
+
+  background do
+    admin = create(:administrator)
+    login_as(admin.user)
+  end
+
+  context "Index" do
+    scenario "Answer with no documents" do
+      answer = create(:poll_question_answer, question: create(:poll_question))
+      document = create(:document)
+
+      visit admin_answer_documents_path(answer)
+
+      expect(page).not_to have_content(document.title)
+    end
+
+    scenario "Answer with documents" do
+      answer = create(:poll_question_answer, question: create(:poll_question))
+      document = create(:document, documentable: answer)
+
+      visit admin_answer_documents_path(answer)
+
+      expect(page).to have_content(document.title)
+    end
+  end
+
+  scenario "Remove document from answer", :js do
+    answer = create(:poll_question_answer, question: create(:poll_question))
+    document = create(:document, documentable: answer)
+
+    visit admin_answer_documents_path(answer)
+    expect(page).to have_content(document.title)
+
+    accept_confirm "Are you sure?" do
+      click_link "Delete"
+    end
+
+    expect(page).not_to have_content(document.title)
+  end
+
+end


### PR DESCRIPTION
## Objectives

Allow admins delete poll answer documents, this PR:

- Remove documents from answers controller.
- Move admin poll questions answers documents view from `/questions/answers/documents.html.erb toi 'questions/answers/documents/index.html.erb`
- Fix admin poll question answers documents layout, _see attached images_.
- Create poll questions answers documents controller: this new controller allows include a delete button for poll questions answers documents on the view.

## Visual Changes

**BEFORE**
![before](https://user-images.githubusercontent.com/631897/51552884-e2663e80-1e71-11e9-8732-8f2ac4fa096c.png)

**AFTER**
![after](https://user-images.githubusercontent.com/631897/51552887-e4300200-1e71-11e9-85e4-9ba488391112.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.