### PR TITLE
Show headings in budgets landing page when translations are missing

### DIFF
--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -27,7 +27,7 @@ class Budget
     delegate :budget, :budget_id, to: :group, allow_nil: true
 
     scope :i18n,                  -> { includes(:translations) }
-    scope :with_group,            -> { joins(group: :translations).where("budget_group_translations.locale = ?", I18n.locale) }
+    scope :with_group,            -> { includes(group: :translations) }
     scope :order_by_group_name,   -> { i18n.with_group.order("budget_group_translations.name DESC") }
     scope :order_by_heading_name, -> { i18n.with_group.order("budget_heading_translations.name") }
     scope :order_by_name,         -> { i18n.with_group.order_by_group_name.order_by_heading_name }

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -73,6 +73,27 @@ feature 'Budgets' do
       end
     end
 
+    scenario "Show groups and headings for missing translations" do
+      group1 = create(:budget_group, budget: last_budget)
+      group2 = create(:budget_group, budget: last_budget)
+
+      heading1 = create(:budget_heading, group: group1)
+      heading2 = create(:budget_heading, group: group2)
+
+      last_budget.update_attributes(phase: "informing")
+
+      visit budgets_path locale: :es
+
+      within("#budget_info") do
+        expect(page).to have_content group1.name
+        expect(page).to have_content group2.name
+        expect(page).to have_content heading1.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading1)
+        expect(page).to have_content heading2.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading2)
+      end
+    end
+
     scenario "Show informing index without links" do
       last_budget.update_attributes(phase: "informing")
       group = create(:budget_group, budget: last_budget)


### PR DESCRIPTION
## Objectives

Show all the groups and headings in the Participatory Budgets landing page when translations for groups are missing

## Does this PR need a Backport to CONSUL?
Yes