### PR TITLE
Remove next legislation processes filter

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,7 +1,7 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
   include Translatable
 
-  has_filters %w{open next past all}, only: :index
+  has_filters %w[open past all], only: :index
 
   load_and_authorize_resource :process, class: "Legislation::Process"
 

--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,7 +1,7 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
   include Translatable
 
-  has_filters %w[open past all], only: :index
+  has_filters %w[open all], only: :index
 
   load_and_authorize_resource :process, class: "Legislation::Process"
 

--- a/app/controllers/legislation/processes_controller.rb
+++ b/app/controllers/legislation/processes_controller.rb
@@ -1,5 +1,5 @@
 class Legislation::ProcessesController < Legislation::BaseController
-  has_filters %w[open next past], only: :index
+  has_filters %w[open past], only: :index
   has_filters %w[random winners], only: :proposals
 
   load_and_authorize_resource :process

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -45,7 +45,6 @@ class Legislation::Process < ActiveRecord::Base
   validate :valid_date_ranges
 
   scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current) }
-  scope :next, -> { where("start_date > ?", Date.current) }
   scope :past, -> { where("end_date < ?", Date.current) }
 
   scope :published, -> { where(published: true) }

--- a/config/locales/ar/admin.yml
+++ b/config/locales/ar/admin.yml
@@ -133,7 +133,6 @@ ar:
           delete: حذف
           filters:
             open: فتح
-            past: السابق
         new:
           back: عودة
           submit_button: إنشاء عملية

--- a/config/locales/ar/admin.yml
+++ b/config/locales/ar/admin.yml
@@ -133,7 +133,6 @@ ar:
           delete: حذف
           filters:
             open: فتح
-            next: التالي
             past: السابق
         new:
           back: عودة

--- a/config/locales/de-DE/admin.yml
+++ b/config/locales/de-DE/admin.yml
@@ -386,7 +386,6 @@ de:
           title: Kollaborative Gesetzgebungsprozesse
           filters:
             open: Offen
-            past: Vorherige
             all: Alle
         new:
           back: Zurück

--- a/config/locales/de-DE/admin.yml
+++ b/config/locales/de-DE/admin.yml
@@ -386,7 +386,6 @@ de:
           title: Kollaborative Gesetzgebungsprozesse
           filters:
             open: Offen
-            next: Nächste/r
             past: Vorherige
             all: Alle
         new:

--- a/config/locales/de-DE/legislation.yml
+++ b/config/locales/de-DE/legislation.yml
@@ -62,10 +62,8 @@ de:
         filter: Filter
         filters:
           open: Laufende Verfahren
-          next: Geplante
           past: Vorherige
         no_open_processes: Es gibt keine offenen Verfahren
-        no_next_processes: Es gibt keine geplanten Prozesse
         no_past_processes: Es gibt keine vergangene Prozesse
         section_header:
           icon_alt: Gesetzgebungsverfahren Icon

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -466,7 +466,6 @@ en:
           title: Legislation processes
           filters:
             open: Open
-            next: Next
             past: Past
             all: All
         new:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -466,7 +466,6 @@ en:
           title: Legislation processes
           filters:
             open: Open
-            past: Past
             all: All
         new:
           back: Back

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -62,10 +62,8 @@ en:
         filter: Filter
         filters:
           open: Open processes
-          next: Next
           past: Past
         no_open_processes: There aren't open processes
-        no_next_processes: There aren't planned processes
         no_past_processes: There aren't past processes
         section_header:
           icon_alt: Legislation processes icon

--- a/config/locales/es-AR/admin.yml
+++ b/config/locales/es-AR/admin.yml
@@ -350,7 +350,6 @@ es-AR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-AR/admin.yml
+++ b/config/locales/es-AR/admin.yml
@@ -350,7 +350,6 @@ es-AR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-AR/legislation.yml
+++ b/config/locales/es-AR/legislation.yml
@@ -54,10 +54,8 @@ es-AR:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-BO/admin.yml
+++ b/config/locales/es-BO/admin.yml
@@ -261,7 +261,6 @@ es-BO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-BO/admin.yml
+++ b/config/locales/es-BO/admin.yml
@@ -261,7 +261,6 @@ es-BO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-BO/legislation.yml
+++ b/config/locales/es-BO/legislation.yml
@@ -54,10 +54,8 @@ es-BO:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-CL/admin.yml
+++ b/config/locales/es-CL/admin.yml
@@ -344,7 +344,6 @@ es-CL:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-CL/admin.yml
+++ b/config/locales/es-CL/admin.yml
@@ -344,7 +344,6 @@ es-CL:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-CL/legislation.yml
+++ b/config/locales/es-CL/legislation.yml
@@ -54,10 +54,8 @@ es-CL:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-CO/admin.yml
+++ b/config/locales/es-CO/admin.yml
@@ -261,7 +261,6 @@ es-CO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-CO/admin.yml
+++ b/config/locales/es-CO/admin.yml
@@ -261,7 +261,6 @@ es-CO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-CO/legislation.yml
+++ b/config/locales/es-CO/legislation.yml
@@ -54,10 +54,8 @@ es-CO:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-CR/admin.yml
+++ b/config/locales/es-CR/admin.yml
@@ -261,7 +261,6 @@ es-CR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-CR/admin.yml
+++ b/config/locales/es-CR/admin.yml
@@ -261,7 +261,6 @@ es-CR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-CR/legislation.yml
+++ b/config/locales/es-CR/legislation.yml
@@ -54,10 +54,8 @@ es-CR:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-DO/admin.yml
+++ b/config/locales/es-DO/admin.yml
@@ -261,7 +261,6 @@ es-DO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-DO/admin.yml
+++ b/config/locales/es-DO/admin.yml
@@ -261,7 +261,6 @@ es-DO:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-DO/legislation.yml
+++ b/config/locales/es-DO/legislation.yml
@@ -54,10 +54,8 @@ es-DO:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-EC/admin.yml
+++ b/config/locales/es-EC/admin.yml
@@ -261,7 +261,6 @@ es-EC:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-EC/admin.yml
+++ b/config/locales/es-EC/admin.yml
@@ -261,7 +261,6 @@ es-EC:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-EC/legislation.yml
+++ b/config/locales/es-EC/legislation.yml
@@ -54,10 +54,8 @@ es-EC:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-GT/admin.yml
+++ b/config/locales/es-GT/admin.yml
@@ -261,7 +261,6 @@ es-GT:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-GT/admin.yml
+++ b/config/locales/es-GT/admin.yml
@@ -261,7 +261,6 @@ es-GT:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-GT/legislation.yml
+++ b/config/locales/es-GT/legislation.yml
@@ -54,10 +54,8 @@ es-GT:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-HN/admin.yml
+++ b/config/locales/es-HN/admin.yml
@@ -261,7 +261,6 @@ es-HN:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-HN/admin.yml
+++ b/config/locales/es-HN/admin.yml
@@ -261,7 +261,6 @@ es-HN:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-HN/legislation.yml
+++ b/config/locales/es-HN/legislation.yml
@@ -54,10 +54,8 @@ es-HN:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-MX/admin.yml
+++ b/config/locales/es-MX/admin.yml
@@ -261,7 +261,6 @@ es-MX:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-MX/admin.yml
+++ b/config/locales/es-MX/admin.yml
@@ -261,7 +261,6 @@ es-MX:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-MX/legislation.yml
+++ b/config/locales/es-MX/legislation.yml
@@ -54,10 +54,8 @@ es-MX:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-NI/admin.yml
+++ b/config/locales/es-NI/admin.yml
@@ -261,7 +261,6 @@ es-NI:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-NI/admin.yml
+++ b/config/locales/es-NI/admin.yml
@@ -261,7 +261,6 @@ es-NI:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-NI/legislation.yml
+++ b/config/locales/es-NI/legislation.yml
@@ -54,10 +54,8 @@ es-NI:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PA/admin.yml
+++ b/config/locales/es-PA/admin.yml
@@ -261,7 +261,6 @@ es-PA:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PA/admin.yml
+++ b/config/locales/es-PA/admin.yml
@@ -261,7 +261,6 @@ es-PA:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PA/legislation.yml
+++ b/config/locales/es-PA/legislation.yml
@@ -54,10 +54,8 @@ es-PA:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PE/admin.yml
+++ b/config/locales/es-PE/admin.yml
@@ -261,7 +261,6 @@ es-PE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PE/admin.yml
+++ b/config/locales/es-PE/admin.yml
@@ -261,7 +261,6 @@ es-PE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PE/legislation.yml
+++ b/config/locales/es-PE/legislation.yml
@@ -54,10 +54,8 @@ es-PE:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PR/admin.yml
+++ b/config/locales/es-PR/admin.yml
@@ -261,7 +261,6 @@ es-PR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PR/admin.yml
+++ b/config/locales/es-PR/admin.yml
@@ -261,7 +261,6 @@ es-PR:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PR/legislation.yml
+++ b/config/locales/es-PR/legislation.yml
@@ -54,10 +54,8 @@ es-PR:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-PY/admin.yml
+++ b/config/locales/es-PY/admin.yml
@@ -261,7 +261,6 @@ es-PY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-PY/admin.yml
+++ b/config/locales/es-PY/admin.yml
@@ -261,7 +261,6 @@ es-PY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-PY/legislation.yml
+++ b/config/locales/es-PY/legislation.yml
@@ -54,10 +54,8 @@ es-PY:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-SV/admin.yml
+++ b/config/locales/es-SV/admin.yml
@@ -261,7 +261,6 @@ es-SV:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-SV/admin.yml
+++ b/config/locales/es-SV/admin.yml
@@ -261,7 +261,6 @@ es-SV:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-SV/legislation.yml
+++ b/config/locales/es-SV/legislation.yml
@@ -54,10 +54,8 @@ es-SV:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-UY/admin.yml
+++ b/config/locales/es-UY/admin.yml
@@ -261,7 +261,6 @@ es-UY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-UY/admin.yml
+++ b/config/locales/es-UY/admin.yml
@@ -261,7 +261,6 @@ es-UY:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-UY/legislation.yml
+++ b/config/locales/es-UY/legislation.yml
@@ -54,10 +54,8 @@ es-UY:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es-VE/admin.yml
+++ b/config/locales/es-VE/admin.yml
@@ -306,7 +306,6 @@ es-VE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es-VE/admin.yml
+++ b/config/locales/es-VE/admin.yml
@@ -306,7 +306,6 @@ es-VE:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es-VE/legislation.yml
+++ b/config/locales/es-VE/legislation.yml
@@ -54,10 +54,8 @@ es-VE:
       index:
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -467,7 +467,6 @@ es:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -467,7 +467,6 @@ es:
           title: Procesos de legislación colaborativa
           filters:
             open: Abiertos
-            next: Próximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -62,10 +62,8 @@ es:
         filter: Filtro
         filters:
           open: Procesos activos
-          next: Próximamente
           past: Terminados
         no_open_processes: No hay procesos activos
-        no_next_processes: No hay procesos planeados
         no_past_processes: No hay procesos terminados
         section_header:
           icon_alt: Icono de Procesos legislativos

--- a/config/locales/fa-IR/admin.yml
+++ b/config/locales/fa-IR/admin.yml
@@ -322,7 +322,6 @@ fa:
           title: فرآیندهای قانونی
           filters:
             open: بازکردن
-            past: گذشته
             all: همه
         new:
           back: برگشت

--- a/config/locales/fa-IR/admin.yml
+++ b/config/locales/fa-IR/admin.yml
@@ -322,7 +322,6 @@ fa:
           title: فرآیندهای قانونی
           filters:
             open: بازکردن
-            next: بعدی
             past: گذشته
             all: همه
         new:

--- a/config/locales/fa-IR/legislation.yml
+++ b/config/locales/fa-IR/legislation.yml
@@ -59,10 +59,8 @@ fa:
         filter: فیلتر
         filters:
           open: فرآیندهای باز
-          next: بعدی
           past: گذشته
         no_open_processes: فرایندهای باز وجود ندارد
-        no_next_processes: فرایندها برنامه ریزی نشده است
         no_past_processes: فرآیندهای گذشته وجود ندارد
         section_header:
           icon_alt: آیکون قوانین پردازش 

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -385,7 +385,6 @@ fr:
           title: Processus législatifs
           filters:
             open: Ouvert
-            next: Suivant
             past: Passé
             all: Tous
         new:

--- a/config/locales/fr/admin.yml
+++ b/config/locales/fr/admin.yml
@@ -385,7 +385,6 @@ fr:
           title: Processus législatifs
           filters:
             open: Ouvert
-            past: Passé
             all: Tous
         new:
           back: Retour

--- a/config/locales/fr/legislation.yml
+++ b/config/locales/fr/legislation.yml
@@ -59,10 +59,8 @@ fr:
         filter: Filtrer
         filters:
           open: Processus ouverts
-          next: À venir
           past: Passés
         no_open_processes: Il n'y a pas de processus ouverts
-        no_next_processes: Il n'y a pas de processus à venir
         no_past_processes: Il n'y a pas de processus passés
         section_header:
           icon_alt: Icône des processus législatifs

--- a/config/locales/gl/admin.yml
+++ b/config/locales/gl/admin.yml
@@ -388,7 +388,6 @@ gl:
           title: Proceso de lexislación colaborativa
           filters:
             open: Abertos
-            past: Pasados
             all: Todos
         new:
           back: Volver

--- a/config/locales/gl/admin.yml
+++ b/config/locales/gl/admin.yml
@@ -388,7 +388,6 @@ gl:
           title: Proceso de lexislación colaborativa
           filters:
             open: Abertos
-            next: Proximamente
             past: Pasados
             all: Todos
         new:

--- a/config/locales/gl/legislation.yml
+++ b/config/locales/gl/legislation.yml
@@ -62,10 +62,8 @@ gl:
         filter: Filtro
         filters:
           open: Procesos abertos
-          next: Proximamente
           past: Rematados
         no_open_processes: Non hai ningún proceso activo
-        no_next_processes: Non hai ningún proceso planeado
         no_past_processes: Non hai procesos rematados
         section_header:
           icon_alt: Icona de procesos lexislativos

--- a/config/locales/id-ID/admin.yml
+++ b/config/locales/id-ID/admin.yml
@@ -306,7 +306,6 @@ id:
           title: Proses undang-undang
           filters:
             open: Buka
-            past: Yang lalu
             all: Semua
         new:
           back: Kembali

--- a/config/locales/id-ID/admin.yml
+++ b/config/locales/id-ID/admin.yml
@@ -306,7 +306,6 @@ id:
           title: Proses undang-undang
           filters:
             open: Buka
-            next: Lanjut
             past: Yang lalu
             all: Semua
         new:

--- a/config/locales/id-ID/legislation.yml
+++ b/config/locales/id-ID/legislation.yml
@@ -51,10 +51,8 @@ id:
       index:
         filters:
           open: Proses yang terbuka
-          next: Selanjutnya
           past: Sebelumnya
         no_open_processes: Tidak ada proses yang terbuka
-        no_next_processes: Tidak ada proses yang direncanakan
         no_past_processes: Tidak ada masa lalu proses
         section_header:
           icon_alt: Undang-undang proses ikon

--- a/config/locales/it/admin.yml
+++ b/config/locales/it/admin.yml
@@ -385,7 +385,6 @@ it:
           title: Procedimenti legislativi
           filters:
             open: Aperti
-            past: Precedente
             all: Tutti
         new:
           back: Indietro

--- a/config/locales/it/admin.yml
+++ b/config/locales/it/admin.yml
@@ -385,7 +385,6 @@ it:
           title: Procedimenti legislativi
           filters:
             open: Aperti
-            next: Successivo
             past: Precedente
             all: Tutti
         new:

--- a/config/locales/it/legislation.yml
+++ b/config/locales/it/legislation.yml
@@ -59,10 +59,8 @@ it:
         filter: Filtra
         filters:
           open: Procedimenti aperti
-          next: Successivo
           past: Passato
         no_open_processes: Non ci sono procedimenti aperti
-        no_next_processes: Non ci sono procedimenti in programma
         no_past_processes: Non ci sono procedimenti passati
         section_header:
           icon_alt: Icona dei procedimenti legislativi

--- a/config/locales/nl/admin.yml
+++ b/config/locales/nl/admin.yml
@@ -386,7 +386,6 @@ nl:
           title: Plannen
           filters:
             open: Open
-            next: Volgende
             past: Verleden
             all: Alle
         new:

--- a/config/locales/nl/admin.yml
+++ b/config/locales/nl/admin.yml
@@ -386,7 +386,6 @@ nl:
           title: Plannen
           filters:
             open: Open
-            past: Verleden
             all: Alle
         new:
           back: Terug

--- a/config/locales/nl/legislation.yml
+++ b/config/locales/nl/legislation.yml
@@ -59,10 +59,8 @@ nl:
         filter: Filter
         filters:
           open: Open processen
-          next: Toekomstige
           past: Vorige
         no_open_processes: Er zijn geen open processen
-        no_next_processes: Er zijn geen toekomstige plannen
         no_past_processes: Er zijn geen afgesloten plannen
         section_header:
           icon_alt: Plannen icoon

--- a/config/locales/pl-PL/admin.yml
+++ b/config/locales/pl-PL/admin.yml
@@ -391,7 +391,6 @@ pl:
           title: Procesy legislacyjne
           filters:
             open: Otwórz
-            next: Następny
             past: Ubiegły
             all: Wszystko
         new:

--- a/config/locales/pl-PL/admin.yml
+++ b/config/locales/pl-PL/admin.yml
@@ -391,7 +391,6 @@ pl:
           title: Procesy legislacyjne
           filters:
             open: Otwórz
-            past: Ubiegły
             all: Wszystko
         new:
           back: Wstecz

--- a/config/locales/pl-PL/legislation.yml
+++ b/config/locales/pl-PL/legislation.yml
@@ -60,10 +60,8 @@ pl:
         filter: Filtr
         filters:
           open: Otwarte procesy
-          next: Następny
           past: Ubiegły
         no_open_processes: Nie ma otwartych procesów
-        no_next_processes: Nie ma zaplanowanych procesów
         no_past_processes: Brak ubiegłych procesów
         section_header:
           icon_alt: Ikona procesów legislacyjnych

--- a/config/locales/pt-BR/admin.yml
+++ b/config/locales/pt-BR/admin.yml
@@ -387,7 +387,6 @@ pt-BR:
           title: Processos legislativos
           filters:
             open: Abertos
-            next: Próximo
             past: Passados
             all: Todos
         new:

--- a/config/locales/pt-BR/admin.yml
+++ b/config/locales/pt-BR/admin.yml
@@ -387,7 +387,6 @@ pt-BR:
           title: Processos legislativos
           filters:
             open: Abertos
-            past: Passados
             all: Todos
         new:
           back: Voltar

--- a/config/locales/pt-BR/legislation.yml
+++ b/config/locales/pt-BR/legislation.yml
@@ -59,10 +59,8 @@ pt-BR:
         filter: Filtro
         filters:
           open: Processos abertos
-          next: Próximo
           past: Passado
         no_open_processes: Não existem processos abertos
-        no_next_processes: Não existem processos planejados
         no_past_processes: Não existem processos terminados
         section_header:
           icon_alt: Ícone de processos legislativos

--- a/config/locales/sq-AL/admin.yml
+++ b/config/locales/sq-AL/admin.yml
@@ -387,7 +387,6 @@ sq:
           title: Proceset legjislative
           filters:
             open: Hapur
-            next: Tjetër
             past: E kaluara
             all: Të gjithë
         new:

--- a/config/locales/sq-AL/admin.yml
+++ b/config/locales/sq-AL/admin.yml
@@ -387,7 +387,6 @@ sq:
           title: Proceset legjislative
           filters:
             open: Hapur
-            past: E kaluara
             all: Të gjithë
         new:
           back: Pas

--- a/config/locales/sq-AL/legislation.yml
+++ b/config/locales/sq-AL/legislation.yml
@@ -62,10 +62,8 @@ sq:
         filter: Filtër
         filters:
           open: "\nProceset e hapura"
-          next: Tjetra
           past: E kaluara
         no_open_processes: Nuk ka procese të hapura
-        no_next_processes: Nuk ka procese të planifikuar
         no_past_processes: Nuk ka procese të kaluara
         section_header:
           icon_alt: Ikona e proceseve të legjilacionit

--- a/config/locales/sv-SE/admin.yml
+++ b/config/locales/sv-SE/admin.yml
@@ -386,7 +386,6 @@ sv:
           title: Dialoger
           filters:
             open: Pågående
-            past: Avslutade
             all: Alla
         new:
           back: Tillbaka

--- a/config/locales/sv-SE/admin.yml
+++ b/config/locales/sv-SE/admin.yml
@@ -386,7 +386,6 @@ sv:
           title: Dialoger
           filters:
             open: Pågående
-            next: Kommande
             past: Avslutade
             all: Alla
         new:

--- a/config/locales/sv-SE/legislation.yml
+++ b/config/locales/sv-SE/legislation.yml
@@ -59,10 +59,8 @@ sv:
         filter: Filtrera
         filters:
           open: Pågående processer
-          next: Kommande
           past: Avslutade
         no_open_processes: Det finns inga pågående processer
-        no_next_processes: Det finns inga planerade processer
         no_past_processes: Det finns inga avslutade processer
         section_header:
           icon_alt: Ikon för dialoger

--- a/config/locales/val/admin.yml
+++ b/config/locales/val/admin.yml
@@ -382,7 +382,6 @@ val:
           title: Processos de legislació col·laborativa
           filters:
             open: Oberts
-            next: Pròximament
             past: Finalitzats
             all: Tots
         new:

--- a/config/locales/val/admin.yml
+++ b/config/locales/val/admin.yml
@@ -382,7 +382,6 @@ val:
           title: Processos de legislació col·laborativa
           filters:
             open: Oberts
-            past: Finalitzats
             all: Tots
         new:
           back: Tornar

--- a/config/locales/val/legislation.yml
+++ b/config/locales/val/legislation.yml
@@ -59,10 +59,8 @@ val:
         filter: Filtre
         filters:
           open: Processos actius
-          next: Pròximament
           past: Finalitzats
         no_open_processes: No hi ha processos actius
-        no_next_processes: No hi ha processos planejats
         no_past_processes: No hi ha processos finalitzats
         section_header:
           icon_alt: Icona de Processos legislatius

--- a/config/locales/zh-CN/admin.yml
+++ b/config/locales/zh-CN/admin.yml
@@ -384,7 +384,6 @@ zh-CN:
           title: 立法进程
           filters:
             open: 打开
-            past: 过去的
             all: 所有
         new:
           back: 返回

--- a/config/locales/zh-CN/admin.yml
+++ b/config/locales/zh-CN/admin.yml
@@ -384,7 +384,6 @@ zh-CN:
           title: 立法进程
           filters:
             open: 打开
-            next: 下一个
             past: 过去的
             all: 所有
         new:

--- a/config/locales/zh-CN/legislation.yml
+++ b/config/locales/zh-CN/legislation.yml
@@ -59,10 +59,8 @@ zh-CN:
         filter: 过滤器
         filters:
           open: 开启进程
-          next: 下一个
           past: 过去的
         no_open_processes: 没有已开放的进程
-        no_next_processes: 没有已计划的进程
         no_past_processes: 没有已去过的进程
         section_header:
           icon_alt: 立法进程图标

--- a/config/locales/zh-TW/admin.yml
+++ b/config/locales/zh-TW/admin.yml
@@ -385,7 +385,6 @@ zh-TW:
           title: 立法進程
           filters:
             open: 打開
-            next: 下一個
             past: 過去的
             all: 所有
         new:

--- a/config/locales/zh-TW/admin.yml
+++ b/config/locales/zh-TW/admin.yml
@@ -385,7 +385,6 @@ zh-TW:
           title: 立法進程
           filters:
             open: 打開
-            past: 過去的
             all: 所有
         new:
           back: 返回

--- a/config/locales/zh-TW/legislation.yml
+++ b/config/locales/zh-TW/legislation.yml
@@ -56,10 +56,8 @@ zh-TW:
         filter: 篩選器
         filters:
           open: 開啟進程
-          next: 下一個
           past: 過去的
         no_open_processes: 沒有已開啟的進程
-        no_next_processes: 沒有已計劃的進程
         no_past_processes: 沒有過去的進程
         section_header:
           icon_alt: 立法進程圖標

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -21,17 +21,6 @@ FactoryBot.define do
     result_publication_enabled true
     published true
 
-    trait :next do
-      start_date { Date.current + 2.days }
-      end_date { Date.current + 8.days }
-      debate_start_date { Date.current + 2.days }
-      debate_end_date { Date.current + 4.days }
-      draft_publication_date { Date.current + 5.days }
-      allegations_start_date { Date.current + 5.days }
-      allegations_end_date { Date.current + 7.days }
-      result_publication_date { Date.current + 8.days }
-    end
-
     trait :past do
       start_date { Date.current - 12.days }
       end_date { Date.current - 2.days }

--- a/spec/features/legislation/processes_spec.rb
+++ b/spec/features/legislation/processes_spec.rb
@@ -26,12 +26,9 @@ feature 'Legislation' do
 
   context 'processes home page' do
 
-    scenario 'No processes to be listed' do
+    scenario "No processes to be listed" do
       visit legislation_processes_path
       expect(page).to have_text "There aren't open processes"
-
-      visit legislation_processes_path(filter: 'next')
-      expect(page).to have_text "There aren't planned processes"
     end
 
     scenario 'Processes can be listed' do
@@ -87,24 +84,16 @@ feature 'Legislation' do
 
     scenario 'Filtering processes' do
       create(:legislation_process, title: "Process open")
-      create(:legislation_process, :next, title: "Process next")
       create(:legislation_process, :past, title: "Process past")
       create(:legislation_process, :in_draft_phase, title: "Process in draft phase")
 
       visit legislation_processes_path
       expect(page).to have_content('Process open')
-      expect(page).not_to have_content('Process next')
       expect(page).not_to have_content('Process past')
       expect(page).not_to have_content('Process in draft phase')
 
-      visit legislation_processes_path(filter: 'next')
-      expect(page).not_to have_content('Process open')
-      expect(page).to have_content('Process next')
-      expect(page).not_to have_content('Process past')
-
       visit legislation_processes_path(filter: 'past')
       expect(page).not_to have_content('Process open')
-      expect(page).not_to have_content('Process next')
       expect(page).to have_content('Process past')
     end
 
@@ -112,10 +101,8 @@ feature 'Legislation' do
       before do
         create(:legislation_process, title: "published")
         create(:legislation_process, :not_published, title: "not published")
-        [:next, :past].each do |trait|
-          create(:legislation_process, trait, title: "#{trait} published")
-          create(:legislation_process, :not_published, trait, title: "#{trait} not published")
-        end
+        create(:legislation_process, :past, title: "past published")
+        create(:legislation_process, :not_published, :past, title: "past not published")
       end
 
       it "aren't listed" do
@@ -127,17 +114,6 @@ feature 'Legislation' do
         visit legislation_processes_path
         expect(page).not_to have_content('not published')
         expect(page).to have_content('published')
-      end
-
-      it "aren't listed with next filter" do
-        visit legislation_processes_path(filter: 'next')
-        expect(page).not_to have_content('not published')
-        expect(page).to have_content('next published')
-
-        login_as(administrator)
-        visit legislation_processes_path(filter: 'next')
-        expect(page).not_to have_content('not published')
-        expect(page).to have_content('next published')
       end
 
       it "aren't listed with past filter" do

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -144,14 +144,6 @@ describe Legislation::Process do
       expect(processes_not_in_draft).not_to include(process_with_draft_only_today)
     end
 
-    it "filters next" do
-      next_processes = ::Legislation::Process.next
-
-      expect(next_processes).to include(process_2)
-      expect(next_processes).not_to include(process_1)
-      expect(next_processes).not_to include(process_3)
-    end
-
     it "filters past" do
       past_processes = ::Legislation::Process.past
 


### PR DESCRIPTION
## References

This is the second part of [consul#3181](https://github.com/consul/consul/issues/3181) with https://github.com/AyuntamientoMadrid/consul/pull/1861.

## Objectives

Remove **next legislation processes filter**. 

Now there are only two filters `Open processes` and `Past`.

Also remove  `Past` legislation processes filter on **Admin panel**. 

## Visual Changes

**FRONT VIEW**
<img width="376" alt="process front" src="https://user-images.githubusercontent.com/631897/52359396-1e84cc00-2a3a-11e9-94c6-07c50c2649f2.png">

**ADMIN**
<img width="327" alt="process admin" src="https://user-images.githubusercontent.com/631897/52359404-20e72600-2a3a-11e9-91dc-9a0f4f00ad1b.png">

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.