### PR TITLE
Improve UI of budgets index page

### DIFF
--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -56,6 +56,10 @@ module BudgetsHelper
     Budget::Investment.by_budget(budget).tags_on(:valuation).order(:name).select(:name).distinct
   end
 
+  def unfeasible_or_unselected_filter
+    ["unselected", "unfeasible"].include?(@current_filter)
+  end
+
   def budget_published?(budget)
     !budget.drafting? || current_user&.administrator?
   end

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -72,8 +72,9 @@
             <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
               <% group.headings.order_by_group_name.each do |heading| %>
                 <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
-                  <% unless current_budget.informing? %>
-                    <%= link_to budget_investments_path(current_budget.id, heading_id: heading.id) do %>
+                  <% unless current_budget.informing? || current_budget.finished? %>
+                    <%= link_to budget_investments_path(current_budget.id,
+                                                        heading_id: heading.id) do %>
                       <%= heading_name_and_price_html(heading, current_budget) %>
                     <% end %>
                   <% else %>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -89,7 +89,7 @@
         </div>
 
         <% unless current_budget.informing? %>
-          <div class="map">
+          <div class="map inline">
             <h3><%= t("budgets.index.map") %></h3>
             <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
           </div>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -96,15 +96,15 @@
           <p>
             <% show_links = show_links_to_budget_investments(current_budget) %>
             <% if show_links %>
-              <%= link_to budget_investments_path(current_budget.id) do %>
+              <%= link_to budget_url(current_budget) do %>
                 <small><%= t("budgets.index.investment_proyects") %></small>
               <% end %><br>
             <% end %>
-            <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unfeasible') do %>
+            <%= link_to budget_url(current_budget, filter: 'unfeasible') do %>
               <small><%= t("budgets.index.unfeasible_investment_proyects") %></small>
             <% end %><br>
             <% if show_links %>
-              <%= link_to budget_investments_path(budget_id: current_budget.id, filter: 'unselected') do %>
+              <%= link_to budget_url(current_budget, filter: 'unselected') do %>
                 <small><%= t("budgets.index.not_selected_investment_proyects") %></small>
               <% end %>
             <% end %>

--- a/app/views/budgets/investments/index.html.erb
+++ b/app/views/budgets/investments/index.html.erb
@@ -57,7 +57,18 @@
 
       <%= render("shared/advanced_search", search_path: budget_investments_url(@budget)) %>
 
-      <%= render('shared/order_links', i18n_namespace: "budgets.investments.index") unless @current_filter == "unfeasible" %>
+      <% if unfeasible_or_unselected_filter %>
+        <ul class="no-bullet submenu">
+          <li class="inline-block">
+            <%= link_to current_path_with_query_params(order: "random", page: 1),
+                        class: "is-active" do %>
+              <h2><%= t("budgets.investments.index.orders.random") %></h2>
+            <% end %>
+          </li>
+        </ul>
+      <% else %>
+        <%= render("shared/order_links", i18n_namespace: "budgets.investments.index") %>
+      <% end %>
 
       <% if investments_default_view? %>
 

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -100,7 +100,7 @@
 
         <% unless current_budget.informing? %>
           <% cache [@budgets_coordinates] do %>
-            <div class="map">
+            <div class="map inline">
               <h3><%= t("budgets.index.map") %></h3>
               <%= render_map(nil, "budgets", false, nil, @budgets_coordinates) %>
             </div>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -81,7 +81,7 @@
             <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
               <% group.headings.order_by_group_name.each do |heading| %>
                 <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
-                  <% unless current_budget.informing? %>
+                  <% unless current_budget.informing? || current_budget.finished? %>
                     <%= link_to custom_budget_investments_path(group,
                                                                budget_id: current_budget,
                                                                heading_id: heading) do %>

--- a/app/views/custom/budgets/investments/index.html.erb
+++ b/app/views/custom/budgets/investments/index.html.erb
@@ -62,7 +62,18 @@
 
       <%= render("shared/advanced_search", search_path: budget_investments_url(@budget)) %>
 
-      <%= render('shared/order_links', i18n_namespace: "budgets.investments.index") unless @current_filter == "unfeasible" %>
+      <% if unfeasible_or_unselected_filter %>
+        <ul class="no-bullet submenu">
+          <li class="inline-block">
+            <%= link_to current_path_with_query_params(order: "random", page: 1),
+                        class: "is-active" do %>
+              <h2><%= t("budgets.investments.index.orders.random") %></h2>
+            <% end %>
+          </li>
+        </ul>
+      <% else %>
+        <%= render("shared/order_links", i18n_namespace: "budgets.investments.index") %>
+      <% end %>
 
       <% if investments_default_view? %>
         <% @investments.each do |investment| %>

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -73,14 +73,14 @@ feature 'Budgets' do
       end
     end
 
-    scenario 'Show informing index without links' do
-      last_budget.update_attributes(phase: 'informing')
+    scenario "Show informing index without links" do
+      last_budget.update_attributes(phase: "informing")
       group = create(:budget_group, budget: last_budget)
       heading = create(:budget_heading, group: group)
 
       visit budgets_path
 
-      within('#budget_info') do
+      within("#budget_info") do
         expect(page).not_to have_link "#{heading.name} €1,000,000"
         expect(page).to have_content "#{heading.name} €1,000,000"
 
@@ -88,7 +88,31 @@ feature 'Budgets' do
         expect(page).not_to have_link "List of all unfeasible investment projects"
         expect(page).not_to have_link "List of all investment projects not selected for balloting"
 
-        expect(page).not_to have_css('div#map')
+        expect(page).not_to have_css("div.map")
+      end
+    end
+
+    scenario "Show finished index without heading links" do
+      last_budget.update_attributes(phase: "finished")
+      group = create(:budget_group, budget: last_budget)
+      heading = create(:budget_heading, group: group)
+
+      visit budgets_path
+
+      within("#budget_info") do
+        expect(page).not_to have_link "#{heading.name} €1,000,000"
+        expect(page).to have_content "#{heading.name} €1,000,000"
+
+        expect(page).to have_link "List of all investment projects",
+                                   href: budget_url(last_budget)
+
+        expect(page).to have_link "List of all unfeasible investment projects",
+                                   href: budget_url(last_budget, filter: "unfeasible")
+
+        expect(page).to have_link "List of all investment projects not selected for balloting",
+                                   href: budget_url(last_budget, filter: "unselected")
+
+        expect(page).to have_css("div.map")
       end
     end
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -761,6 +761,28 @@ feature 'Budget Investments' do
       expect(order).not_to eq(new_order)
     end
 
+    scenario "Order always is random for unfeasible and unselected investments" do
+      Budget::Phase::PHASE_KINDS.each do |phase|
+        budget.update(phase: phase)
+
+        visit budget_investments_path(budget, heading_id: heading.id, filter: "unfeasible")
+
+        within(".submenu") do
+          expect(page).to have_content "random"
+          expect(page).not_to have_content "by price"
+          expect(page).not_to have_content "highest rated"
+        end
+
+        visit budget_investments_path(budget, heading_id: heading.id, filter: "unselected")
+
+        within(".submenu") do
+          expect(page).to have_content "random"
+          expect(page).not_to have_content "price"
+          expect(page).not_to have_content "highest rated"
+        end
+      end
+    end
+
     def investments_order
       all(".budget-investment h3").collect {|i| i.text }
     end


### PR DESCRIPTION
## Objectives

- Fix links on budgets index page: these links were linking to `/budgets/N/investments?filter=unfeasible` instead of `/budgets/N?filter=unfeasible`

- Hide heading links if budget is finished: now when the budget is finished the headings are no links. The users still can view the results with the "See results" button on header sidebar. _[Image 1]_

- Fix map overlapping links. _[Image 2]_
## Visual Changes

**[Image 1]**
![screenshot 2019-01-29 at 13 51 59](https://user-images.githubusercontent.com/631897/51909498-163ee800-23cd-11e9-975a-32920d4ad668.png)

**[Image 2]**
![screenshot 2019-01-29 at 13 49 44](https://user-images.githubusercontent.com/631897/51909499-17701500-23cd-11e9-90a4-7a71a8dfca30.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.