### PR TITLE
Migrate internal comments with a large body

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,7 +20,7 @@ class Comment < ActiveRecord::Base
 
   validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
 
-  validate :validate_body_length
+  validate :validate_body_length, unless: -> { valuation }
   validate :comment_valuation, if: -> { valuation }
 
   belongs_to :commentable, -> { with_hidden }, polymorphic: true, counter_cache: true

--- a/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investment_spec.rb
@@ -112,6 +112,23 @@ describe Migrations::SpendingProposal::BudgetInvestment do
       expect(comment.valuation).to eq(true)
     end
 
+    it "migrates internal comments with a body larger than the standard comment limit" do
+      allow(Comment).to receive(:body_max_length).and_return(20)
+
+      internal_comment = "This project will last 2 years"
+      spending_proposal.update(internal_comments: internal_comment)
+      spending_proposal.update(administrator: create(:administrator))
+
+      migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
+      migration.update
+
+      comment = Comment.first
+      expect(Comment.count).to eq(1)
+      expect(comment.body).to eq(internal_comment)
+      expect(comment.commentable).to eq(budget_investment)
+      expect(comment.valuation).to eq(true)
+    end
+
     it "does not create a comment if internal_comments is blank" do
       migration = Migrations::SpendingProposal::BudgetInvestment.new(spending_proposal)
       migration.update


### PR DESCRIPTION
## References

**PR** Migrate spending proposal internal comments https://github.com/AyuntamientoMadrid/consul/pull/1865

## Context

Some internal valuation comments exceed the [maximum length of 1000 characters](https://github.com/AyuntamientoMadrid/consul/blob/master/db/seeds.rb#L26) in the [Comments validations](https://github.com/AyuntamientoMadrid/consul/blob/master/app/models/comment.rb#L23).

This comments were not being migrated properly from Spending Proposals to Budget::Investments.

## Objectives

With this PR we are allowing valuation comments to be created even if they exceed the limit of 1000 characters.

## Does this PR need a Backport to CONSUL?

Yes, internal comments should be migrated in CONSUL too.
