### PR TITLE
Fix UI details for a better UX and design

### DIFF
--- a/app/controllers/admin/legislation/processes_controller.rb
+++ b/app/controllers/admin/legislation/processes_controller.rb
@@ -1,7 +1,7 @@
 class Admin::Legislation::ProcessesController < Admin::Legislation::BaseController
   include Translatable
 
-  has_filters %w[open all], only: :index
+  has_filters %w[active all], only: :index
 
   load_and_authorize_resource :process, class: "Legislation::Process"
 

--- a/app/helpers/legislation_helper.rb
+++ b/app/helpers/legislation_helper.rb
@@ -64,7 +64,7 @@ module LegislationHelper
 
   def css_for_process_header
     if banner_color?
-      "background:" + @process.background_color + ";color:" + @process.font_color + ";"
+      "background: #{@process.background_color};color: #{@process.font_color};"
     end
   end
 

--- a/app/helpers/legislation_helper.rb
+++ b/app/helpers/legislation_helper.rb
@@ -46,6 +46,22 @@ module LegislationHelper
     @process.background_color.present? && @process.font_color.present?
   end
 
+  def default_bg_color
+    "#e7f2fc"
+  end
+
+  def default_font_color
+    "#222222"
+  end
+
+  def bg_color_or_default
+    @process.background_color.present? ? @process.background_color : default_bg_color
+  end
+
+  def font_color_or_default
+    @process.font_color.present? ? @process.font_color : default_font_color
+  end
+
   def css_for_process_header
     if banner_color?
       "background:" + @process.background_color + ";color:" + @process.font_color + ";"

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -50,6 +50,7 @@ class Legislation::Process < ActiveRecord::Base
   validates :font_color, format: { allow_blank: true, with: CSS_HEX_COLOR }
 
   scope :open, -> { where("start_date <= ? and end_date >= ?", Date.current, Date.current) }
+  scope :active, -> { where("end_date >= ?", Date.current) }
   scope :past, -> { where("end_date < ?", Date.current) }
 
   scope :published, -> { where(published: true) }

--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -220,12 +220,11 @@
     <p class="help-text"><%= t("admin.legislation.processes.form.color_help") %></p>
     <div class="row collapse">
       <div class="small-12 medium-6 column">
-        <%= f.text_field :background_color, label: false, type: :color %>
+        <%= f.text_field :background_color, label: false, type: :color,
+                                            value: bg_color_or_default %>
       </div>
       <div class="small-12 medium-6 column">
-        <%= f.text_field :background_color, label: false,
-                                            placeholder: "#e7f2fc",
-                                            id: "background_color_input" %>
+        <%= f.text_field :background_color, label: false, id: "background_color_input" %>
       </div>
     </div>
   </div>
@@ -235,12 +234,10 @@
     <p class="help-text"><%= t("admin.legislation.processes.form.color_help") %></p>
     <div class="row collapse">
       <div class="small-12 medium-6 column">
-        <%= f.text_field :font_color, label: false, type: :color %>
+        <%= f.text_field :font_color, label: false, type: :color, value: font_color_or_default %>
       </div>
       <div class="small-12 medium-6 column">
-        <%= f.text_field :font_color, label: false,
-                                      placeholder: "#222222",
-                                      id: "font_color_input" %>
+        <%= f.text_field :font_color, label: false, id: "font_color_input" %>
       </div>
     </div>
   </div>

--- a/app/views/admin/legislation/processes/index.html.erb
+++ b/app/views/admin/legislation/processes/index.html.erb
@@ -17,7 +17,8 @@
       <tr>
         <th><%= t("admin.legislation.processes.process.title") %></th>
         <th><%= t("admin.legislation.processes.process.status") %></th>
-        <th><%= t("admin.legislation.processes.process.creation_date") %></th>
+        <th class="text-center"><%= t("admin.legislation.processes.process.start_date") %></th>
+        <th class="text-center"><%= t("admin.legislation.processes.process.end_date") %></th>
         <th class="text-center"><%= t("admin.legislation.processes.process.comments") %></th>
         <th><%= t("admin.actions.actions") %></th>
       </tr>
@@ -26,11 +27,12 @@
     <tbody>
       <% @processes.each do |process| %>
         <tr id="<%= dom_id(process) %>">
-          <td class="small-12 medium-6">
+          <td class="small-12 medium-6 large-4">
             <%= link_to process.title, edit_admin_legislation_process_path(process) %>
           </td>
           <td><%= t("admin.legislation.processes.process.status_#{process.status}") %></td>
-          <td><%= I18n.l process.created_at.to_date %></td>
+          <td class="text-center"><%= I18n.l process.start_date %></td>
+          <td class="text-center"><%= I18n.l process.end_date %></td>
           <td class="text-center"><%= process.total_comments %></td>
           <td>
             <%= link_to t("admin.legislation.processes.index.delete"), admin_legislation_process_path(process),

--- a/app/views/welcome/_card.html.erb
+++ b/app/views/welcome/_card.html.erb
@@ -7,7 +7,10 @@
         <%= image_tag(card.image_url(:large), alt: card.image.title) %>
       <% end %>
       <figcaption>
-        <span><%= card.label %></span><br>
+        <% if card.label.present? %>
+          <span><%= card.label %></span>
+        <% end %>
+        <br>
         <h3><%= card.title %></h3>
       </figcaption>
     </figure>

--- a/app/views/welcome/_feeds.html.erb
+++ b/app/views/welcome/_feeds.html.erb
@@ -17,8 +17,8 @@
                   </div>
                 </div>
               <% end %>
-              <div class="feed-description small-12 column
-                          <%= 'large-9' if feature?(:allow_images) && item.image.present? %>">
+              <div class="feed-description small-12 medium-6 column
+                         <%= item.image.present? ? 'large-9' : 'medium-offset-6 large-offset-3' %>">
                 <strong><%= link_to item.title, url_for(item) %></strong><br>
                 <p><%= item.summary %></p>
               </div>

--- a/app/views/welcome/_feeds.html.erb
+++ b/app/views/welcome/_feeds.html.erb
@@ -9,7 +9,7 @@
 
           <% feed.items.each do |item| %>
             <div class="<%= item.class.to_s.parameterize('_') %> row">
-              <% if feature?(:allow_images) && item.image.present? %>
+              <% if item.image.present? %>
                 <div class="small-12 medium-6 large-3 column">
                   <div class="feed-image">
                     <%= image_tag item.image_url(:thumb),
@@ -17,8 +17,8 @@
                   </div>
                 </div>
               <% end %>
-              <div class="feed-description small-12 medium-6 column
-                         <%= item.image.present? ? 'large-9' : 'medium-offset-6 large-offset-3' %>">
+              <div class="feed-description small-12 medium-6 large-9 column
+                         <%= item.image.present? ? '' : 'medium-offset-6 large-offset-3' %>">
                 <strong><%= link_to item.title, url_for(item) %></strong><br>
                 <p><%= item.summary %></p>
               </div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -483,7 +483,8 @@ en:
           title: Process
           comments: Comments
           status: Status
-          creation_date: Creation date
+          start_date: Start date
+          end_date: End date
           status_open: Open
           status_closed: Closed
           status_planned: Planned

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -508,7 +508,7 @@ en:
           selected: Selected
         form:
           custom_categories: Categories
-          custom_categories_description: Categories that users can select creating the proposal.
+          custom_categories_description: Categories that users can select creating the proposal. Max 160 characteres by category.
           custom_categories_placeholder: Enter the tags you would like to use, separated by commas (,) and between quotes ("")
       draft_versions:
         create:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -467,7 +467,7 @@ en:
           delete: Delete
           title: Legislation processes
           filters:
-            open: Open
+            active: Active
             all: All
         new:
           back: Back

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -507,7 +507,7 @@ es:
           selected: Seleccionada
         form:
           custom_categories: Categorías
-          custom_categories_description: Categorías que el usuario puede seleccionar al crear la propuesta.
+          custom_categories_description: Categorías que el usuario puede seleccionar al crear la propuesta. Máximo 160 caracteres por categoría.
           custom_categories_placeholder: Escribe las etiquetas que desees separadas por una coma (,) y entrecomilladas ("")
       draft_versions:
         create:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -467,7 +467,7 @@ es:
           delete: Borrar
           title: Procesos de legislación colaborativa
           filters:
-            open: Abiertos
+            active: Activos
             all: Todos
         new:
           back: Volver

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -483,7 +483,8 @@ es:
           title: Proceso
           comments: Comentarios
           status: Estado
-          creation_date: Fecha de creación
+          start_date: Fecha de apertura
+          end_date: Fecha de cierre
           status_open: Abierto
           status_closed: Cerrado
           status_planned: Próximamente

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -50,14 +50,22 @@ feature 'Admin legislation processes' do
     end
 
     scenario "Processes are sorted by descending start date" do
-      create(:legislation_process, title: "Process 1", start_date: Date.yesterday)
-      create(:legislation_process, title: "Process 2", start_date: Date.today)
-      create(:legislation_process, title: "Process 3", start_date: Date.tomorrow)
+      process_1 = create(:legislation_process, title: "Process 1", start_date: Date.yesterday)
+      process_2 = create(:legislation_process, title: "Process 2", start_date: Date.today)
+      process_3 = create(:legislation_process, title: "Process 3", start_date: Date.tomorrow)
 
       visit admin_legislation_processes_path(filter: "all")
 
-      expect("Process 3").to appear_before("Process 2")
-      expect("Process 2").to appear_before("Process 1")
+      expect(page).to have_content (process_1.start_date)
+      expect(page).to have_content (process_2.start_date)
+      expect(page).to have_content (process_3.start_date)
+
+      expect(page).to have_content (process_1.end_date)
+      expect(page).to have_content (process_2.end_date)
+      expect(page).to have_content (process_3.end_date)
+
+      expect(process_3.title).to appear_before(process_2.title)
+      expect(process_2.title).to appear_before(process_1.title)
     end
 
   end
@@ -179,6 +187,14 @@ feature 'Admin legislation processes' do
       expect(page).not_to have_content "Summary of the process"
       expect(page).to have_css("img[alt='#{Legislation::Process.last.title}']")
     end
+
+    scenario "Default colors are present" do
+      visit new_admin_legislation_process_path
+
+      expect(find("#legislation_process_background_color").value).to eq "#e7f2fc"
+      expect(find("#legislation_process_font_color").value).to eq "#222222"
+    end
+
   end
 
   context 'Update' do

--- a/spec/features/admin/legislation/processes_spec.rb
+++ b/spec/features/admin/legislation/processes_spec.rb
@@ -28,11 +28,25 @@ feature 'Admin legislation processes' do
 
   context "Index" do
 
-    scenario 'Displaying legislation processes' do
-      process = create(:legislation_process)
-      visit admin_legislation_processes_path(filter: 'all')
+    scenario "Displaying legislation processes" do
+      process_1 = create(:legislation_process, title: "Process open")
+      process_2 = create(:legislation_process, title: "Process for the future",
+                                               start_date: Date.current + 5.days)
+      process_3 = create(:legislation_process, title: "Process closed",
+                                               start_date: Date.current - 10.days,
+                                               end_date: Date.current - 6.days)
 
-      expect(page).to have_content(process.title)
+      visit admin_legislation_processes_path(filter: "active")
+
+      expect(page).to have_content(process_1.title)
+      expect(page).to have_content(process_2.title)
+      expect(page).not_to have_content(process_3.title)
+
+      visit admin_legislation_processes_path(filter: "all")
+
+      expect(page).to have_content(process_1.title)
+      expect(page).to have_content(process_2.title)
+      expect(page).to have_content(process_3.title)
     end
 
     scenario "Processes are sorted by descending start date" do


### PR DESCRIPTION
## Objectives

This PR fix some UI details for a better UX and design. 👨‍🎨 

- Improve help text for legislation processes proposals categories indicating to admin users they can use 160 characters by category. _[Image 1]_

- Align proposal feed description without image on welcome page: when enable only proposals feed from admin, the proposals without an image appear unaligned. _[Image 2]_

- Show card label only if it is present on welcome page: this was added on cards of custom pages, now on welcome page too avoiding to show an empty span. _[Image 3]_

- Replace open to active filter on admin legislation processes index: now on active filter show open processes and the "next" ones, processes with a start date greater than current date. _[Image 4]_

- Replace created at date to start and end date on admin legislation processes _[Image 4]_

- Add default colours for legislation processes header _[Image 5]_

- Use interpolation instead of concatenation on legislation helper. ✊ 🤓 

## Visual Changes

**[Image 1]**
![categories](https://user-images.githubusercontent.com/631897/52490534-3b99d600-2bc5-11e9-8cbe-01d378cc7f6b.png)

**[Image 2] BEFORE**
![before](https://user-images.githubusercontent.com/631897/52490549-47859800-2bc5-11e9-8728-e406801f7b51.png)

**[Image 2] AFTER**
![after](https://user-images.githubusercontent.com/631897/52490552-49e7f200-2bc5-11e9-9a94-a423cbe1ef61.png)

**Also fixed on small screens**
![mobile](https://user-images.githubusercontent.com/631897/52490581-553b1d80-2bc5-11e9-8a43-b42a00434262.png)

**[Image 3] BEFORE**
![card_before](https://user-images.githubusercontent.com/631897/52490593-58360e00-2bc5-11e9-93b9-b9c63e25459c.png)

**[Image 3] AFTER**
![card_after](https://user-images.githubusercontent.com/631897/52490595-59673b00-2bc5-11e9-83ad-da976ba640da.png)

**[Image 4]**
![admin_processes](https://user-images.githubusercontent.com/631897/52797396-18b06b80-3076-11e9-975d-9a0b2adbf104.png)

**[Image 5]**
![screenshot 2019-02-15 at 18 21 41](https://user-images.githubusercontent.com/631897/52873133-934cba00-314e-11e9-88e5-1ffb77e1b30f.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.