### PR TITLE
Migrate spending proposal delegated ballots

### DIFF
--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -8,7 +8,7 @@ class Migrations::SpendingProposal::Ballot
   end
 
   def migrate_ballot
-    if budget_investment_ballot.save
+    if budget_investment_ballot_valid?
       puts "."
 
       migrate_ballot_lines
@@ -42,6 +42,10 @@ class Migrations::SpendingProposal::Ballot
 
     def find_or_initialize_budget_investment_ballot
       Budget::Ballot.find_or_initialize_by(budget_investment_ballot_attributes)
+    end
+
+    def budget_investment_ballot_valid?
+      budget_investment_ballot.new_record? && budget_investment_ballot.save
     end
 
     def new_ballot_line(budget_investment)

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -1,7 +1,8 @@
 class Migrations::SpendingProposal::Ballot
-  attr_accessor :spending_proposal_ballot, :budget_investment_ballot
+  attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
 
-  def initialize(spending_proposal_ballot)
+  def initialize(spending_proposal_ballot, represented_user=nil)
+    @represented_user = represented_user
     @spending_proposal_ballot = spending_proposal_ballot
     @budget_investment_ballot = find_or_initialize_budget_investment_ballot
   end
@@ -60,8 +61,12 @@ class Migrations::SpendingProposal::Ballot
     def budget_investment_ballot_attributes
       {
         budget: budget,
-        user: spending_proposal_ballot.user
+        user: user
       }
+    end
+
+    def user
+      represented_user || spending_proposal_ballot.user
     end
 
 end

--- a/lib/migrations/spending_proposal/delegated_ballot.rb
+++ b/lib/migrations/spending_proposal/delegated_ballot.rb
@@ -1,0 +1,28 @@
+class Migrations::SpendingProposal::DelegatedBallot
+  attr_accessor :delegated_ballot
+
+  def initialize(delegated_ballot)
+    @delegated_ballot = delegated_ballot
+  end
+
+  def migrate_delegated_ballot
+    represented_users.each do |represented_user|
+      migrate_ballot(represented_user)
+    end
+  end
+
+  private
+
+    def represented_users
+      forum.represented_users
+    end
+
+    def forum
+      delegated_ballot.user.forum
+    end
+
+    def migrate_ballot(represented_user)
+      Migrations::SpendingProposal::Ballot.new(delegated_ballot, represented_user).migrate_ballot
+    end
+
+end

--- a/lib/migrations/spending_proposal/delegated_ballots.rb
+++ b/lib/migrations/spending_proposal/delegated_ballots.rb
@@ -1,0 +1,25 @@
+class Migrations::SpendingProposal::DelegatedBallots
+  attr_accessor :delegated_ballots
+
+  def initialize
+    @delegated_ballots = load_delegated_ballots
+  end
+
+  def migrate_all
+    delegated_ballots.each do |ballot|
+      migrate_delegated_ballot(ballot)
+    end
+  end
+
+  private
+
+    def load_delegated_ballots
+      Ballot.where(user: User.forums)
+    end
+
+
+    def migrate_delegated_ballot(ballot)
+      Migrations::SpendingProposal::DelegatedBallot.new(ballot).migrate_delegated_ballot
+    end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -59,4 +59,14 @@ namespace :spending_proposals do
     puts "Finished"
   end
 
+
+  desc "Migrates spending proposals delegated ballots to budget investments ballots"
+  task migrate_ballots: :environment do
+    require "migrations/spending_proposal/delegated_ballots"
+
+    puts "Starting to migrate spending proposals delegated ballots"
+    Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+    puts "Finished"
+  end
+
 end

--- a/spec/lib/migrations/spending_proposals/delegated_ballot_spec.rb
+++ b/spec/lib/migrations/spending_proposals/delegated_ballot_spec.rb
@@ -1,0 +1,218 @@
+require "rails_helper"
+require "migrations/spending_proposal/delegated_ballot"
+
+describe Migrations::SpendingProposal::DelegatedBallot do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+
+  describe "#initialize" do
+
+    it "initializes a delegated spending proposal ballot" do
+      forum = create(:forum)
+      delegated_ballot = create(:ballot, user: forum.user)
+
+      migration = Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot)
+
+      expect(migration.delegated_ballot.class).to eq(Ballot)
+      expect(migration.delegated_ballot.user).to eq(forum.user)
+    end
+
+  end
+
+  describe "#migrate_delegated_ballot" do
+
+    context "ballot" do
+
+      it "migrates a delegated ballot for a single represented user" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_ballot = Budget::Ballot.first
+        expect(budget_ballot.user).to eq(represented_user)
+      end
+
+      it "migrates a delegated ballot for each represented user" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user1 = create(:represented_user, representative: forum)
+        represented_user2 = create(:represented_user, representative: forum)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(2)
+
+        budget_ballot_users = Budget::Ballot.all.map(&:user)
+        expect(budget_ballot_users).to include(represented_user1)
+        expect(budget_ballot_users).to include(represented_user2)
+      end
+
+      it "only creates delegated ballots if there are represented users" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(0)
+      end
+
+      it "verifies if represented user also created a ballot" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user = create(:represented_user, representative: forum)
+        represented_user_ballot = create(:budget_ballot, user: represented_user, budget: budget)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_ballot = Budget::Ballot.first
+        expect(budget_ballot.user).to eq(represented_user)
+      end
+
+      it "verifies if delegated ballot has already been migrated" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_ballot = Budget::Ballot.first
+        expect(budget_ballot.user).to eq(represented_user)
+      end
+
+    end
+
+    context "ballot lines" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates a single delegated ballot line" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        spending_proposal = create(:spending_proposal, feasible: true)
+        delegated_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(budget_investment_ballot.investments).to eq([budget_investment])
+      end
+
+      it "migrates all delegated ballot lines for a ballot" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot.spending_proposals << spending_proposal1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        budget_investment_ballot = Budget::Ballot.first
+
+        expect(budget_investment_ballot.investments).to include(budget_investment1)
+        expect(budget_investment_ballot.investments).to include(budget_investment2)
+        expect(budget_investment_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "migrates all delegated ballot lines for each represented user" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user1 = create(:represented_user, representative: forum)
+        represented_user2 = create(:represented_user, representative: forum)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot.spending_proposals << spending_proposal1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        represented_user1_ballot = Budget::Ballot.where(user: represented_user1).first
+        expect(represented_user1_ballot.investments).to include(budget_investment1)
+        expect(represented_user1_ballot.investments).to include(budget_investment2)
+        expect(represented_user1_ballot.investments).not_to include(budget_investment3)
+
+        represented_user2_ballot = Budget::Ballot.where(user: represented_user2).first
+        expect(represented_user2_ballot.investments).to include(budget_investment1)
+        expect(represented_user2_ballot.investments).to include(budget_investment2)
+        expect(represented_user2_ballot.investments).not_to include(budget_investment3)
+      end
+
+      it "verifies if represented user already has ballot lines" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+
+        represented_user = create(:represented_user, representative: forum)
+        represented_user_ballot = create(:budget_ballot, user: represented_user, budget: budget)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+
+        represented_user_ballot.investments << budget_investment1
+        delegated_ballot.spending_proposals << spending_proposal2
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot.count).to eq(1)
+
+        budget_investment_ballot = Budget::Ballot.first
+        expect(represented_user_ballot.user).to eq(represented_user)
+
+        expect(represented_user_ballot.investments).to include(budget_investment1)
+        expect(represented_user_ballot.investments).not_to include(budget_investment2)
+      end
+
+      it "verifies if delegated ballot lines have already been migrated" do
+        forum = create(:forum)
+        delegated_ballot = create(:ballot, user: forum.user)
+        represented_user = create(:represented_user, representative: forum)
+
+        spending_proposal = create(:spending_proposal, feasible: true)
+        delegated_ballot.spending_proposals << spending_proposal
+
+        budget_investment = budget_invesment_for(spending_proposal, heading: heading)
+
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+        Migrations::SpendingProposal::DelegatedBallot.new(delegated_ballot).migrate_delegated_ballot
+
+        expect(Budget::Ballot::Line.count).to eq(1)
+        expect(Budget::Ballot::Line.first.investment).to eq(budget_investment)
+      end
+
+    end
+  end
+end

--- a/spec/lib/migrations/spending_proposals/delegated_ballots_spec.rb
+++ b/spec/lib/migrations/spending_proposals/delegated_ballots_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+require "migrations/spending_proposal/delegated_ballots"
+
+describe Migrations::SpendingProposal::DelegatedBallots do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+
+  describe "#initialize" do
+
+    it "initializes all delegated spending proposal ballots" do
+      forum1 = create(:forum)
+      delegated_ballot1 = create(:ballot, user: forum1.user)
+
+      forum2 = create(:forum)
+      delegated_ballot2 = create(:ballot, user: forum2.user)
+
+      non_delegated_ballot = create(:ballot)
+
+      migration = Migrations::SpendingProposal::DelegatedBallots.new
+
+      expect(migration.delegated_ballots.count).to eq(2)
+      expect(migration.delegated_ballots).to include(delegated_ballot1)
+      expect(migration.delegated_ballots).to include(delegated_ballot2)
+      expect(migration.delegated_ballots).not_to include(non_delegated_ballot)
+    end
+
+  end
+
+  describe "#migrate_all" do
+
+    context "ballot" do
+
+      it "migrates all delegated spending proposal ballots to budget investment ballots" do
+        forum1 = create(:forum)
+        represented_user1 = create(:represented_user, representative: forum1)
+        delegated_ballot1 = create(:ballot, user: forum1.user)
+
+        forum2 = create(:forum)
+        represented_user2 = create(:represented_user, representative: forum2)
+        delegated_ballot2 = create(:ballot, user: forum2.user)
+
+        Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+
+        expect(Budget::Ballot.count).to eq(2)
+
+        budget_ballot_users = Budget::Ballot.all.map(&:user)
+        expect(budget_ballot_users).to include(represented_user1)
+        expect(budget_ballot_users).to include(represented_user2)
+      end
+
+    end
+
+    context "ballot line" do
+
+      let!(:group)   { create(:budget_group, budget: budget) }
+      let!(:heading) { create(:budget_heading, group: group) }
+
+      it "migrates all delegated spending proposal ballot lines to budget investment ballot lines" do
+        forum1 = create(:forum)
+        represented_user1 = create(:represented_user, representative: forum1)
+        delegated_ballot1 = create(:ballot, user: forum1.user)
+
+        forum2 = create(:forum)
+        represented_user2 = create(:represented_user, representative: forum2)
+        delegated_ballot2 = create(:ballot, user: forum2.user)
+
+        spending_proposal1 = create(:spending_proposal, feasible: true)
+        spending_proposal2 = create(:spending_proposal, feasible: true)
+        spending_proposal3 = create(:spending_proposal, feasible: true)
+
+        budget_investment1 = budget_invesment_for(spending_proposal1, heading: heading)
+        budget_investment2 = budget_invesment_for(spending_proposal2, heading: heading)
+        budget_investment3 = budget_invesment_for(spending_proposal3, heading: heading)
+
+        delegated_ballot1.spending_proposals << spending_proposal1
+        delegated_ballot1.spending_proposals << spending_proposal2
+
+        delegated_ballot2.spending_proposals << spending_proposal1
+
+        Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+
+        represented_user_ballot1 = Budget::Ballot.where(user: represented_user1).first
+
+        expect(represented_user_ballot1.investments).to include(budget_investment1)
+        expect(represented_user_ballot1.investments).to include(budget_investment2)
+        expect(represented_user_ballot1.investments).not_to include(budget_investment3)
+
+        represented_user_ballot2 = Budget::Ballot.where(user: represented_user2).first
+
+        expect(represented_user_ballot2.investments).to include(budget_investment1)
+        expect(represented_user_ballot2.investments).not_to include(budget_investment2)
+        expect(represented_user_ballot2.investments).not_to include(budget_investment3)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
## References

**PR**: Migrate spending proposal ballots https://github.com/AyuntamientoMadrid/consul/pull/1868

## Context 

A Delegated Ballot is Ballot created by a Forum.

A Forum has many Represented Users.

## Objectives

Create a Budget Investment Ballot from the Spending Proposal Ballot of a Forum, for each Represented User.

## Does this PR need a Backport to CONSUL?

No, delegation is not in CONSUL.

## Notes

⚠️ To migrate delegated spending proposal ballots run the following migration:

```
bin/rake spending_proposals:migrate_delegated_ballots
```
