### PR TITLE
Show headings in budgets landing page when translations are missing

### DIFF
--- a/app/helpers/budget_headings_helper.rb
+++ b/app/helpers/budget_headings_helper.rb
@@ -3,7 +3,7 @@ module BudgetHeadingsHelper
   def budget_heading_select_options(budget)
     budget.headings.order_by_name.map do |heading|
       [heading.name_scoped_by_group, heading.id]
-    end
+    end.uniq
   end
 
   def heading_link(assigned_heading = nil, budget = nil)

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -27,7 +27,7 @@ class Budget
     delegate :budget, :budget_id, to: :group, allow_nil: true
 
     scope :i18n,                  -> { includes(:translations) }
-    scope :with_group,            -> { joins(group: :translations).where("budget_group_translations.locale = ?", I18n.locale) }
+    scope :with_group,            -> { joins(group: :translations) }
     scope :order_by_group_name,   -> { i18n.with_group.order("budget_group_translations.name DESC") }
     scope :order_by_heading_name, -> { i18n.with_group.order("budget_heading_translations.name") }
     scope :order_by_name,         -> { i18n.with_group.order_by_group_name.order_by_heading_name }

--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -32,7 +32,7 @@
 <div class="row margin">
   <div id="headings" class="small-12 medium-7 column select-district">
     <div class="row">
-      <% @group.headings.order_by_group_name.each_slice(7) do |slice| %>
+      <% @group.headings.order_by_group_name.to_a.uniq.each_slice(7) do |slice| %>
         <div class="small-6 medium-4 column end">
           <% slice.each do |heading| %>
             <span id="<%= dom_id(heading) %>"

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -70,7 +70,7 @@
           <% current_budget.groups.each do |group| %>
             <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
             <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
-              <% group.headings.order_by_group_name.each do |heading| %>
+              <% group.headings.order_by_group_name.to_a.uniq.each do |heading| %>
                 <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
                   <% unless current_budget.informing? || current_budget.finished? %>
                     <%= link_to budget_investments_path(current_budget.id,

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -79,7 +79,7 @@
           <% current_budget.groups.each do |group| %>
             <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
             <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
-              <% group.headings.order_by_group_name.each do |heading| %>
+              <% group.headings.order_by_group_name.to_a.uniq.each do |heading| %>
                 <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
                   <% unless current_budget.informing? || current_budget.finished? %>
                     <%= link_to custom_budget_investments_path(group,

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -73,6 +73,27 @@ feature 'Budgets' do
       end
     end
 
+    scenario "Show groups and headings for missing translations" do
+      group1 = create(:budget_group, budget: last_budget)
+      group2 = create(:budget_group, budget: last_budget)
+
+      heading1 = create(:budget_heading, group: group1)
+      heading2 = create(:budget_heading, group: group2)
+
+      last_budget.update_attributes(phase: "informing")
+
+      visit budgets_path locale: :es
+
+      within("#budget_info") do
+        expect(page).to have_content group1.name
+        expect(page).to have_content group2.name
+        expect(page).to have_content heading1.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading1)
+        expect(page).to have_content heading2.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading2)
+      end
+    end
+
     scenario "Show informing index without links" do
       last_budget.update_attributes(phase: "informing")
       group = create(:budget_group, budget: last_budget)


### PR DESCRIPTION
## Objectives

Show all the groups and headings in the Participatory Budgets landing page when translations for groups are missing

## Does this PR need a Backport to CONSUL?
Yes