### PR TITLE
[Upstream] Custom pages cards

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -2886,11 +2886,19 @@ table {
 .figure-card {
   display: flex;
   margin: 0 0 $line-height;
+  overflow: hidden;
   position: relative;
+
+  @include breakpoint(medium down) {
+    min-height: $line-height * 4;
+  }
 
   @include breakpoint(medium) {
     max-height: rem-calc(185);
-    overflow: hidden;
+  }
+
+  @include breakpoint(large) {
+    min-height: rem-calc(185);
   }
 
   a {
@@ -2922,8 +2930,16 @@ table {
 
     h3,
     .title {
-      font-size: rem-calc(24);
-      line-height: rem-calc(24);
+      font-size: $base-font-size;
+
+      @include breakpoint(medium) {
+        font-size: rem-calc(20);
+      }
+
+      @include breakpoint(large) {
+        font-size: rem-calc(24);
+        line-height: rem-calc(24);
+      }
     }
 
     span {

--- a/app/controllers/admin/widget/cards_controller.rb
+++ b/app/controllers/admin/widget/cards_controller.rb
@@ -40,37 +40,37 @@ class Admin::Widget::CardsController < Admin::BaseController
 
   private
 
-  def card_params
-    image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
+    def card_params
+      image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
 
-    params.require(:widget_card).permit(
-      :label, :title, :description, :link_text, :link_url,
-      :button_text, :button_url, :alignment, :header, :site_customization_page_id,
-      :columns,
-      translation_params(Widget::Card),
-      image_attributes: image_attributes
-    )
-  end
-
-  def header_card?
-    params[:header_card].present?
-  end
-
-  def redirect_to_customization_page_cards_or_homepage
-    notice = t("admin.site_customization.pages.cards.#{params[:action]}.notice")
-
-    if @card.site_customization_page_id
-      redirect_to admin_site_customization_page_cards_path(page), notice: notice
-    else
-      redirect_to admin_homepage_url, notice: notice
+      params.require(:widget_card).permit(
+        :label, :title, :description, :link_text, :link_url,
+        :button_text, :button_url, :alignment, :header, :site_customization_page_id,
+        :columns,
+        translation_params(Widget::Card),
+        image_attributes: image_attributes
+      )
     end
-  end
 
-  def page
-    ::SiteCustomization::Page.find(@card.site_customization_page_id)
-  end
+    def header_card?
+      params[:header_card].present?
+    end
 
-  def resource
-    Widget::Card.find(params[:id])
-  end
+    def redirect_to_customization_page_cards_or_homepage
+      notice = t("admin.site_customization.pages.cards.#{params[:action]}.notice")
+
+      if @card.site_customization_page_id
+        redirect_to admin_site_customization_page_cards_path(page), notice: notice
+      else
+        redirect_to admin_homepage_url, notice: notice
+      end
+    end
+
+    def page
+      ::SiteCustomization::Page.find(@card.site_customization_page_id)
+    end
+
+    def resource
+      Widget::Card.find(params[:id])
+    end
 end

--- a/app/controllers/admin/widget/cards_controller.rb
+++ b/app/controllers/admin/widget/cards_controller.rb
@@ -46,6 +46,7 @@ class Admin::Widget::CardsController < Admin::BaseController
     params.require(:widget_card).permit(
       :label, :title, :description, :link_text, :link_url,
       :button_text, :button_url, :alignment, :header, :site_customization_page_id,
+      :columns,
       translation_params(Widget::Card),
       image_attributes: image_attributes
     )

--- a/app/views/admin/site_customization/cards/index.html.erb
+++ b/app/views/admin/site_customization/cards/index.html.erb
@@ -7,7 +7,7 @@
     <%= @page.title %> <%= t("admin.site_customization.pages.cards.cards_title") %></h2>
 
   <div class="float-right">
-    <%= link_to t("admin.site_customization.pages.cards.create_card"), 
+    <%= link_to t("admin.site_customization.pages.cards.create_card"),
         new_admin_widget_card_path(page_id: params[:page_id]), class: "button" %>
   </div>
 

--- a/app/views/admin/widget/cards/_form.html.erb
+++ b/app/views/admin/widget/cards/_form.html.erb
@@ -20,6 +20,14 @@
     <%= f.text_field :link_url %>
   </div>
 
+  <% unless @card.header? %>
+    <%= f.label :columns %>
+    <p class="help-text"><%= t("admin.site_customization.pages.cards.columns_help") %></p>
+    <div class="small-12 medium-4 large-2">
+      <%= f.select :columns, (1..12), label: false %>
+    </div>
+  <% end %>
+
   <%= f.hidden_field :header, value: @card.header? %>
   <%= f.hidden_field :site_customization_page_id, value: @card.site_customization_page_id %>
 

--- a/app/views/pages/_card.html.erb
+++ b/app/views/pages/_card.html.erb
@@ -7,7 +7,10 @@
         <%= image_tag(card.image_url(:large), alt: card.image.title) %>
       <% end %>
       <figcaption>
-        <span><%= card.label %></span><br>
+        <% if card.label.present? %>
+          <span><%= card.label %></span>
+        <% end %>
+        <br>
         <h3><%= card.title %></h3>
       </figcaption>
     </figure>

--- a/app/views/pages/_card.html.erb
+++ b/app/views/pages/_card.html.erb
@@ -1,4 +1,5 @@
-<div id="<%= dom_id(card) %>" class="card small-12 medium-6 column margin-bottom end large-4" data-equalizer-watch>
+<div id="<%= dom_id(card) %>"
+     class="card small-12 medium-<%= card.columns %> column margin-bottom end" data-equalizer-watch>
   <%= link_to card.link_url do %>
     <figure class="figure-card">
       <div class="gradient"></div>

--- a/app/views/pages/_cards.html.erb
+++ b/app/views/pages/_cards.html.erb
@@ -1,5 +1,3 @@
-<h3 class="title"><%= t("welcome.cards.title") %></h3>
-
 <div class="row" data-equalizer data-equalizer-on="medium">
   <% @cards.find_each do |card| %>
     <%= render "card", card: card %>

--- a/app/views/welcome/_card.html.erb
+++ b/app/views/welcome/_card.html.erb
@@ -1,4 +1,5 @@
-<div id="<%= dom_id(card) %>" class="card small-12 medium-6 column margin-bottom end <%= 'large-4' unless feed_processes_enabled? %>" data-equalizer-watch>
+<div id="<%= dom_id(card) %>"
+     class="card small-12 medium-<%= card.columns %> column margin-bottom end" data-equalizer-watch>
   <%= link_to card.link_url do %>
     <figure class="figure-card">
       <div class="gradient"></div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -26,9 +26,11 @@
       </div>
     <% end %>
 
-    <div class="small-12 large-4 column">
-      <%= render "processes" %>
-    </div>
+    <% if feed_processes_enabled? %>
+      <div class="small-12 large-4 column">
+        <%= render "processes" %>
+      </div>
+    <% end %>
   </div>
 
   <% if feature?("user.recommendations") && (@recommended_debates.present? || @recommended_proposals.present?) %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -313,6 +313,7 @@ en:
         description: Description
         link_text: Link text
         link_url: Link URL
+        columns: Number of columns
       widget/card/translation:
         label: Label (optional)
         title: Title

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1517,12 +1517,11 @@ en:
           link_url: Link URL
           columns_help: "Width of the card in number of columns. On mobile screens it's always a width of 100%."
           create:
-            notice: "Success"
+            notice: "Card created successfully!"
           update:
-            notice: "Updated"
+            notice: "Card updated successfully"
           destroy:
-            notice: "Removed"
-
+            notice: "Card removed successfully"
     homepage:
       title: Homepage
       description: The active modules appear in the homepage in the same order as here.

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1515,6 +1515,7 @@ en:
           description: Description
           link_text: Link text
           link_url: Link URL
+          columns_help: "Width of the card in number of columns. On mobile screens it's always a width of 100%."
           create:
             notice: "Success"
           update:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -313,6 +313,7 @@ es:
         description: Descripción
         link_text: Texto del enlace
         link_url: URL del enlace
+        columns: Número de columnas
       widget/card/translation:
         label: Etiqueta (opcional)
         title: Título

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1516,6 +1516,7 @@ es:
           description: Descripción
           link_text: Texto del enlace
           link_url: URL del enlace
+          columns_help: "Ancho de la tarjeta en número de columnas. En pantallas móviles siempre es un ancho del 100%."
     homepage:
       title: Homepage
       description: Los módulos activos aparecerán en la homepage en el mismo orden que aquí.

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1517,6 +1517,12 @@ es:
           link_text: Texto del enlace
           link_url: URL del enlace
           columns_help: "Ancho de la tarjeta en número de columnas. En pantallas móviles siempre es un ancho del 100%."
+          create:
+            notice: "¡Tarjeta creada con éxito!"
+          update:
+            notice: "Tarjeta actualizada con éxito"
+          destroy:
+            notice: "Tarjeta eliminada con éxito"
     homepage:
       title: Homepage
       description: Los módulos activos aparecerán en la homepage en el mismo orden que aquí.

--- a/db/migrate/20190131122858_add_columns_to_widget_cards.rb
+++ b/db/migrate/20190131122858_add_columns_to_widget_cards.rb
@@ -1,0 +1,5 @@
+class AddColumnsToWidgetCards < ActiveRecord::Migration
+  def change
+    add_column :widget_cards, :columns, :integer, default: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190124085815) do
+ActiveRecord::Schema.define(version: 20190131122858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1758,6 +1758,7 @@ ActiveRecord::Schema.define(version: 20190124085815) do
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
     t.integer  "site_customization_page_id"
+    t.integer  "columns",                    default: 4
   end
 
   add_index "widget_cards", ["site_customization_page_id"], name: "index_widget_cards_on_site_customization_page_id", using: :btree

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Cards' do
+feature "Cards" do
 
   background do
     admin = create(:administrator).user
@@ -232,8 +232,8 @@ feature 'Cards' do
     image_input = all(".image").last.find("input[type=file]", visible: false)
     attach_file(
       image_input[:id],
-      Rails.root.join('spec/fixtures/files/clippy.jpg'),
+      Rails.root.join("spec/fixtures/files/clippy.jpg"),
       make_visible: true)
-    expect(page).to have_field('widget_card_image_attributes_title', with: "clippy.jpg")
+    expect(page).to have_field("widget_card_image_attributes_title", with: "clippy.jpg")
   end
 end

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -24,7 +24,7 @@ feature 'Cards' do
     attach_image_to_card
     click_button "Create card"
 
-    expect(page).to have_content "Success"
+    expect(page).to have_content "Card created successfully!"
     expect(page).to have_css(".homepage-card", count: 1)
 
     card = Widget::Card.last
@@ -74,7 +74,7 @@ feature 'Cards' do
     fill_in "widget_card_link_url", with: "consul.dev updated"
     click_button "Save card"
 
-    expect(page).to have_content "Updated"
+    expect(page).to have_content "Card updated successfully"
 
     expect(page).to have_css(".homepage-card", count: 1)
     within("#widget_card_#{Widget::Card.last.id}") do
@@ -97,7 +97,7 @@ feature 'Cards' do
       end
     end
 
-    expect(page).to have_content "Removed"
+    expect(page).to have_content "Card removed successfully"
     expect(page).to have_css(".homepage-card", count: 0)
   end
 
@@ -114,7 +114,7 @@ feature 'Cards' do
       fill_in "widget_card_link_url", with: "consul.dev"
       click_button "Create header"
 
-      expect(page).to have_content "Success"
+      expect(page).to have_content "Card created successfully!"
 
       within("#header") do
         expect(page).to have_css(".homepage-card", count: 1)

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -55,6 +55,18 @@ feature 'Cards' do
     end
   end
 
+  scenario "Show" do
+    card_1 = create(:widget_card, title: "Card homepage large", columns: 8)
+    card_2 = create(:widget_card, title: "Card homepage medium", columns: 4)
+    card_3 = create(:widget_card, title: "Card homepage small", columns: 2)
+
+    visit root_path
+
+    expect(page).to have_css("#widget_card_#{card_1.id}.medium-8")
+    expect(page).to have_css("#widget_card_#{card_2.id}.medium-4")
+    expect(page).to have_css("#widget_card_#{card_3.id}.medium-2")
+  end
+
   scenario "Edit" do
     card = create(:widget_card)
 

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -131,7 +131,7 @@ feature 'Cards' do
     end
 
     context "Page card" do
-      let!(:custom_page) { create(:site_customization_page) }
+      let!(:custom_page) { create(:site_customization_page, :published) }
 
       scenario "Create", :js do
         visit admin_site_customization_pages_path
@@ -143,6 +143,20 @@ feature 'Cards' do
 
         expect(page).to have_current_path admin_site_customization_page_cards_path(custom_page)
         expect(page).to have_content "Card for a custom page"
+      end
+
+      scenario "Show" do
+        card_1 = create(:widget_card, page: custom_page, title: "Card large", columns: 8)
+        card_2 = create(:widget_card, page: custom_page, title: "Card medium", columns: 4)
+        card_3 = create(:widget_card, page: custom_page, title: "Card small", columns: 2)
+
+        visit (custom_page).url
+
+        expect(page).to have_css(".card", count: 3)
+
+        expect(page).to have_css("#widget_card_#{card_1.id}.medium-8")
+        expect(page).to have_css("#widget_card_#{card_2.id}.medium-4")
+        expect(page).to have_css("#widget_card_#{card_3.id}.medium-2")
       end
 
       scenario "Edit", :js do

--- a/spec/features/admin/widgets/cards_spec.rb
+++ b/spec/features/admin/widgets/cards_spec.rb
@@ -159,6 +159,21 @@ feature 'Cards' do
         expect(page).to have_css("#widget_card_#{card_3.id}.medium-2")
       end
 
+      scenario "Show label only if it is present" do
+        card_1 = create(:widget_card, page: custom_page, title: "Card one", label: "My label")
+        card_2 = create(:widget_card, page: custom_page, title: "Card two")
+
+        visit (custom_page).url
+
+        within("#widget_card_#{card_1.id}") do
+          expect(page).to have_selector("span", text: "My label")
+        end
+
+        within("#widget_card_#{card_2.id}") do
+          expect(page).not_to have_selector("span")
+        end
+      end
+
       scenario "Edit", :js do
         create(:widget_card, page: custom_page, title: "Original title")
 


### PR DESCRIPTION
## References

Upstream from https://github.com/consul/consul/pull/3252

## Background

Admins can create cards for homepage on `/admin/widget/cards/new` and  since #3149 also for custom pages on `/admin/widget/cards/new?page_id=N`.

## Objectives

- Add **columns** to widget cards: this add a select on each card new form to select the number of columns for their width (for a better UX on mobile screens it's always 100%)
- Improve notice message for pages cards.
- Improve CSS layout.
- Show card label only if it is present: until now was showing an empty span.
- Remove unnecessary title on page cards: on custom pages a "Featured title" is not necessary.
- Add columns on welcome card view: I include this _feature_ for the cards created for the homepage.
- Fix hound warnings. Clean code! ✊🤓 

## Notes

For cards you can use **from 1 to 12 columns**, based on [Foundation Float Grid].(https://foundation.zurb.com/sites/docs/grid.html)

## Visual Changes
**New select on admin card new form**
![screenshot 2019-01-31 at 15 53 34](https://user-images.githubusercontent.com/631897/52069163-79bc4780-257e-11e9-97d7-c4fd93d7bb4f.png)
![screenshot 2019-01-31 at 15 53 40](https://user-images.githubusercontent.com/631897/52069164-7a54de00-257e-11e9-9ba5-f6d501b82f21.png)

**Now you can create more interesting layouts**
![layout](https://user-images.githubusercontent.com/631897/52068940-01558680-257e-11e9-99c1-f11a69388fe9.png)

**BEFORE if a card didn't have a label show a blank span**
![screenshot 2019-01-31 at 14 10 49](https://user-images.githubusercontent.com/631897/52069107-5beee280-257e-11e9-8049-1c5a46fe7f45.png)

**Now show card label only if it is present**
![screenshot 2019-01-31 at 14 11 03](https://user-images.githubusercontent.com/631897/52069113-5e513c80-257e-11e9-8600-7a4d3c5bf83a.png)

**You can use from 1 to 12 columns**
![screenshot 2019-01-31 at 14 34 32](https://user-images.githubusercontent.com/631897/52069030-3bbf2380-257e-11e9-942d-5a1c657fe2f1.png)
![2](https://user-images.githubusercontent.com/631897/52069448-06670580-257f-11e9-8fde-4713b9d6735c.jpg)