### PR TITLE
Require dependencies for Budget and Budget::Ballot classes

### DIFF
--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -1,3 +1,6 @@
+require_dependency "budget"
+require_dependency "budget/ballot"
+
 class Migrations::SpendingProposal::Ballot
   attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
 


### PR DESCRIPTION
## References
**PR**: Migrate spending proposal ballots https://github.com/AyuntamientoMadrid/consul/pull/1868

## Context
Even though the specs run fine, when [running the rake task to migrate spending proposal ballots](https://github.com/AyuntamientoMadrid/consul/pull/1868) we are getting an exception, as Rails is not finding the correct `Budget` and `Budget::Ballot` classes.

## Objectives
Explicitly load the required dependencies so that the rake task can run successfully.

## Does this PR need a Backport to CONSUL?
Yes, this is part of a migration that should be included in CONSUL.