### PR TITLE
Migrate unfeasibility explanation

### DIFF
--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -1,0 +1,31 @@
+class Migrations::SpendingProposal::BudgetInvestment
+  attr_accessor :spending_proposal, :budget_investment
+
+  def initialize(spending_proposal)
+    @spending_proposal = spending_proposal
+    @budget_investment = find_or_initialize_budget_investment
+  end
+
+  def update
+    if budget_investment.update(budget_investment_attributes)
+      print "."
+    else
+      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}"
+    end
+  end
+
+  private
+
+    def budget
+      Budget.where(slug: "2016").first
+    end
+
+    def find_or_initialize_budget_investment
+      budget.investments.where(original_spending_proposal_id: spending_proposal.id).first
+    end
+
+    def budget_investment_attributes
+      { unfeasibility_explanation: spending_proposal.feasible_explanation }
+    end
+
+end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -7,7 +7,7 @@ class Migrations::SpendingProposal::BudgetInvestment
   end
 
   def update
-    if budget_investment.update(budget_investment_attributes)
+    if budget_investment && budget_investment.update(budget_investment_attributes)
       print "."
     else
       puts "Error updating budget investment from spending proposal: #{spending_proposal.id}"

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -3,7 +3,7 @@ class Migrations::SpendingProposal::BudgetInvestment
 
   def initialize(spending_proposal)
     @spending_proposal = spending_proposal
-    @budget_investment = find_or_initialize_budget_investment
+    @budget_investment = find_budget_investment
   end
 
   def update
@@ -20,7 +20,7 @@ class Migrations::SpendingProposal::BudgetInvestment
       Budget.where(slug: "2016").first
     end
 
-    def find_or_initialize_budget_investment
+    def find_budget_investment
       budget.investments.where(original_spending_proposal_id: spending_proposal.id).first
     end
 

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -10,7 +10,7 @@ class Migrations::SpendingProposal::BudgetInvestment
     if budget_investment && budget_investment.update(budget_investment_attributes)
       print "."
     else
-      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}"
+      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}\n"
     end
   end
 
@@ -25,7 +25,17 @@ class Migrations::SpendingProposal::BudgetInvestment
     end
 
     def budget_investment_attributes
-      { unfeasibility_explanation: spending_proposal.feasible_explanation }
+      { unfeasibility_explanation: field_with_unfeasibility_explanation }
+    end
+
+    def field_with_unfeasibility_explanation
+      if spending_proposal.unfeasible?
+        spending_proposal.feasible_explanation.presence ||
+        spending_proposal.price_explanation.presence ||
+        spending_proposal.internal_comments
+      else
+        spending_proposal.feasible_explanation
+      end
     end
 
 end

--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -15,7 +15,7 @@ class Migrations::SpendingProposal::BudgetInvestments
   private
 
     def load_spending_proposals
-      SpendingProposal.all
+      ::SpendingProposal.all
     end
 
 end

--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -1,0 +1,21 @@
+class Migrations::SpendingProposal::BudgetInvestments
+  attr_accessor :spending_proposals
+
+  def initialize
+    @spending_proposals = load_spending_proposals
+  end
+
+  def update_all
+    spending_proposals.each do |spending_proposal|
+      budget_investment = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      budget_investment.update
+    end
+  end
+
+  private
+
+    def load_spending_proposals
+      SpendingProposal.all
+    end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -39,4 +39,13 @@ namespace :spending_proposals do
     require "migrations/spending_proposal/vote"
     Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
   end
+
+  desc "Migrates spending proposals attributes to corresponding budget investments attributes"
+  task migrate_attributes_to_budget_investments: :environment do
+    require "migrations/spending_proposal/budget_investments"
+
+    puts "Starting to migration attributes from spending proposals to budget investments"
+    Migrations::SpendingProposal::BudgetInvestments.new.update_all
+    puts "Finished"
+  end
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -82,6 +82,14 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(budget_investment.unfeasibility_explanation).to eq("")
     end
 
+    it "gracefully handles missing corresponding budget investment" do
+      budget_investment.destroy
+
+      expect{ migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal);
+              migration.update }
+      .not_to raise_error
+    end
+
   end
 
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget_investment"
+
+describe Migrations::SpendingProposal::BudgetInvestment do
+
+  let!(:budget)            { create(:budget, slug: "2016") }
+
+  let!(:spending_proposal) { create(:spending_proposal) }
+
+  let!(:budget_investment) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal.id) }
+
+  describe "#initialize" do
+
+    it "initializes the spending proposal and corresponding budget investment" do
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+
+      expect(migration.spending_proposal).to eq(spending_proposal)
+      expect(migration.budget_investment).to eq(budget_investment)
+    end
+
+  end
+
+  describe "#update" do
+
+    it "updates the attribute unfeasibility_explanation" do
+      explanation = "This project is not feasible because it is too expensive"
+      spending_proposal.update(feasible_explanation: explanation)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+
+      expect(budget_investment.unfeasibility_explanation).to eq(explanation)
+    end
+
+  end
+
+end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -36,6 +36,52 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(budget_investment.unfeasibility_explanation).to eq(explanation)
     end
 
+    it "uses the price explanation attribute if unfeasibility explanation is not present" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.price_explanation = "price explanation saying it is too expensive"
+
+      spending_proposal.feasible = false
+      spending_proposal.valuation_finished = true
+
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("price explanation saying it is too expensive")
+    end
+
+    it "uses the internal comments if unfeasibility explanation is not present" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.internal_comments = "Internal comment with explanation"
+
+      spending_proposal.feasible = false
+      spending_proposal.valuation_finished = true
+
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("Internal comment with explanation")
+    end
+
+    it "does not use other attributes if investment is feasible" do
+      spending_proposal.feasible_explanation = ""
+      spending_proposal.price_explanation = "price explanation saying it is too expensive"
+
+      spending_proposal.feasible = true
+      spending_proposal.save(validate: false)
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      budget_investment.reload
+      expect(budget_investment.unfeasibility_explanation).to eq("")
+    end
+
   end
 
 end

--- a/spec/lib/migrations/spending_proposals/budget_investments_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investments_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget_investments"
+
+describe Migrations::SpendingProposal::BudgetInvestments do
+
+  let!(:budget)            { create(:budget, slug: "2016") }
+
+  let!(:spending_proposal1) { create(:spending_proposal) }
+  let!(:spending_proposal2) { create(:spending_proposal) }
+
+  let!(:budget_investment1) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal1.id) }
+
+  let!(:budget_investment2) { create(:budget_investment,
+                                     budget: budget,
+                                     original_spending_proposal_id: spending_proposal2.id) }
+
+  describe "#initialize" do
+
+    it "initializes all spending proposals" do
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+
+      expect(migration.spending_proposals.count).to eq(2)
+      expect(migration.spending_proposals).to include(spending_proposal1)
+      expect(migration.spending_proposals).to include(spending_proposal2)
+    end
+
+  end
+
+  describe "#update_all" do
+
+    it "updates all budget investments with their corresponding spending proposal attributes" do
+      explanation1 = "This project is not feasible because it is too expensive"
+      explanation2 = "This project is not feasible because it out of the governments jurisdiction"
+
+      spending_proposal1.update(feasible_explanation: explanation1)
+      spending_proposal2.update(feasible_explanation: explanation2)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.update_all
+
+      budget_investment1.reload
+      budget_investment2.reload
+
+      expect(budget_investment1.unfeasibility_explanation).to eq(explanation1)
+      expect(budget_investment2.unfeasibility_explanation).to eq(explanation2)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Context
=== 
We already have budget investment for every corresponding spending proposal. 

However the `unfeasibility_explanation` attribute was [not migrated correctly](https://github.com/AyuntamientoMadrid/consul/pull/1059/files#diff-06e514cba40826339cac0ad0b9fba6ffR36). This raises a validation error when trying to update any other attribute in these budget investments.

Objectives
===
Migrate this attribute for all relevant budget investments to make them valid so that we can continue working on migrating supports and ballots.

## Does this PR need a Backport to CONSUL?

Yes, this will be important for the final migration

## Notes
Adding some [debug information](https://github.com/AyuntamientoMadrid/consul/compare/spending_proposals...AyuntamientoMadrid:spending_proposals_to_budget_investments?expand=1#diff-14fcc12aeb8116f3dbb72e855b0db07bR10) in a method, to prevent the rake task from stopping early. If something is printed the ssh connection stays open.