### PR TITLE
Do not display logs in test environment

### DIFF
--- a/lib/migrations/log.rb
+++ b/lib/migrations/log.rb
@@ -1,0 +1,7 @@
+module Migrations::Log
+
+  def log(message)
+    print message unless Rails.env.test?
+  end
+
+end

--- a/lib/migrations/spending_proposal/ballot.rb
+++ b/lib/migrations/spending_proposal/ballot.rb
@@ -1,4 +1,6 @@
 class Migrations::SpendingProposal::Ballot
+  include Migrations::Log
+
   attr_accessor :spending_proposal_ballot, :budget_investment_ballot, :represented_user
 
   def initialize(spending_proposal_ballot, represented_user=nil)
@@ -9,11 +11,11 @@ class Migrations::SpendingProposal::Ballot
 
   def migrate_ballot
     if budget_investment_ballot_valid?
-      puts "."
+      log(".")
 
       migrate_ballot_lines
     else
-      puts "Error creating budget investment ballot from spending proposal ballot #{spending_proposal_ballot.id}\n"
+      log("\nError creating budget investment ballot from spending proposal ballot #{spending_proposal_ballot.id}\n")
     end
   end
 
@@ -23,9 +25,9 @@ class Migrations::SpendingProposal::Ballot
 
       ballot_line = new_ballot_line(budget_investment)
       if ballot_line_valid?(ballot_line) && ballot_line.save
-        print "."
+        log(".")
       else
-        puts "Error adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n"
+        log("\nError adding spending proposal: #{spending_proposal.id} to ballot: #{budget_investment_ballot.id}\n")
       end
     end
   end

--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -1,4 +1,6 @@
 class Migrations::SpendingProposal::BudgetInvestment
+  include Migrations::Log
+
   attr_accessor :spending_proposal, :budget_investment
 
   def initialize(spending_proposal)
@@ -8,9 +10,9 @@ class Migrations::SpendingProposal::BudgetInvestment
 
   def update
     if updated?
-      print "."
+      log(".")
     else
-      puts "Error updating budget investment from spending proposal: #{spending_proposal.id}\n"
+      log("\nError updating budget investment from spending proposal: #{spending_proposal.id}\n")
     end
   end
 


### PR DESCRIPTION
## References

**PR**: Migrate spending proposal ballots https://github.com/AyuntamientoMadrid/consul/pull/1868

## Context
We are seeing some unnecessary logs in Travis and locally when running these specs.

## Objectives
Only displaying these debugging logs when running the rake task in an environment other than _test_.

## Does this PR need a Backport to CONSUL?
Yes, these specs are going to be executed in CONSUL too 😌