### PR TITLE
Remove incoming polls filter

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -56,7 +56,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def booth_assignments
-    @polls = Poll.current_or_incoming
+    @polls = Poll.current
   end
 
   private

--- a/app/controllers/admin/poll/shifts_controller.rb
+++ b/app/controllers/admin/poll/shifts_controller.rb
@@ -6,8 +6,8 @@ class Admin::Poll::ShiftsController < Admin::Poll::BaseController
   def new
     load_shifts
     @shift = ::Poll::Shift.new
-    @voting_polls = @booth.polls.current_or_incoming
-    @recount_polls = @booth.polls.current_or_recounting_or_incoming
+    @voting_polls = @booth.polls.current
+    @recount_polls = @booth.polls.current_or_recounting
   end
 
   def create

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -5,7 +5,7 @@ class PollsController < ApplicationController
 
   load_and_authorize_resource
 
-  has_filters %w{current expired incoming}
+  has_filters %w[current expired]
   has_orders %w{most_voted newest oldest}, only: :show
 
   ::Poll::Answer # trigger autoload

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -36,7 +36,6 @@ class Poll < ActiveRecord::Base
   validate :date_range
 
   scope :current,  -> { where('starts_at <= ? and ? <= ends_at', Date.current.beginning_of_day, Date.current.beginning_of_day) }
-  scope :incoming, -> { where('? < starts_at', Date.current.beginning_of_day) }
   scope :expired,  -> { where('ends_at < ?', Date.current.beginning_of_day) }
   scope :recounting, -> { Poll.where(ends_at: (Date.current.beginning_of_day - RECOUNT_DURATION)..Date.current.beginning_of_day) }
   scope :published, -> { where('published = ?', true) }
@@ -55,20 +54,12 @@ class Poll < ActiveRecord::Base
     starts_at <= timestamp && timestamp <= ends_at
   end
 
-  def incoming?(timestamp = Date.current.beginning_of_day)
-    timestamp < starts_at
-  end
-
   def expired?(timestamp = Date.current.beginning_of_day)
     ends_at < timestamp
   end
 
-  def self.current_or_incoming
-    current + incoming
-  end
-
-  def self.current_or_recounting_or_incoming
-    current + recounting + incoming
+  def self.current_or_recounting
+    current + recounting
   end
 
   def answerable_by?(user)

--- a/app/models/poll/booth.rb
+++ b/app/models/poll/booth.rb
@@ -12,7 +12,7 @@ class Poll
     end
 
     def self.available
-      where(polls: { id: Poll.current_or_recounting_or_incoming }).includes(:polls)
+      where(polls: { id: Poll.current_or_recounting }).includes(:polls)
     end
 
     def assignment_on_poll(poll)

--- a/app/views/custom/polls/_poll_group.html.erb
+++ b/app/views/custom/polls/_poll_group.html.erb
@@ -83,8 +83,6 @@
           <%= link_to poll_path(id: poll.slug || poll.id), class: "button hollow expanded", data: { no_turbolink: true } do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
-            <% elsif poll.incoming? %>
-              <%= t("polls.index.participate_button_incoming") %>
             <% else %>
               <%= t("polls.index.participate_button") %>
             <% end %>

--- a/app/views/polls/_callout.html.erb
+++ b/app/views/polls/_callout.html.erb
@@ -10,10 +10,6 @@
       <%= t('polls.show.cant_answer_verify_html',
             verify_link: link_to(t('polls.show.verify_link'), verification_path)) %>
     </div>
-  <% elsif @poll.incoming? %>
-    <div class="callout primary">
-      <%= t('polls.show.cant_answer_incoming') %>
-    </div>
   <% elsif @poll.expired? %>
     <div class="callout alert">
       <%= t('polls.show.cant_answer_expired') %>

--- a/app/views/polls/_poll_group.html.erb
+++ b/app/views/polls/_poll_group.html.erb
@@ -75,8 +75,6 @@
           <%= link_to poll_path(id: poll.slug || poll.id), class: "button hollow expanded", data: { no_turbolink: true } do %>
             <% if poll.expired? %>
               <%= t("polls.index.participate_button_expired") %>
-            <% elsif poll.incoming? %>
-              <%= t("polls.index.participate_button_incoming") %>
             <% else %>
               <%= t("polls.index.participate_button") %>
             <% end %>

--- a/config/locales/ar/seeds.yml
+++ b/config/locales/ar/seeds.yml
@@ -49,7 +49,6 @@ ar:
     polls:
       current_poll: "الاستطلاع الحالي"
       current_poll_geozone_restricted: "الاستطلاع الجغرافي الاحالي مقيد"
-      incoming_poll: "الاقتراع الوارد"
       recounting_poll: "اعادة حساب الاستطلاع"
       expired_poll_without_stats: "انتهاء مدة صلاحية الاستطلاع دون احصائيات و النتائج"
       expired_poll_with_stats: "انتهاء مدة صلاحية الاستطلاع مع الاحصائيات و النتائج"

--- a/config/locales/de-DE/general.yml
+++ b/config/locales/de-DE/general.yml
@@ -456,11 +456,9 @@ de:
     index:
       filters:
         current: "Offen"
-        incoming: "Demnächst"
         expired: "Abgelaufen"
       title: "Umfragen"
       participate_button: "An dieser Umfrage teilnehmen"
-      participate_button_incoming: "Weitere Informationen"
       participate_button_expired: "Umfrage beendet"
       no_geozone_restricted: "Ganze Stadt"
       geozone_restricted: "Bezirke"
@@ -484,7 +482,6 @@ de:
       signup: Registrierung
       cant_answer_verify_html: "Sie müssen %{verify_link}, um zu antworten."
       verify_link: "verifizieren Sie Ihr Konto"
-      cant_answer_incoming: "Diese Umfrage hat noch nicht begonnen."
       cant_answer_expired: "Diese Umfrage wurde beendet."
       cant_answer_wrong_geozone: "Diese Frage ist nicht in ihrem Gebiet verfügbar."
       more_info_title: "Weitere Informationen"

--- a/config/locales/de-DE/seeds.yml
+++ b/config/locales/de-DE/seeds.yml
@@ -49,7 +49,6 @@ de:
     polls:
       current_poll: "Aktuelle Umfrage"
       current_poll_geozone_restricted: "Aktuelle Umfrage eingeschränkt auf Geo-Zone"
-      incoming_poll: "Eingehende Umfrage"
       recounting_poll: "Umfrage wiederholen"
       expired_poll_without_stats: "Abgelaufene Umfrage ohne Statistiken und Ergebnisse"
       expired_poll_with_stats: "Abgelaufene Umfrage mit Statistiken und Ergebnisse"

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -451,11 +451,9 @@ en:
     index:
       filters:
         current: "Open"
-        incoming: "Incoming"
         expired: "Expired"
       title: "Polls"
       participate_button: "Participate in this poll"
-      participate_button_incoming: "More information"
       participate_button_expired: "Poll ended"
       no_geozone_restricted: "All city"
       geozone_restricted: "Districts"
@@ -483,7 +481,6 @@ en:
       signup: Sign up
       cant_answer_verify_html: "You must %{verify_link} in order to answer."
       verify_link: "verify your account"
-      cant_answer_incoming: "This poll has not yet started."
       cant_answer_expired: "This poll has finished."
       cant_answer_wrong_geozone: "This question is not available on your geozone."
       more_info_title: "More information"

--- a/config/locales/en/seeds.yml
+++ b/config/locales/en/seeds.yml
@@ -49,7 +49,6 @@ en:
     polls:
       current_poll: "Current Poll"
       current_poll_geozone_restricted: "Current Poll Geozone Restricted"
-      incoming_poll: "Incoming Poll"
       recounting_poll: "Recounting Poll"
       expired_poll_without_stats: "Expired Poll without Stats & Results"
       expired_poll_with_stats: "Expired Poll with Stats & Results"

--- a/config/locales/es-AR/general.yml
+++ b/config/locales/es-AR/general.yml
@@ -431,11 +431,9 @@ es-AR:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -459,7 +457,6 @@ es-AR:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-BO/general.yml
+++ b/config/locales/es-BO/general.yml
@@ -406,11 +406,9 @@ es-BO:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-BO:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-CL/general.yml
+++ b/config/locales/es-CL/general.yml
@@ -406,11 +406,9 @@ es-CL:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-CL:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-CO/general.yml
+++ b/config/locales/es-CO/general.yml
@@ -406,11 +406,9 @@ es-CO:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-CO:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-CR/general.yml
+++ b/config/locales/es-CR/general.yml
@@ -406,11 +406,9 @@ es-CR:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-CR:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-DO/general.yml
+++ b/config/locales/es-DO/general.yml
@@ -406,11 +406,9 @@ es-DO:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-DO:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-EC/general.yml
+++ b/config/locales/es-EC/general.yml
@@ -406,11 +406,9 @@ es-EC:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-EC:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-GT/general.yml
+++ b/config/locales/es-GT/general.yml
@@ -406,11 +406,9 @@ es-GT:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-GT:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-HN/general.yml
+++ b/config/locales/es-HN/general.yml
@@ -406,11 +406,9 @@ es-HN:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-HN:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-MX/general.yml
+++ b/config/locales/es-MX/general.yml
@@ -406,11 +406,9 @@ es-MX:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-MX:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-NI/general.yml
+++ b/config/locales/es-NI/general.yml
@@ -406,11 +406,9 @@ es-NI:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-NI:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PA/general.yml
+++ b/config/locales/es-PA/general.yml
@@ -406,11 +406,9 @@ es-PA:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PA:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PE/general.yml
+++ b/config/locales/es-PE/general.yml
@@ -406,11 +406,9 @@ es-PE:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PE:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PR/general.yml
+++ b/config/locales/es-PR/general.yml
@@ -406,11 +406,9 @@ es-PR:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PR:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-PY/general.yml
+++ b/config/locales/es-PY/general.yml
@@ -406,11 +406,9 @@ es-PY:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-PY:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-SV/general.yml
+++ b/config/locales/es-SV/general.yml
@@ -415,11 +415,9 @@ es-SV:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -446,7 +444,6 @@ es-SV:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-UY/general.yml
+++ b/config/locales/es-UY/general.yml
@@ -406,11 +406,9 @@ es-UY:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -433,7 +431,6 @@ es-UY:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es-VE/general.yml
+++ b/config/locales/es-VE/general.yml
@@ -422,11 +422,9 @@ es-VE:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -449,7 +447,6 @@ es-VE:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -448,11 +448,9 @@ es:
     index:
       filters:
         current: "Abiertas"
-        incoming: "Próximamente"
         expired: "Terminadas"
       title: "Votaciones"
       participate_button: "Participar en esta votación"
-      participate_button_incoming: "Más información"
       participate_button_expired: "Votación terminada"
       no_geozone_restricted: "Toda la ciudad"
       geozone_restricted: "Distritos"
@@ -480,7 +478,6 @@ es:
       signup: registrarte
       cant_answer_verify_html: "Por favor %{verify_link} para poder responder."
       verify_link: "verifica tu cuenta"
-      cant_answer_incoming: "Esta votación todavía no ha comenzado."
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"

--- a/config/locales/es/seeds.yml
+++ b/config/locales/es/seeds.yml
@@ -49,7 +49,6 @@ es:
     polls:
       current_poll: "Votación Abierta"
       current_poll_geozone_restricted: "Votación Abierta restringida por geozona"
-      incoming_poll: "Siguiente Votación"
       recounting_poll: "Votación en Recuento"
       expired_poll_without_stats: "Votación Finalizada (sin Estadísticas o Resultados)"
       expired_poll_with_stats: "Votación Finalizada (con Estadísticas y Resultado)"

--- a/config/locales/fa-IR/seeds.yml
+++ b/config/locales/fa-IR/seeds.yml
@@ -33,7 +33,6 @@ fa:
     polls:
       current_poll: "نظرسنجی کنونی"
       current_poll_geozone_restricted: "نظرسنجی کنونی Geozone محصور"
-      incoming_poll: "نظرسنجی ورودی"
       recounting_poll: "بازپرداخت نظرسنجی"
       expired_poll_without_stats: "نظرسنجی منقضی شده بدون آمار & نتیجه "
       expired_poll_with_stats: "نظرسنجی منقضی شده با آمار & نتیجه "

--- a/config/locales/fr/general.yml
+++ b/config/locales/fr/general.yml
@@ -458,11 +458,9 @@ fr:
     index:
       filters:
         current: "Ouvert"
-        incoming: "Entrants"
         expired: "Expirés"
       title: "Votes"
       participate_button: "Participer à ce vote"
-      participate_button_incoming: "Plus d'informations"
       participate_button_expired: "Vote terminé"
       no_geozone_restricted: "Toute la ville"
       geozone_restricted: "Quartiers"
@@ -487,7 +485,6 @@ fr:
       signup: S'inscrire
       cant_answer_verify_html: "Vous devez %{verify_link} pour répondre."
       verify_link: "vérifier votre compte"
-      cant_answer_incoming: "Ce vote n'a pas encore commencé."
       cant_answer_expired: "Ce vote est terminé."
       cant_answer_wrong_geozone: "Cette question n'est pas disponible pour votre zone géographique."
       more_info_title: "Plus d'informations"

--- a/config/locales/fr/seeds.yml
+++ b/config/locales/fr/seeds.yml
@@ -49,7 +49,6 @@ fr:
     polls:
       current_poll: "Vote en cours"
       current_poll_geozone_restricted: "Géozone du vote en cours restreinte"
-      incoming_poll: "Vote entrant"
       recounting_poll: "Re-dépouillement du vote"
       expired_poll_without_stats: "Vote terminé sans statistiques ni résultats"
       expired_poll_with_stats: "Vote terminé avec statistiques et résultats"

--- a/config/locales/gl/general.yml
+++ b/config/locales/gl/general.yml
@@ -461,11 +461,9 @@ gl:
     index:
       filters:
         current: "Abertas"
-        incoming: "Proximamente"
         expired: "Rematadas"
       title: "Votacións"
       participate_button: "Participar nesta votación"
-      participate_button_incoming: "Máis información"
       participate_button_expired: "Votación rematada"
       no_geozone_restricted: "Toda a cidade"
       geozone_restricted: "Zonas"
@@ -493,7 +491,6 @@ gl:
       signup: rexistrarte
       cant_answer_verify_html: "Debes %{verify_link} para poder responder."
       verify_link: "verificar a túa conta"
-      cant_answer_incoming: "Esta votación aínda non comezou."
       cant_answer_expired: "A votación rematou."
       cant_answer_wrong_geozone: "Esta pregunta non está dispoñible na túa zona."
       more_info_title: "Máis información"

--- a/config/locales/gl/seeds.yml
+++ b/config/locales/gl/seeds.yml
@@ -49,7 +49,6 @@ gl:
     polls:
       current_poll: "Votación aberta"
       current_poll_geozone_restricted: "Votación aberta restrinxida por zona xeográfica"
-      incoming_poll: "Seguinte votación"
       recounting_poll: "Votación en escrutinio"
       expired_poll_without_stats: "Votación pechada sen Estatísticas e Resultados"
       expired_poll_with_stats: "Votación pechada con Estatísticas e Resultados"

--- a/config/locales/he/general.yml
+++ b/config/locales/he/general.yml
@@ -321,11 +321,9 @@ he:
     index:
       filters:
         current: "פתיחה"
-        incoming: "מתקרב"
         expired: "לא בתוקף"
       title: "הצבעות"
       participate_button: "השתתפות בהצבעה זו"
-      participate_button_incoming: "מידע נוסף"
       participate_button_expired: "ההצבעה הסתיימה"
       no_geozone_restricted: "בכל הערים/הרשויות"
       geozone_restricted: "מחוזות"
@@ -337,7 +335,6 @@ he:
       signup: הרשמה
       cant_answer_verify_html: "נדרש %{verify_link}על מנת להצביע."
       verify_link: "לאמת את חשבונך"
-      cant_answer_incoming: "הצבעה זו טרם התחילה"
       cant_answer_expired: "הצבעה זו הסתיימה"
   poll_questions:
     create_question: "יצירת שאלה חדשה"

--- a/config/locales/id-ID/general.yml
+++ b/config/locales/id-ID/general.yml
@@ -409,11 +409,9 @@ id:
     index:
       filters:
         current: "Buka"
-        incoming: "Masuk"
         expired: "Kadaluarsa"
       title: "Jajak pendapat"
       participate_button: "Berpartisipasi dalam jajak pendapat ini"
-      participate_button_incoming: "Informasi lebih lanjut"
       participate_button_expired: "Jajak pendapat terakhir"
       no_geozone_restricted: "Semua kota"
       geozone_restricted: "Kabupaten"
@@ -436,7 +434,6 @@ id:
       signup: Daftar
       cant_answer_verify_html: "Anda harus %{verify_link} dalam rangka untuk menjawab."
       verify_link: "verivikasi akun anda"
-      cant_answer_incoming: "Jajak pendapat ini belum dimulai."
       cant_answer_expired: "Jajak pendapat ini telah selesai."
       cant_answer_wrong_geozone: "Pertanyaan ini tidak tersedia pada geozone."
       more_info_title: "Informasi lebih lanjut"

--- a/config/locales/it/general.yml
+++ b/config/locales/it/general.yml
@@ -458,11 +458,9 @@ it:
     index:
       filters:
         current: "Aperte"
-        incoming: "In arrivo"
         expired: "Scadute"
       title: "Votazioni"
       participate_button: "Partecipa a questa votazione"
-      participate_button_incoming: "Più informazioni"
       participate_button_expired: "Votazione conclusa"
       no_geozone_restricted: "Tutta la città"
       geozone_restricted: "Distretti"
@@ -490,7 +488,6 @@ it:
       signup: Registrati
       cant_answer_verify_html: "È necessario %{verify_link} per rispondere."
       verify_link: "verifica il tuo account"
-      cant_answer_incoming: "Questa votazione non è ancora iniziata."
       cant_answer_expired: "Questa votazione è conclusa."
       cant_answer_wrong_geozone: "Questo quesito non è disponibile nella tua zona."
       more_info_title: "Più informazioni"

--- a/config/locales/it/seeds.yml
+++ b/config/locales/it/seeds.yml
@@ -49,7 +49,6 @@ it:
     polls:
       current_poll: "Votazione Corrente"
       current_poll_geozone_restricted: "Votazione Corrente Geograficamente Ristretta"
-      incoming_poll: "Votazione Imminente"
       recounting_poll: "Votazione a Scrutinio"
       expired_poll_without_stats: "Votazione Scaduta senza Statistiche & Risultati"
       expired_poll_with_stats: "Votazione Scaduta con Statistiche & Risultati"

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -458,11 +458,9 @@ nl:
     index:
       filters:
         current: "Open"
-        incoming: "Binnenkort"
         expired: "Verlopen"
       title: "Stemmen"
       participate_button: "Neem deel aan deze stemronde"
-      participate_button_incoming: "Meer informatie"
       participate_button_expired: "Stemronde is voorbij"
       no_geozone_restricted: "Gehele gemeente"
       geozone_restricted: "Regio's"
@@ -487,7 +485,6 @@ nl:
       signup: Registreren
       cant_answer_verify_html: "Je moet %{verify_link} om te kunnen antwoorden."
       verify_link: "je account verifieren"
-      cant_answer_incoming: "Deze stemronde is nog niet gestart."
       cant_answer_expired: "Deze stemronde is afgesloten."
       cant_answer_wrong_geozone: "Deze vraag wordt niet behandeld in jouw regio."
       more_info_title: "Meer informatie"

--- a/config/locales/nl/seeds.yml
+++ b/config/locales/nl/seeds.yml
@@ -49,7 +49,6 @@ nl:
     polls:
       current_poll: "Huidige peiling"
       current_poll_geozone_restricted: "Huidige peiling is gebiedsgebonden"
-      incoming_poll: "Inkomende peiling"
       recounting_poll: "Hertellen peiling"
       expired_poll_without_stats: "Verlopen peiling zonder statistieken en resultaten"
       expired_poll_with_stats: "Verlopen peilingen met statistieken en resultaten"

--- a/config/locales/pl-PL/general.yml
+++ b/config/locales/pl-PL/general.yml
@@ -484,11 +484,9 @@ pl:
     index:
       filters:
         current: "Otwórz"
-        incoming: "Przychodzące"
         expired: "Przedawnione"
       title: "Ankiety"
       participate_button: "Weź udział w tej sondzie"
-      participate_button_incoming: "Więcej informacji"
       participate_button_expired: "Sonda zakończyła się"
       no_geozone_restricted: "Wszystkie miasta"
       geozone_restricted: "Dzielnice"
@@ -516,7 +514,6 @@ pl:
       signup: Zarejestruj się
       cant_answer_verify_html: "Aby odpowiedzieć, musisz %{verify_link}."
       verify_link: "zweryfikuj swoje konto"
-      cant_answer_incoming: "Ta sonda jeszcze się nie rozpoczęła."
       cant_answer_expired: "Ta sonda została zakończona."
       cant_answer_wrong_geozone: "To pytanie nie jest dostępne w Twojej strefie geograficznej."
       more_info_title: "Więcej informacji"

--- a/config/locales/pl-PL/seeds.yml
+++ b/config/locales/pl-PL/seeds.yml
@@ -49,7 +49,6 @@ pl:
     polls:
       current_poll: "Aktualna Ankieta"
       current_poll_geozone_restricted: "Obecna Ankieta Ograniczona przez Geostrefę"
-      incoming_poll: "Nadchodząca ankieta"
       recounting_poll: "Przeliczanie ankiety"
       expired_poll_without_stats: "Ankieta Wygasła bez Statystyk i Wyników"
       expired_poll_with_stats: "Ankieta Wygasła ze Statystykami i Wynikami"

--- a/config/locales/pt-BR/general.yml
+++ b/config/locales/pt-BR/general.yml
@@ -458,11 +458,9 @@ pt-BR:
     index:
       filters:
         current: "Abrir"
-        incoming: "Entrada"
         expired: "Expirado"
       title: "Votações"
       participate_button: "Participar desta votação"
-      participate_button_incoming: "Mais informações"
       participate_button_expired: "Votação encerrada"
       no_geozone_restricted: "Toda a cidade"
       geozone_restricted: "Distritos"
@@ -490,7 +488,6 @@ pt-BR:
       signup: Inscrever-se
       cant_answer_verify_html: "Você deve %{verify_link} para poder responder."
       verify_link: "verificar sua conta"
-      cant_answer_incoming: "Esta votação ainda não iniciou."
       cant_answer_expired: "Esta votação já foi encerrada."
       cant_answer_wrong_geozone: "Esta questão não está disponível na sua geozona."
       more_info_title: "Mais informações"

--- a/config/locales/pt-BR/seeds.yml
+++ b/config/locales/pt-BR/seeds.yml
@@ -49,7 +49,6 @@ pt-BR:
     polls:
       current_poll: "Votação atual"
       current_poll_geozone_restricted: "Votação atual restrita por geozona"
-      incoming_poll: "Votação próxima"
       recounting_poll: "Votação em recontagem"
       expired_poll_without_stats: "Votação expirada sem estatísticas e resultados"
       expired_poll_with_stats: "Votação expirada com estatísticas e resultados"

--- a/config/locales/sq-AL/general.yml
+++ b/config/locales/sq-AL/general.yml
@@ -458,11 +458,9 @@ sq:
     index:
       filters:
         current: "Hapur"
-        incoming: "Hyrës"
         expired: "Ka skaduar"
       title: "Sondazhet"
       participate_button: "Merrni pjesë në këtë sondazh"
-      participate_button_incoming: "Më shumë informacion"
       participate_button_expired: "Sondazhi përfundoi"
       no_geozone_restricted: "I gjithë qyteti"
       geozone_restricted: "Zonë"
@@ -490,7 +488,6 @@ sq:
       signup: Rregjistrohu
       cant_answer_verify_html: "Ju duhet të %{verify_link}për t'u përgjigjur."
       verify_link: "verifikoni llogarinë tuaj"
-      cant_answer_incoming: "Ky sondazh ende nuk ka filluar."
       cant_answer_expired: "Ky sondazh ka përfunduar."
       cant_answer_wrong_geozone: "Kjo pyetje nuk është e disponueshme në gjeozonën tuaj"
       more_info_title: "Më shumë informacion"

--- a/config/locales/sq-AL/seeds.yml
+++ b/config/locales/sq-AL/seeds.yml
@@ -49,7 +49,6 @@ sq:
     polls:
       current_poll: "Sondazhi aktual"
       current_poll_geozone_restricted: "Sondazhi aktual Gjeozone i kufizuar"
-      incoming_poll: "Sondazhi i ardhur"
       recounting_poll: "Rinumërimi sondazhit"
       expired_poll_without_stats: "Sondazh i skaduar pa statistika dhe rezultate"
       expired_poll_with_stats: "Sondazh i skaduar me statistika dhe rezultate"

--- a/config/locales/sv-SE/general.yml
+++ b/config/locales/sv-SE/general.yml
@@ -458,11 +458,9 @@ sv:
     index:
       filters:
         current: "Pågående"
-        incoming: "Kommande"
         expired: "Avslutade"
       title: "Omröstningar"
       participate_button: "Delta i omröstningen"
-      participate_button_incoming: "Mer information"
       participate_button_expired: "Omröstningen är avslutad"
       no_geozone_restricted: "Hela staden"
       geozone_restricted: "Stadsdelar"
@@ -487,7 +485,6 @@ sv:
       signup: Registrera dig
       cant_answer_verify_html: "Du måste %{verify_link} för att svara."
       verify_link: "verifiera ditt konto"
-      cant_answer_incoming: "Omröstningen har inte börjat än."
       cant_answer_expired: "Omröstningen är avslutad."
       cant_answer_wrong_geozone: "Den här frågan är inte tillgänglig i ditt område."
       more_info_title: "Mer information"

--- a/config/locales/sv-SE/seeds.yml
+++ b/config/locales/sv-SE/seeds.yml
@@ -49,7 +49,6 @@ sv:
     polls:
       current_poll: "Aktuell omröstning"
       current_poll_geozone_restricted: "Omröstningen är begränsad till ett geografiskt område"
-      incoming_poll: "Kommande omröstning"
       recounting_poll: "Rösträkning"
       expired_poll_without_stats: "Avslutad omröstning (utan statistik eller resultat)"
       expired_poll_with_stats: "Avslutad omröstning (med statistik och resultat)"

--- a/config/locales/tr-TR/seeds.yml
+++ b/config/locales/tr-TR/seeds.yml
@@ -33,7 +33,6 @@ tr:
     polls:
       current_poll: "Geçerli Anket"
       current_poll_geozone_restricted: "Geçerli Anket Geozone sınırlı"
-      incoming_poll: "Gelen anket"
       recounting_poll: "Anket anlatırken"
       expired_poll_without_stats: "İstatistikler ve sonuçları olmadan anket süresi"
       expired_poll_with_stats: "İstatistikler ve sonuçları olmadan anket süresi"

--- a/config/locales/val/general.yml
+++ b/config/locales/val/general.yml
@@ -456,11 +456,9 @@ val:
     index:
       filters:
         current: "Obertes"
-        incoming: "Pròximament"
         expired: "Acabades"
       title: "Votacions"
       participate_button: "Participar en esta votació"
-      participate_button_incoming: "Més informació"
       participate_button_expired: "Votació finalitzada"
       no_geozone_restricted: "Tota la ciutat"
       geozone_restricted: "Districtes"
@@ -484,7 +482,6 @@ val:
       signup: Registrar-te
       cant_answer_verify_html: "Si us plau %{verify_link} per a poder respondre."
       verify_link: "verifica el teu compte"
-      cant_answer_incoming: "Esta votació encara no ha començat."
       cant_answer_expired: "Esta votació ha acabat."
       cant_answer_wrong_geozone: "Esta votació no està disponible en la teua zona."
       more_info_title: "Més informació"

--- a/config/locales/val/seeds.yml
+++ b/config/locales/val/seeds.yml
@@ -43,7 +43,6 @@ val:
     polls:
       current_poll: "Votació Oberta"
       current_poll_geozone_restricted: "Votació Oberta restringida per geozona"
-      incoming_poll: "Següent Votació"
       recounting_poll: "Votació en Recompte"
       expired_poll_without_stats: "Votació Finalitzada sense Estadístiques ni Resultats"
       expired_poll_with_stats: "Votació Finalitzada amb Estadístiques i Resultats"

--- a/config/locales/zh-CN/general.yml
+++ b/config/locales/zh-CN/general.yml
@@ -441,11 +441,9 @@ zh-CN:
     index:
       filters:
         current: "打开"
-        incoming: "传入"
         expired: "过期的"
       title: "投票"
       participate_button: "参与此投票"
-      participate_button_incoming: "更多信息"
       participate_button_expired: "投票已结束"
       no_geozone_restricted: "所有城市"
       geozone_restricted: "地区"
@@ -473,7 +471,6 @@ zh-CN:
       signup: 注册
       cant_answer_verify_html: "您必须%{verify_link} 才能回答。"
       verify_link: "验证您的账户"
-      cant_answer_incoming: "此投票还没有开始。"
       cant_answer_expired: "此投票已经结束。"
       cant_answer_wrong_geozone: "此问题在您的地理区域里不可用。"
       more_info_title: "更多信息"

--- a/config/locales/zh-CN/seeds.yml
+++ b/config/locales/zh-CN/seeds.yml
@@ -49,7 +49,6 @@ zh-CN:
     polls:
       current_poll: "当前的投票"
       current_poll_geozone_restricted: "当前投票地理区域的限制"
-      incoming_poll: "进来的投票"
       recounting_poll: "重新计票"
       expired_poll_without_stats: "已过期的投票，没有统计数据&结果"
       expired_poll_with_stats: "已过期的投票，有统计数据&结果"

--- a/config/locales/zh-TW/general.yml
+++ b/config/locales/zh-TW/general.yml
@@ -441,11 +441,9 @@ zh-TW:
     index:
       filters:
         current: "開"
-        incoming: "傳入"
         expired: "已過期"
       title: "投票"
       participate_button: "參與此投票"
-      participate_button_incoming: "更多資訊"
       participate_button_expired: "投票結束"
       no_geozone_restricted: "所有城市"
       geozone_restricted: "地區"
@@ -473,7 +471,6 @@ zh-TW:
       signup: 登記
       cant_answer_verify_html: "您必須%{verify_link} 才能回答。"
       verify_link: "核實您的帳戶"
-      cant_answer_incoming: "此投票項尚未開始。"
       cant_answer_expired: "此投票項已結束。"
       cant_answer_wrong_geozone: "此問題並不適用於您的地理區域。"
       more_info_title: "更多資訊"

--- a/config/locales/zh-TW/seeds.yml
+++ b/config/locales/zh-TW/seeds.yml
@@ -49,7 +49,6 @@ zh-TW:
     polls:
       current_poll: "當前的投票"
       current_poll_geozone_restricted: "當前投票地理區域的限制"
-      incoming_poll: "傳入投票"
       recounting_poll: "重新計票"
       expired_poll_without_stats: "已過期的投票項目，沒有統計數據和結果"
       expired_poll_with_stats: "已過期的投票項目，連帶統計數據和結果"

--- a/db/dev_seeds/polls.rb
+++ b/db/dev_seeds/polls.rb
@@ -13,11 +13,6 @@ section "Creating polls" do
               geozone_restricted: true,
               geozones: Geozone.reorder("RANDOM()").limit(3))
 
-  Poll.create(name: I18n.t('seeds.polls.incoming_poll'),
-              slug: I18n.t('seeds.polls.incoming_poll').parameterize,
-              starts_at: 1.month.from_now,
-              ends_at:   2.months.from_now)
-
   Poll.create(name: I18n.t('seeds.polls.recounting_poll'),
               slug: I18n.t('seeds.polls.recounting_poll').parameterize,
               starts_at: 15.days.ago,

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -13,11 +13,6 @@ FactoryBot.define do
       ends_at { 2.days.from_now }
     end
 
-    trait :incoming do
-      starts_at { 2.days.from_now }
-      ends_at { 1.month.from_now }
-    end
-
     trait :expired do
       starts_at { 1.month.ago }
       ends_at { 15.days.ago }

--- a/spec/features/admin/poll/booths_spec.rb
+++ b/spec/features/admin/poll/booths_spec.rb
@@ -38,27 +38,23 @@ feature 'Admin booths' do
 
   scenario "Available" do
     booth_for_current_poll  = create(:poll_booth)
-    booth_for_incoming_poll = create(:poll_booth)
     booth_for_expired_poll  = create(:poll_booth)
 
     current_poll  = create(:poll, :current)
-    incoming_poll = create(:poll, :incoming)
     expired_poll  = create(:poll, :expired)
 
     create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
-    create(:poll_booth_assignment, poll: incoming_poll, booth: booth_for_incoming_poll)
     create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
 
     visit admin_root_path
 
-    within('#side_menu') do
+    within("#side_menu") do
       click_link "Manage shifts"
     end
 
-    expect(page).to have_css(".booth", count: 2)
+    expect(page).to have_css(".booth", count: 1)
 
     expect(page).to have_content booth_for_current_poll.name
-    expect(page).to have_content booth_for_incoming_poll.name
     expect(page).not_to have_content booth_for_expired_poll.name
     expect(page).not_to have_link "Edit booth"
   end

--- a/spec/features/admin/poll/shifts_spec.rb
+++ b/spec/features/admin/poll/shifts_spec.rb
@@ -32,7 +32,6 @@ feature 'Admin shifts' do
 
   scenario "Create Vote Collection Shift and Recount & Scrutiny Shift on same date", :js do
     create(:poll)
-    create(:poll, :incoming)
     poll = create(:poll, :current)
     booth = create(:poll_booth)
     create(:poll_booth_assignment, poll: poll, booth: booth)

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -96,9 +96,6 @@ feature 'Voters' do
     poll_expired = create(:poll, :expired)
     create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: poll_expired, booth: booth))
 
-    poll_incoming = create(:poll, :incoming)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: poll_incoming, booth: booth))
-
     poll_geozone_restricted_in = create(:poll, :current, geozone_restricted: true, geozones: [Geozone.first])
     booth_assignment = create(:poll_booth_assignment, poll: poll_geozone_restricted_in, booth: booth)
     create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
@@ -115,7 +112,6 @@ feature 'Voters' do
     expect(page).to have_content poll.name
     expect(page).not_to have_content poll_current.name
     expect(page).not_to have_content poll_expired.name
-    expect(page).not_to have_content poll_incoming.name
     expect(page).to have_content poll_geozone_restricted_in.name
     expect(page).not_to have_content poll_geozone_restricted_out.name
   end

--- a/spec/features/polls/nvotes_spec.rb
+++ b/spec/features/polls/nvotes_spec.rb
@@ -54,7 +54,7 @@ feature 'Nvotes' do
 
     scenario "Valid signature", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
-      poll = create(:poll, :incoming, published: true, nvotes_poll_id: 128)
+      poll = create(:poll, published: true, nvotes_poll_id: 128)
 
       nvote = create(:poll_nvote, user: user, poll: poll)
       nvote.update(voter_hash: "33333333")
@@ -74,7 +74,7 @@ feature 'Nvotes' do
 
     scenario "Invalid signature", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
-      poll = create(:poll, :incoming, published: true, nvotes_poll_id: 128)
+      poll = create(:poll, published: true, nvotes_poll_id: 128)
       nvote = create(:poll_nvote, user: user, poll: poll)
       nvote.update(voter_hash: "33333333")
 
@@ -93,7 +93,7 @@ feature 'Nvotes' do
 
     scenario "Officer information", :page_driver do
       user  = create(:user, :in_census, id: rand(9999999))
-      poll = create(:poll, :incoming, published: true, nvotes_poll_id: 128)
+      poll = create(:poll, published: true, nvotes_poll_id: 128)
 
       booth_assignment = create(:poll_booth_assignment, poll: poll)
       officer_assignment = create(:poll_officer_assignment, booth_assignment: booth_assignment)

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -28,24 +28,15 @@ feature 'Polls' do
 
     scenario 'Filtering polls' do
       create(:poll, name: "Current poll")
-      create(:poll, :incoming, name: "Incoming poll")
       create(:poll, :expired, name: "Expired poll")
 
       visit polls_path
       expect(page).to have_content('Current poll')
       expect(page).to have_link('Participate in this poll')
-      expect(page).not_to have_content('Incoming poll')
-      expect(page).not_to have_content('Expired poll')
-
-      visit polls_path(filter: 'incoming')
-      expect(page).not_to have_content('Current poll')
-      expect(page).to have_content('Incoming poll')
-      expect(page).to have_link('More information')
       expect(page).not_to have_content('Expired poll')
 
       visit polls_path(filter: 'expired')
       expect(page).not_to have_content('Current poll')
-      expect(page).not_to have_content('Incoming poll')
       expect(page).to have_content('Expired poll')
       expect(page).to have_link('Poll ended')
     end
@@ -53,17 +44,10 @@ feature 'Polls' do
     scenario "Current filter is properly highlighted" do
       visit polls_path
       expect(page).not_to have_link('Open')
-      expect(page).to have_link('Incoming')
-      expect(page).to have_link('Expired')
-
-      visit polls_path(filter: 'incoming')
-      expect(page).to have_link('Open')
-      expect(page).not_to have_link('Incoming')
       expect(page).to have_link('Expired')
 
       visit polls_path(filter: 'expired')
       expect(page).to have_link('Open')
-      expect(page).to have_link('Incoming')
       expect(page).not_to have_link('Expired')
     end
 
@@ -214,26 +198,6 @@ feature 'Polls' do
 
       expect(page).to have_link('Han Solo', href: verification_path)
       expect(page).to have_link('Chewbacca', href: verification_path)
-    end
-
-    scenario 'Level 2 users in an incoming poll' do
-      incoming_poll = create(:poll, :incoming, geozone_restricted: true)
-      incoming_poll.geozones << geozone
-
-      question = create(:poll_question, poll: incoming_poll)
-      answer1 = create(:poll_question_answer, question: question, title: 'Rey')
-      answer2 = create(:poll_question_answer, question: question, title: 'Finn')
-
-      login_as(create(:user, :level_two, geozone: geozone))
-
-      visit poll_path(incoming_poll)
-
-      expect(page).to have_content('Rey')
-      expect(page).to have_content('Finn')
-      expect(page).not_to have_link('Rey')
-      expect(page).not_to have_link('Finn')
-
-      expect(page).to have_content('This poll has not yet started')
     end
 
     scenario 'Level 2 users in an expired poll' do

--- a/spec/models/abilities/common_spec.rb
+++ b/spec/models/abilities/common_spec.rb
@@ -33,9 +33,6 @@ describe Abilities::Common do
   let(:ballot_in_balloting_budget) { create(:budget_ballot, budget: balloting_budget) }
 
   let(:current_poll)  { create(:poll) }
-  let(:incoming_poll) { create(:poll, :incoming) }
-  let(:incoming_poll_from_own_geozone) { create(:poll, :incoming, geozone_restricted: true, geozones: [geozone]) }
-  let(:incoming_poll_from_other_geozone) { create(:poll, :incoming, geozone_restricted: true, geozones: [create(:geozone)]) }
   let(:expired_poll) { create(:poll, :expired) }
   let(:expired_poll_from_own_geozone) { create(:poll, :expired, geozone_restricted: true, geozones: [geozone]) }
   let(:expired_poll_from_other_geozone) { create(:poll, :expired, geozone_restricted: true, geozones: [create(:geozone)]) }
@@ -50,10 +47,6 @@ describe Abilities::Common do
   let(:expired_poll_question_from_own_geozone)   { create(:poll_question, poll: expired_poll_from_own_geozone) }
   let(:expired_poll_question_from_other_geozone) { create(:poll_question, poll: expired_poll_from_other_geozone) }
   let(:expired_poll_question_from_all_geozones)  { create(:poll_question, poll: expired_poll) }
-
-  let(:incoming_poll_question_from_own_geozone)   { create(:poll_question, poll: incoming_poll_from_own_geozone) }
-  let(:incoming_poll_question_from_other_geozone) { create(:poll_question, poll: incoming_poll_from_other_geozone) }
-  let(:incoming_poll_question_from_all_geozones)  { create(:poll_question, poll: incoming_poll) }
 
   let(:own_proposal_document)          { build(:document, documentable: own_proposal) }
   let(:proposal_document)              { build(:document, documentable: proposal) }
@@ -209,7 +202,6 @@ describe Abilities::Common do
     describe "Poll" do
       it { should     be_able_to(:answer, current_poll)  }
       it { should_not be_able_to(:answer, expired_poll)  }
-      it { should_not be_able_to(:answer, incoming_poll) }
 
       it { should     be_able_to(:answer, poll_question_from_own_geozone)   }
       it { should     be_able_to(:answer, poll_question_from_all_geozones)  }
@@ -218,10 +210,6 @@ describe Abilities::Common do
       it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
       it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
       it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-      it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
 
       context "without geozone" do
         before { user.geozone = nil }
@@ -233,10 +221,6 @@ describe Abilities::Common do
         it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
         it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
         it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-        it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
       end
     end
 
@@ -313,7 +297,6 @@ describe Abilities::Common do
       describe "Poll" do
         it { should_not be_able_to(:answer, current_poll)  }
         it { should_not be_able_to(:answer, expired_poll)  }
-        it { should_not be_able_to(:answer, incoming_poll) }
 
         it { should_not be_able_to(:answer, poll_question_from_own_geozone)   }
         it { should_not be_able_to(:answer, poll_question_from_all_geozones)  }
@@ -322,10 +305,6 @@ describe Abilities::Common do
         it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
         it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
         it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-        it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
 
         context "without geozone" do
           before(:each) { user.geozone = nil }
@@ -337,10 +316,6 @@ describe Abilities::Common do
           it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
           it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
           it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-          it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-          it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-          it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
         end
       end
 
@@ -382,7 +357,6 @@ describe Abilities::Common do
 
     it { should     be_able_to(:answer, current_poll)  }
     it { should_not be_able_to(:answer, expired_poll)  }
-    it { should_not be_able_to(:answer, incoming_poll) }
 
     it { should     be_able_to(:answer, poll_question_from_own_geozone)   }
     it { should     be_able_to(:answer, poll_question_from_all_geozones)  }
@@ -391,10 +365,6 @@ describe Abilities::Common do
     it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
     it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
     it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-    it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-    it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-    it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
 
     context "without geozone" do
       before { user.geozone = nil }
@@ -405,10 +375,6 @@ describe Abilities::Common do
       it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
       it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
       it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-      it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
     end
 
     context "when not old enough to vote" do
@@ -428,7 +394,6 @@ describe Abilities::Common do
 
       it { should_not be_able_to(:answer, current_poll)  }
       it { should_not be_able_to(:answer, expired_poll)  }
-      it { should_not be_able_to(:answer, incoming_poll) }
 
       it { should_not be_able_to(:answer, poll_question_from_own_geozone)   }
       it { should_not be_able_to(:answer, poll_question_from_all_geozones)  }
@@ -437,10 +402,6 @@ describe Abilities::Common do
       it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
       it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
       it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-      it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-      it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
 
       context "without geozone" do
         before(:each) { user.geozone = nil }
@@ -451,10 +412,6 @@ describe Abilities::Common do
         it { should_not be_able_to(:answer, expired_poll_question_from_own_geozone)   }
         it { should_not be_able_to(:answer, expired_poll_question_from_all_geozones)  }
         it { should_not be_able_to(:answer, expired_poll_question_from_other_geozone) }
-
-        it { should_not be_able_to(:answer, incoming_poll_question_from_own_geozone)   }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_all_geozones)  }
-        it { should_not be_able_to(:answer, incoming_poll_question_from_other_geozone) }
       end
     end
   end

--- a/spec/models/poll/booth_spec.rb
+++ b/spec/models/poll/booth_spec.rb
@@ -26,21 +26,17 @@ describe Poll::Booth do
 
   describe "#available" do
 
-    it "returns booths associated to current or incoming polls" do
+    it "returns booths associated to current polls" do
       booth_for_current_poll  = create(:poll_booth)
-      booth_for_incoming_poll = create(:poll_booth)
       booth_for_expired_poll  = create(:poll_booth)
 
       current_poll  = create(:poll, :current)
-      incoming_poll = create(:poll, :incoming)
       expired_poll  = create(:poll, :expired)
 
       create(:poll_booth_assignment, poll: current_poll,  booth: booth_for_current_poll)
-      create(:poll_booth_assignment, poll: incoming_poll, booth: booth_for_incoming_poll)
       create(:poll_booth_assignment, poll: expired_poll,  booth: booth_for_expired_poll)
 
       expect(described_class.available).to include(booth_for_current_poll)
-      expect(described_class.available).to include(booth_for_incoming_poll)
       expect(described_class.available).not_to include(booth_for_expired_poll)
     end
 

--- a/spec/models/poll/poll_spec.rb
+++ b/spec/models/poll/poll_spec.rb
@@ -36,24 +36,14 @@ describe Poll do
   end
 
   describe "#opened?" do
-    it "returns true only when it isn't too early or too late" do
-      expect(create(:poll, :incoming)).not_to be_current
+    it "returns true only when it isn't too late" do
       expect(create(:poll, :expired)).not_to be_current
       expect(create(:poll)).to be_current
     end
   end
 
-  describe "#incoming?" do
-    it "returns true only when it is too early" do
-      expect(create(:poll, :incoming)).to be_incoming
-      expect(create(:poll, :expired)).not_to be_incoming
-      expect(create(:poll)).not_to be_incoming
-    end
-  end
-
   describe "#expired?" do
     it "returns true only when it is too late" do
-      expect(create(:poll, :incoming)).not_to be_expired
       expect(create(:poll, :expired)).to be_expired
       expect(create(:poll)).not_to be_expired
     end
@@ -66,49 +56,31 @@ describe Poll do
     end
   end
 
-  describe "#current_or_incoming" do
-    it "returns current or incoming polls" do
-      current = create(:poll, :current)
-      incoming = create(:poll, :incoming)
-      expired = create(:poll, :expired)
-
-      current_or_incoming = described_class.current_or_incoming
-
-      expect(current_or_incoming).to include(current)
-      expect(current_or_incoming).to include(incoming)
-      expect(current_or_incoming).not_to include(expired)
-    end
-  end
-
   describe "#recounting" do
     it "returns polls in recount & scrutiny phase" do
       current = create(:poll, :current)
-      incoming = create(:poll, :incoming)
       expired = create(:poll, :expired)
       recounting = create(:poll, :recounting)
 
       recounting_polls = described_class.recounting
 
       expect(recounting_polls).not_to include(current)
-      expect(recounting_polls).not_to include(incoming)
       expect(recounting_polls).not_to include(expired)
       expect(recounting_polls).to include(recounting)
     end
   end
 
-  describe "#current_or_recounting_or_incoming" do
-    it "returns current or recounting or incoming polls" do
+  describe "#current_or_recounting" do
+    it "returns current or recounting polls" do
       current = create(:poll, :current)
-      incoming = create(:poll, :incoming)
       expired = create(:poll, :expired)
       recounting = create(:poll, :recounting)
 
-      current_or_recounting_or_incoming = described_class.current_or_recounting_or_incoming
+      current_or_recounting = described_class.current_or_recounting
 
-      expect(current_or_recounting_or_incoming).to include(current)
-      expect(current_or_recounting_or_incoming).to include(recounting)
-      expect(current_or_recounting_or_incoming).to include(incoming)
-      expect(current_or_recounting_or_incoming).not_to include(expired)
+      expect(current_or_recounting).to include(current)
+      expect(current_or_recounting).to include(recounting)
+      expect(current_or_recounting).not_to include(expired)
     end
   end
 
@@ -117,14 +89,12 @@ describe Poll do
 
     let!(:current_poll) { create(:poll) }
     let!(:expired_poll) { create(:poll, :expired) }
-    let!(:incoming_poll) { create(:poll, :incoming) }
 
     let!(:current_restricted_poll) { create(:poll, geozone_restricted: true, geozones: [geozone]) }
     let!(:expired_restricted_poll) { create(:poll, :expired, geozone_restricted: true, geozones: [geozone]) }
-    let!(:incoming_restricted_poll) { create(:poll, :incoming, geozone_restricted: true, geozones: [geozone]) }
 
-    let!(:all_polls) { [current_poll, expired_poll, incoming_poll, current_poll, expired_restricted_poll, incoming_restricted_poll] }
-    let(:non_current_polls) { [expired_poll, incoming_poll, expired_restricted_poll, incoming_restricted_poll] }
+    let!(:all_polls) { [current_poll, expired_poll, current_poll, expired_restricted_poll] }
+    let(:non_current_polls) { [expired_poll, expired_restricted_poll] }
 
     let(:non_user) { nil }
     let(:level1)   { create(:user) }


### PR DESCRIPTION
## References

This is the first part of https://github.com/consul/consul/issues/3181

## Objectives

Remove **incoming polls filter**. 

Now there are only to filters `Open` and `Expired`.

## Visual Changes

![no incoming polls](https://user-images.githubusercontent.com/631897/52344549-53355b00-2a1b-11e9-9cae-cef158ce296e.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.