### PR TITLE
Migrate spending proposal ballots

### DIFF
--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -21,7 +21,7 @@ class Migrations::SpendingProposal::Ballot
       budget_investment = find_budget_investment(spending_proposal)
 
       ballot_line = new_ballot_line(budget_investment)
-      if ballot_line && ballot_line.save
+      if ballot_line_valid?(ballot_line) && ballot_line.save
         print "."
       else
         puts "Error adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n"
@@ -47,6 +47,14 @@ class Migrations::SpendingProposal::Ballot
       if budget_investment
         budget_investment_ballot.lines.new(investment: budget_investment)
       end
+    end
+
+    def ballot_line_valid?(ballot_line)
+      ballot_line && ballot_line_does_not_exist?(ballot_line)
+    end
+
+    def ballot_line_does_not_exist?(ballot_line)
+      budget_investment_ballot.investments.exclude?(ballot_line.investment)
     end
 
     def budget_investment_ballot_attributes

--- a/lib/migrations/spending_proposal/ballots.rb
+++ b/lib/migrations/spending_proposal/ballots.rb
@@ -1,0 +1,21 @@
+class Migrations::SpendingProposal::Ballots
+  attr_accessor :spending_proposal_ballots
+
+  def initialize
+    @spending_proposal_ballots = load_ballots
+  end
+
+  def migrate_all
+    spending_proposal_ballots.each do |spending_proposal_ballot|
+      budget_investment_ballot = Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot)
+      budget_investment_ballot.migrate_ballot
+    end
+  end
+
+  private
+
+    def load_ballots
+      ::Ballot.all
+    end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -49,4 +49,14 @@ namespace :spending_proposals do
     Migrations::SpendingProposal::BudgetInvestments.new.update_all
     puts "Finished"
   end
+
+  desc "Migrates spending proposals ballots to budget investments ballots"
+  task migrate_ballots: :environment do
+    require "migrations/spending_proposal/ballots"
+
+    puts "Starting to migrate spending proposal ballots"
+    Migrations::SpendingProposal::Ballots.new.migrate_all
+    puts "Finished"
+  end
+
 end

--- a/spec/lib/migrations/spending_proposals/ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/ballot_spec.rb
@@ -82,6 +82,19 @@ describe Migrations::SpendingProposal::Ballot do
         expect(budget_investment_ballot.investments).not_to include(budget_investment3)
       end
 
+      it "verifies that the ballot line does not exist" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments.count).to eq(1)
+      end
+
       it "gracefully handles missing corresponding budget investment" do
         spending_proposal = create(:spending_proposal, feasible: true)
         spending_proposal_ballot.spending_proposals << spending_proposal

--- a/spec/lib/migrations/spending_proposals/ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/ballot_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+require "migrations/spending_proposal/ballot"
+
+describe Migrations::SpendingProposal::Ballot do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let!(:spending_proposal_ballot) { create(:ballot) }
+
+  describe "#initialize" do
+
+    it "initializes the spending proposal ballot and corresponding budget investment ballot" do
+      migration = Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot)
+
+      expect(migration.spending_proposal_ballot.class).to eq(Ballot)
+      expect(migration.spending_proposal_ballot).to eq(spending_proposal_ballot)
+
+      expect(migration.budget_investment_ballot.class).to eq(Budget::Ballot)
+      expect(migration.budget_investment_ballot.budget).to eq(budget)
+      expect(migration.budget_investment_ballot.user).to eq(spending_proposal_ballot.user)
+    end
+
+  end
+
+  describe "#migrate_ballot" do
+
+    context "ballot" do
+
+      it "migrates the ballot" do
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.budget).to eq(budget)
+        expect(budget_investment_ballot.user).to eq(spending_proposal_ballot.user)
+      end
+
+      it "verifies if ballot has already been created" do
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates a single ballot line" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments).to eq([budget_investment])
+      end
+
+      it "migrates multiple ballot lines" do
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        spending_proposal_ballot.spending_proposals << spending_proposal1
+        spending_proposal_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+
+        expect(budget_investment_ballot.investments).to include(budget_investment1)
+        expect(budget_investment_ballot.investments).to include(budget_investment2)
+        expect(budget_investment_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "gracefully handles missing corresponding budget investment" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot.spending_proposals << spending_proposal
+
+        expect{ Migrations::SpendingProposal::Ballot.new(spending_proposal_ballot).migrate_ballot }
+        .not_to raise_error
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposals/ballots_spec.rb
+++ b/spec/lib/migrations/spending_proposals/ballots_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+require "migrations/spending_proposal/ballots"
+
+describe Migrations::SpendingProposal::Ballots do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+  let!(:spending_proposal_ballot1) { create(:ballot) }
+  let!(:spending_proposal_ballot2) { create(:ballot) }
+
+  describe "#initialize" do
+
+    it "initializes all spending proposal ballots" do
+      migration = Migrations::SpendingProposal::Ballots.new
+
+      expect(migration.spending_proposal_ballots.count).to eq(2)
+      expect(migration.spending_proposal_ballots).to include(spending_proposal_ballot1)
+      expect(migration.spending_proposal_ballots).to include(spending_proposal_ballot2)
+    end
+
+  end
+
+  describe "#migrate_all" do
+
+    context "ballot" do
+
+      it "migrates all ballots" do
+        Migrations::SpendingProposal::Ballots.new.migrate_all
+
+        expect(Budget::Ballot.count).to eq(2)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates ballot lines for all ballots" do
+        spending_proposal = create(:spending_proposal, feasible: true)
+        spending_proposal_ballot1.spending_proposals << spending_proposal
+        spending_proposal_ballot2.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::Ballots.new.migrate_all
+
+        expect(Budget::Ballot::Line.count).to eq(2)
+
+        budget_investment_ballot1 = Budget::Ballot.first
+        expect(budget_investment_ballot1.investments).to eq([budget_investment])
+
+        budget_investment_ballot2 = Budget::Ballot.second
+        expect(budget_investment_ballot2.investments).to eq([budget_investment])
+      end
+
+    end
+  end
+end

--- a/spec/support/common_actions/budgets.rb
+++ b/spec/support/common_actions/budgets.rb
@@ -10,4 +10,14 @@ module Budgets
       expect(page).to have_content "Remove"
     end
   end
+
+  def budget_invesment_for(spending_proposal, options={})
+    attributes = {
+      original_spending_proposal_id: spending_proposal.id,
+      selected: true
+    }.merge(options)
+
+    create(:budget_investment, attributes)
+  end
+
 end


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Objectives

Migrate spending proposal ballots to budget investment ballots

## Does this PR need a Backport to CONSUL?

Yes 😌

## Notes

To migrate spending proposal ballots run this rake task:

```
bin/rake spending_proposals:migrate_ballots
```
