### PR TITLE
[Upstream] Improve color picker on admin legislation process

### DIFF
--- a/app/assets/javascripts/forms.js.coffee
+++ b/app/assets/javascripts/forms.js.coffee
@@ -24,11 +24,16 @@ App.Forms =
     )
 
   synchronizeInputs: ->
-    $("[name='progress_bar[percentage]']").on
+    progress_bar = "[name='progress_bar[percentage]']"
+    process_background = "[name='legislation_process[background_color]']"
+    process_font = "[name='legislation_process[font_color]']"
+
+    inputs = $("#{progress_bar}, #{process_background}, #{process_font}")
+    inputs.on
       input: ->
         $("[name='#{this.name}']").val($(this).val())
 
-    $("[name='progress_bar[percentage]'][type='range']").trigger("input")
+    inputs.trigger("input")
 
   hideOrShowFieldsAfterSelection: ->
     $("[name='progress_bar[kind]']").on

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -215,26 +215,28 @@
     <h3><%= t("admin.legislation.processes.form.banner_title") %></h3>
   </div>
 
-  <div class="small-3 column">
-    <%= f.label :sections, t("admin.legislation.processes.form.banner_background_color") %>
+  <div class="small-6 large-3 column">
+    <%= f.label :background_color %>
+    <p class="help-text"><%= t("admin.legislation.processes.form.color_help") %></p>
     <div class="row collapse">
-      <div class="small-6 column">
-        <%= color_field(:process, :background_color) %>
+      <div class="small-12 medium-6 column">
+        <%= f.text_field :background_color, label: false, type: :color %>
       </div>
-      <div class="small-6 column">
-        <%= f.text_field :background_color, label: false %>
+      <div class="small-12 medium-6 column">
+        <%= f.text_field :background_color, label: false, placeholder: "#e7f2fc" %>
       </div>
     </div>
   </div>
 
-  <div class="small-3 column end">
-    <%= f.label :sections, t("admin.legislation.processes.form.banner_font_color") %>
+  <div class="small-6 large-3 column end">
+    <%= f.label :font_color %>
+    <p class="help-text"><%= t("admin.legislation.processes.form.color_help") %></p>
     <div class="row collapse">
-      <div class="small-6 column">
-        <%= color_field(:process, :font_color) %>
+      <div class="small-12 medium-6 column">
+        <%= f.text_field :font_color, label: false, type: :color %>
       </div>
-      <div class="small-6 column">
-        <%= f.text_field :font_color, label: false %>
+      <div class="small-12 medium-6 column">
+        <%= f.text_field :font_color, label: false, placeholder: "#222222" %>
       </div>
     </div>
   </div>

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -216,27 +216,31 @@
   </div>
 
   <div class="small-6 large-3 column">
-    <%= f.label :background_color %>
+    <%= f.label :background_color, nil, for: "background_color_input" %>
     <p class="help-text"><%= t("admin.legislation.processes.form.color_help") %></p>
     <div class="row collapse">
       <div class="small-12 medium-6 column">
         <%= f.text_field :background_color, label: false, type: :color %>
       </div>
       <div class="small-12 medium-6 column">
-        <%= f.text_field :background_color, label: false, placeholder: "#e7f2fc" %>
+        <%= f.text_field :background_color, label: false,
+                                            placeholder: "#e7f2fc",
+                                            id: "background_color_input" %>
       </div>
     </div>
   </div>
 
   <div class="small-6 large-3 column end">
-    <%= f.label :font_color %>
+    <%= f.label :font_color, nil, for: "font_color_input" %>
     <p class="help-text"><%= t("admin.legislation.processes.form.color_help") %></p>
     <div class="row collapse">
       <div class="small-12 medium-6 column">
         <%= f.text_field :font_color, label: false, type: :color %>
       </div>
       <div class="small-12 medium-6 column">
-        <%= f.text_field :font_color, label: false, placeholder: "#222222" %>
+        <%= f.text_field :font_color, label: false,
+                                      placeholder: "#222222",
+                                      id: "font_color_input" %>
       </div>
     </div>
   </div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -254,6 +254,8 @@ en:
         allegations_start_date: Allegations start date
         allegations_end_date: Allegations end date
         result_publication_date: Final result publication date
+        background_color: Background color
+        font_color: Font color
       legislation/process/translation:
         title: Process Title
         summary: Summary

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -461,6 +461,7 @@ en:
           homepage_description: Here you can explain the content of the process
           homepage_enabled: Homepage enabled
           banner_title: Header colors
+          color_help: Hexadecimal format
         index:
           create: New process
           delete: Delete

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -461,8 +461,6 @@ en:
           homepage_description: Here you can explain the content of the process
           homepage_enabled: Homepage enabled
           banner_title: Header colors
-          banner_background_color: Background colour
-          banner_font_color: Font colour
         index:
           create: New process
           delete: Delete

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -254,6 +254,8 @@ es:
         allegations_start_date: Fecha de inicio de alegaciones
         allegations_end_date: Fecha de fin de alegaciones
         result_publication_date: Fecha de publicación del resultado final
+        background_color: Color del fondo
+        font_color: Color del texto
       legislation/process/translation:
         title: Título del proceso
         summary: Resumen

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -462,8 +462,6 @@ es:
           homepage_description: Aquí puedes explicar el contenido del proceso
           homepage_enabled: Homepage activada
           banner_title: Colores del encabezado
-          banner_background_color: Color de fondo
-          banner_font_color: Color del texto
         index:
           create: Nuevo proceso
           delete: Borrar

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -462,6 +462,7 @@ es:
           homepage_description: Aquí puedes explicar el contenido del proceso
           homepage_enabled: Homepage activada
           banner_title: Colores del encabezado
+          color_help: Formato hexadecimal
         index:
           create: Nuevo proceso
           delete: Borrar


### PR DESCRIPTION
## References
Upstream from https://github.com/consul/consul/pull/3277/

https://github.com/consul/consul/pull/3152 added the possibility to change background and font colours for legislation processes header.

## Objectives

Synchronise color inputs make much easier to users.

## Visual Changes

**Add placeholder with default values and a little help text**
![help](https://user-images.githubusercontent.com/631897/52430750-147ccf00-2b07-11e9-89d1-daf08b59fb0b.png)

**Now the inputs are synchronised**
![color](https://user-images.githubusercontent.com/631897/52430771-20689100-2b07-11e9-9e2e-9e78cf4e6ac6.png)

**You can update it using input color field**
![automatic](https://user-images.githubusercontent.com/631897/52430846-4857f480-2b07-11e9-9ee6-02365282c4bf.gif)

**Or you can introduce a hexadecimal value manually**
![manual](https://user-images.githubusercontent.com/631897/52430850-4aba4e80-2b07-11e9-8177-5e78de01013a.gif)

## Notes

Native html `<input type="color">` it's [not compatible with IE or Safari](https://caniuse.com/#search=color) but you can introduce value manually.