### PR TITLE
Migrate spending proposal internal comments

### DIFF
--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -58,8 +58,12 @@ class Migrations::SpendingProposal::BudgetInvestment
     def valuation_comment_attributes
       {
         body: spending_proposal.internal_comments,
-        user: spending_proposal.administrator.user
+        user: spending_proposal_administrator
       }
+    end
+
+    def spending_proposal_administrator
+      spending_proposal.administrator.try(&:user) || Administrator.first.user
     end
 
 end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -51,16 +51,14 @@ class Migrations::SpendingProposal::BudgetInvestment
 
     def create_valuation_comments
       if spending_proposal.internal_comments.present?
-        budget_investment.comments.create!(valuation_comment_attributes)
+        budget_investment.valuations.first_or_create!(valuation_comment_attributes)
       end
     end
 
     def valuation_comment_attributes
       {
         body: spending_proposal.internal_comments,
-        user: spending_proposal.administrator.user,
-        commentable: budget_investment,
-        valuation: true
+        user: spending_proposal.administrator.user
       }
     end
 

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -118,5 +118,18 @@ describe Migrations::SpendingProposal::BudgetInvestment do
 
       expect(Comment.count).to eq(0)
     end
+
+    it "verifies if the comment already exists" do
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+
+      expect(Comment.count).to eq(1)
+    end
+
   end
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -58,6 +58,7 @@ describe Migrations::SpendingProposal::BudgetInvestment do
 
       spending_proposal.feasible = false
       spending_proposal.valuation_finished = true
+      spending_proposal.update(administrator: create(:administrator))
 
       spending_proposal.save(validate: false)
 

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -131,5 +131,16 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(Comment.count).to eq(1)
     end
 
+    it "assigns the first administrator if a spending proposal does not have one" do
+      first_admin = create(:administrator).user
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+
+      Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal).update
+
+      expect(Comment.first.author).to eq(first_admin)
+    end
+
   end
 end

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -92,4 +92,30 @@ describe Migrations::SpendingProposal::BudgetInvestment do
 
   end
 
+  context "internal comments" do
+
+    it "migrates internal_comments string to a comment object" do
+      internal_comment = "This project will last 2 years"
+
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      comment = Comment.first
+      expect(Comment.count).to eq(1)
+      expect(comment.body).to eq(internal_comment)
+      expect(comment.author).to eq(spending_proposal.administrator.user)
+      expect(comment.commentable).to eq(budget_investment)
+      expect(comment.valuation).to eq(true)
+    end
+
+    it "does not create a comment if internal_comments is blank" do
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      expect(Comment.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## References

**PR:** https://github.com/AyuntamientoMadrid/consul/pull/1776

## Context
`SpendingProposals` used a string for internal comments, whilst `Budget::Investments` use a `Comment` object instead.

## Objectives

Migrates `Spending Proposals`' internal comments to `Budget::Investment`'s valuation comments.

## Does this PR need a Backport to CONSUL?

Yes 😌