### PR TITLE
Budgets landing page

### DIFF
--- a/app/helpers/budget_headings_helper.rb
+++ b/app/helpers/budget_headings_helper.rb
@@ -1,7 +1,7 @@
 module BudgetHeadingsHelper
 
   def budget_heading_select_options(budget)
-    budget.headings.order_by_name.map do |heading|
+    budget.headings.sort_by_name.map do |heading|
       [heading.name_scoped_by_group, heading.id]
     end
   end

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -27,7 +27,7 @@ class Budget
     delegate :budget, :budget_id, to: :group, allow_nil: true
 
     scope :i18n,                  -> { includes(:translations) }
-    scope :with_group,            -> { joins(group: :translations).where("budget_group_translations.locale = ?", I18n.locale) }
+    scope :with_group,            -> { includes(group: :translations) }
     scope :order_by_group_name,   -> { i18n.with_group.order("budget_group_translations.name DESC") }
     scope :order_by_heading_name, -> { i18n.with_group.order("budget_heading_translations.name") }
     scope :order_by_name,         -> { i18n.with_group.order_by_group_name.order_by_heading_name }

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -27,11 +27,13 @@ class Budget
     delegate :budget, :budget_id, to: :group, allow_nil: true
 
     scope :i18n,                  -> { includes(:translations) }
-    scope :with_group,            -> { includes(group: :translations) }
-    scope :order_by_group_name,   -> { i18n.with_group.order("budget_group_translations.name DESC") }
-    scope :order_by_heading_name, -> { i18n.with_group.order("budget_heading_translations.name") }
-    scope :order_by_name,         -> { i18n.with_group.order_by_group_name.order_by_heading_name }
     scope :allow_custom_content,  -> { i18n.where(allow_custom_content: true).order(:name) }
+
+    def self.sort_by_name
+      all.sort do |heading, other_heading|
+        [other_heading.group.name, heading.name] <=> [heading.group.name, other_heading.name]
+      end
+    end
 
     def name_scoped_by_group
       group.single_heading_group? ? name : "#{group.name}: #{name}"

--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -32,7 +32,7 @@
 <div class="row margin">
   <div id="headings" class="small-12 medium-7 column select-district">
     <div class="row">
-      <% @group.headings.order_by_group_name.each_slice(7) do |slice| %>
+      <% @group.headings.sort_by_name.each_slice(7) do |slice| %>
         <div class="small-6 medium-4 column end">
           <% slice.each do |heading| %>
             <span id="<%= dom_id(heading) %>"

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -70,7 +70,7 @@
           <% current_budget.groups.each do |group| %>
             <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
             <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
-              <% group.headings.order_by_group_name.each do |heading| %>
+              <% group.headings.sort_by_name.each do |heading| %>
                 <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
                   <% unless current_budget.informing? || current_budget.finished? %>
                     <%= link_to budget_investments_path(current_budget.id,

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -79,7 +79,7 @@
           <% current_budget.groups.each do |group| %>
             <h2 id="<%= group.name.parameterize %>"><%= group.name %></h2>
             <ul class="no-bullet" data-equalizer data-equalizer-on="medium">
-              <% group.headings.order_by_group_name.each do |heading| %>
+              <% group.headings.sort_by_name.each do |heading| %>
                 <li class="heading small-12 medium-4 large-2" data-equalizer-watch>
                   <% unless current_budget.informing? || current_budget.finished? %>
                     <%= link_to custom_budget_investments_path(group,

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -73,6 +73,16 @@ feature 'Budgets' do
       end
     end
 
+    scenario "Show headings ordered by name" do
+      group = create(:budget_group, budget: last_budget)
+      last_heading = create(:budget_heading, group: group, name: "BBB")
+      first_heading = create(:budget_heading, group: group, name: "AAA")
+
+      visit budgets_path
+
+      expect(first_heading.name).to appear_before(last_heading.name)
+    end
+
     scenario "Show groups and headings for missing translations" do
       group1 = create(:budget_group, budget: last_budget)
       group2 = create(:budget_group, budget: last_budget)

--- a/spec/features/budgets/budgets_spec.rb
+++ b/spec/features/budgets/budgets_spec.rb
@@ -73,6 +73,25 @@ feature 'Budgets' do
       end
     end
 
+    scenario "Show groups and headings for missing translations" do
+      group1 = create(:budget_group, budget: last_budget)
+      group2 = create(:budget_group, budget: last_budget)
+
+      heading1 = create(:budget_heading, group: group1)
+      heading2 = create(:budget_heading, group: group2)
+
+      visit budgets_path locale: :es
+
+      within("#budget_info") do
+        expect(page).to have_content group1.name
+        expect(page).to have_content group2.name
+        expect(page).to have_content heading1.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading1)
+        expect(page).to have_content heading2.name
+        expect(page).to have_content last_budget.formatted_heading_price(heading2)
+      end
+    end
+
     scenario "Show informing index without links" do
       last_budget.update_attributes(phase: "informing")
       group = create(:budget_group, budget: last_budget)

--- a/spec/features/budgets/groups_spec.rb
+++ b/spec/features/budgets/groups_spec.rb
@@ -43,4 +43,15 @@ feature "Budget Groups" do
 
   end
 
+  context "Show" do
+    scenario "Headings are sorted by name" do
+      last_heading = create(:budget_heading, group: group, name: "BBB")
+      first_heading = create(:budget_heading, group: group, name: "AAA")
+
+      visit budget_group_path(budget, group)
+
+      expect(first_heading.name).to appear_before(last_heading.name)
+    end
+  end
+
 end

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -281,9 +281,9 @@ describe Budget::Heading do
   end
 
   describe "scope order_by_group_name" do
-    it "only sort headings using the group name (DESC) in the current locale" do
-      last_group  = create(:budget_group, name_en: "CCC", name_es: "BBB")
-      first_group = create(:budget_group, name_en: "DDD", name_es: "AAA")
+    it "sorts headings using the group name (DESC) in any locale" do
+      last_group  = create(:budget_group, name_en: "CCC", name_es: "AAA")
+      first_group = create(:budget_group, name_en: "DDD", name_es: "BBB")
 
       last_heading = create(:budget_heading, group: last_group, name: "Name")
       first_heading = create(:budget_heading, group: first_group, name: "Name")

--- a/spec/models/budget/heading_spec.rb
+++ b/spec/models/budget/heading_spec.rb
@@ -280,21 +280,8 @@ describe Budget::Heading do
     end
   end
 
-  describe "scope order_by_group_name" do
-    it "sorts headings using the group name (DESC) in any locale" do
-      last_group  = create(:budget_group, name_en: "CCC", name_es: "AAA")
-      first_group = create(:budget_group, name_en: "DDD", name_es: "BBB")
+  describe ".sort_by_name" do
 
-      last_heading = create(:budget_heading, group: last_group, name: "Name")
-      first_heading = create(:budget_heading, group: first_group, name: "Name")
-
-      expect(Budget::Heading.order_by_group_name.count).to be 2
-      expect(Budget::Heading.order_by_group_name.first).to eq first_heading
-      expect(Budget::Heading.order_by_group_name.last).to eq last_heading
-    end
-  end
-
-  describe "scope order_by_name" do
     it "returns headings sorted by DESC group name first and then ASC heading name" do
       last_group  = create(:budget_group, name: "Group A")
       first_group = create(:budget_group, name: "Group B")
@@ -305,8 +292,21 @@ describe Budget::Heading do
       heading1 = create(:budget_heading, group: first_group, name: "Name C")
 
       sorted_headings = [heading1, heading2, heading3, heading4]
-      expect(Budget::Heading.order_by_name.to_a).to eq sorted_headings
+      expect(Budget::Heading.sort_by_name).to eq sorted_headings
     end
+
+    it "only sort headings using the group name (DESC) in the current locale" do
+      last_group  = create(:budget_group, name_en: "CCC", name_es: "BBB")
+      first_group = create(:budget_group, name_en: "DDD", name_es: "AAA")
+
+      last_heading = create(:budget_heading, group: last_group, name: "Name")
+      first_heading = create(:budget_heading, group: first_group, name: "Name")
+
+      expect(Budget::Heading.sort_by_name.size).to be 2
+      expect(Budget::Heading.sort_by_name.first).to eq first_heading
+      expect(Budget::Heading.sort_by_name.last).to eq last_heading
+    end
+
   end
 
   describe "scope allow_custom_content" do


### PR DESCRIPTION
## Objectives

- Show all headings if the group translations are missing.
- Correctly sort headings by name.

## Does this PR need a Backport to CONSUL?
Yes, together with this PR https://github.com/AyuntamientoMadrid/consul/pull/1842