### PR TITLE
[Upstream] Add sorting links to investments admin table

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -219,10 +219,6 @@ $sidebar-active: #f4fcd0;
 
     thead {
       color: #fff;
-
-      a {
-        color: inherit;
-      }
     }
 
     th {
@@ -231,6 +227,10 @@ $sidebar-active: #f4fcd0;
 
       label {
         color: #fff;
+      }
+
+      a {
+        color: inherit;
       }
     }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -219,6 +219,10 @@ $sidebar-active: #f4fcd0;
 
     thead {
       color: #fff;
+
+      a {
+        color: inherit;
+      }
     }
 
     th {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -231,6 +231,7 @@ $sidebar-active: #f4fcd0;
 
       a {
         color: inherit;
+        white-space: nowrap;
       }
     }
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -376,6 +376,44 @@ $sidebar-active: #f4fcd0;
   color: $text-medium;
 }
 
+.icon-sortable {
+  font-family: "icons";
+  font-size: $small-font-size;
+  padding-right: $line-height / 2;
+  position: relative;
+
+  &::before,
+  &::after {
+    left: 6px;
+    opacity: 0.25;
+    position: absolute;
+  }
+
+  &::before {
+    content: "\57";
+    top: -2px;
+  }
+
+  &::after {
+    content: "\52";
+    bottom: -10px;
+  }
+
+  &.asc {
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &.desc {
+
+    &::before {
+      opacity: 1;
+    }
+  }
+}
+
 // 02. Sidebar
 // -----------
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -77,7 +77,8 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
 
     def load_investments
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-                                       .order_filter(params[:sort_by])
+                                       .order_filter(params[:sort_by], params[:direction])
+
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -80,6 +80,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
                                        .order_filter(params[:sort_by], params[:direction])
 
+      @investments = Budget::Investment.by_budget(@budget).all
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -76,6 +76,7 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_investments
+      params[:direction].present? ? params[:direction] : params[:direction] = "asc"
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
                                        .order_filter(params[:sort_by], params[:direction])
 

--- a/app/controllers/admin/budget_investments_controller.rb
+++ b/app/controllers/admin/budget_investments_controller.rb
@@ -76,11 +76,9 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
     end
 
     def load_investments
-      params[:direction].present? ? params[:direction] : params[:direction] = "asc"
       @investments = Budget::Investment.scoped_filter(params, @current_filter)
-                                       .order_filter(params[:sort_by], params[:direction])
+                                       .order_filter(params)
 
-      @investments = Budget::Investment.by_budget(@budget).all
       @investments = @investments.page(params[:page]) unless request.format.csv?
     end
 
@@ -137,5 +135,4 @@ class Admin::BudgetInvestmentsController < Admin::BaseController
         end
       end
     end
-
 end

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -6,8 +6,9 @@ module BudgetInvestmentsHelper
   def link_to_investments_sorted_by(column)
     sort_by = column.downcase
     default_direction = "desc"
+    current_direction = params[:direction].downcase if params[:direction]
 
-    direction = params[:direction] == default_direction ? default_direction : "asc"
+    direction = current_direction == default_direction ? default_direction : "asc"
 
     icon = direction == default_direction ? "icon-arrow-down" : "icon-arrow-top"
     icon = sort_by == params[:sort_by] ? icon : ""

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -12,7 +12,7 @@ module BudgetInvestmentsHelper
     translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
-      "#{translation} <span class=\"#{icon}\"></span>".html_safe,
+      "#{translation} <span class='#{icon}'></span>".html_safe,
       admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,13 +5,10 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sort_by = column.downcase
-    default_direction = "desc"
     current_direction = params[:direction].downcase if params[:direction]
 
-    direction = current_direction == default_direction ? "asc" : default_direction
-
-    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
-    icon = sort_by == params[:sort_by] ? icon : ""
+    direction = set_direction(current_direction)
+    icon = set_sorting_icon(direction, sort_by)
 
     translation = t("admin.budget_investments.index.sort_by.#{sort_by}")
 
@@ -19,6 +16,15 @@ module BudgetInvestmentsHelper
       "#{translation} <span class=\"#{icon}\"></span>".html_safe,
       admin_budget_budget_investments_path(sort_by: sort_by, direction: direction)
     )
+  end
+
+  def set_sorting_icon(direction, sort_by)
+    icon = direction == "desc" ? "icon-arrow-top" : "icon-arrow-down"
+    icon = sort_by == params[:sort_by] ? icon : ""
+  end
+
+  def set_direction(current_direction)
+    current_direction == "desc" ? "asc" : "desc"
   end
 
   def investments_minimal_view_path

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -4,9 +4,7 @@ module BudgetInvestmentsHelper
   end
 
   def link_to_investments_sorted_by(column)
-    current_direction = params[:direction].downcase if params[:direction]
-
-    direction = set_direction(current_direction)
+    direction = set_direction(params[:direction])
     icon = set_sorting_icon(direction, column)
 
     translation = t("admin.budget_investments.index.list.#{column}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,8 +5,9 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sorting_option = column.downcase
-    direction = sorting_option && params[:direction] == "asc" ? "desc" : "asc"
-    icon = direction == "asc" ? "icon-arrow-top" : "icon-arrow-down"
+    direction = params[:direction] ? params[:direction] : "desc"
+
+    icon = direction == "desc" ? "icon-arrow-down" : "icon-arrow-top"
     icon = sorting_option == params[:sort_by] ? icon : ""
 
     translation = t("admin.budget_investments.index.sort_by.#{sorting_option}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -8,9 +8,9 @@ module BudgetInvestmentsHelper
     default_direction = "desc"
     current_direction = params[:direction].downcase if params[:direction]
 
-    direction = current_direction == default_direction ? default_direction : "asc"
+    direction = current_direction == default_direction ? "asc" : default_direction
 
-    icon = direction == default_direction ? "icon-arrow-down" : "icon-arrow-top"
+    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
     icon = sort_by == params[:sort_by] ? icon : ""
 
     translation = t("admin.budget_investments.index.sort_by.#{sort_by}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -4,17 +4,26 @@ module BudgetInvestmentsHelper
   end
 
   def link_to_investments_sorted_by(column)
-    sorting_option = column.downcase
-    direction = params[:direction] ? params[:direction] : "desc"
+    sort_by = column.downcase
+    allowed_directions = %w[asc desc].freeze
+    default_direction = "desc"
+    current_direction = params[:direction]
 
-    icon = direction == "desc" ? "icon-arrow-down" : "icon-arrow-top"
-    icon = sorting_option == params[:sort_by] ? icon : ""
+    if allowed_directions.include?(current_direction)
+      #select opposite direction
+      direction = allowed_directions.reject { |dir| dir == current_direction }.first
+    else
+      direction = default_direction
+    end
 
-    translation = t("admin.budget_investments.index.sort_by.#{sorting_option}")
+    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
+    icon = sort_by == params[:sort_by] ? icon : ""
+
+    translation = t("admin.budget_investments.index.sort_by.#{sort_by}")
 
     link_to(
       "#{translation} <span class=\"#{icon}\"></span>".html_safe,
-      admin_budget_budget_investments_path(sort_by: sorting_option, direction: direction)
+      admin_budget_budget_investments_path(sort_by: sort_by, direction: direction)
     )
   end
 

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,9 +5,15 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sorting_option = column.downcase
+    direction = sorting_option && params[:direction] == "asc" ? "desc" : "asc"
+    icon = direction == "asc" ? "icon-arrow-top" : "icon-arrow-down"
+    icon = sorting_option == params[:sort_by] ? icon : ""
+
+    translation = t("admin.budget_investments.index.sort_by.#{sorting_option}")
+
     link_to(
-      t("admin.budget_investments.index.sort_by.#{sorting_option}"),
-      admin_budget_budget_investments_path(sort_by: sorting_option)
+      "#{translation} <span class=\"#{icon}\"></span>".html_safe,
+      admin_budget_budget_investments_path(sort_by: sorting_option, direction: direction)
     )
   end
 

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -1,17 +1,14 @@
 module BudgetInvestmentsHelper
-  def budget_investments_sorting_options
-    Budget::Investment::SORTING_OPTIONS.map do |so|
-      [t("admin.budget_investments.index.sort_by.#{so}"), so]
-    end
-  end
-
   def budget_investments_advanced_filters(params)
     params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(', ')
   end
 
   def link_to_investments_sorted_by(column)
-    sorting_option = budget_investments_sorting_options.select { |so| so[1] == column.downcase }.flatten
-    link_to t(sorting_option[0]), admin_budget_budget_investments_path(sort_by: sorting_option[1])
+    sorting_option = column.downcase
+    link_to(
+      t("admin.budget_investments.index.sort_by.#{sorting_option}"),
+      admin_budget_budget_investments_path(sort_by: sorting_option)
+    )
   end
 
   def investments_minimal_view_path

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -16,8 +16,15 @@ module BudgetInvestmentsHelper
   end
 
   def set_sorting_icon(direction, sort_by)
-    icon = direction == "desc" ? "icon-arrow-top" : "icon-arrow-down"
-    icon = sort_by.to_s == params[:sort_by] ? icon : ""
+    if sort_by.to_s == params[:sort_by]
+      if direction == "desc"
+        "icon-arrow-top"
+      else
+        "icon-arrow-down"
+      end
+    else
+      ""
+    end
   end
 
   def set_direction(current_direction)

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -5,18 +5,11 @@ module BudgetInvestmentsHelper
 
   def link_to_investments_sorted_by(column)
     sort_by = column.downcase
-    allowed_directions = %w[asc desc].freeze
     default_direction = "desc"
-    current_direction = params[:direction]
 
-    if allowed_directions.include?(current_direction)
-      #select opposite direction
-      direction = allowed_directions.reject { |dir| dir == current_direction }.first
-    else
-      direction = default_direction
-    end
+    direction = params[:direction] == default_direction ? default_direction : "asc"
 
-    icon = direction == default_direction ? "icon-arrow-top" : "icon-arrow-down"
+    icon = direction == default_direction ? "icon-arrow-down" : "icon-arrow-top"
     icon = sort_by == params[:sort_by] ? icon : ""
 
     translation = t("admin.budget_investments.index.sort_by.#{sort_by}")

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -4,23 +4,22 @@ module BudgetInvestmentsHelper
   end
 
   def link_to_investments_sorted_by(column)
-    sort_by = column.downcase
     current_direction = params[:direction].downcase if params[:direction]
 
     direction = set_direction(current_direction)
-    icon = set_sorting_icon(direction, sort_by)
+    icon = set_sorting_icon(direction, column)
 
-    translation = t("admin.budget_investments.index.sort_by.#{sort_by}")
+    translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
       "#{translation} <span class=\"#{icon}\"></span>".html_safe,
-      admin_budget_budget_investments_path(sort_by: sort_by, direction: direction)
+      admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end
 
   def set_sorting_icon(direction, sort_by)
     icon = direction == "desc" ? "icon-arrow-top" : "icon-arrow-down"
-    icon = sort_by == params[:sort_by] ? icon : ""
+    icon = sort_by.to_s == params[:sort_by] ? icon : ""
   end
 
   def set_direction(current_direction)

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -9,6 +9,11 @@ module BudgetInvestmentsHelper
     params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(', ')
   end
 
+  def link_to_investments_sorted_by(column)
+    sorting_option = budget_investments_sorting_options.select { |so| so[1] == column.downcase }.flatten
+    link_to t(sorting_option[0]), admin_budget_budget_investments_path(sort_by: sorting_option[1])
+  end
+
   def investments_minimal_view_path
     custom_budget_investments_path(id: @heading.group.to_param,
                                    heading_id: @heading.to_param,

--- a/app/helpers/budget_investments_helper.rb
+++ b/app/helpers/budget_investments_helper.rb
@@ -1,6 +1,6 @@
 module BudgetInvestmentsHelper
   def budget_investments_advanced_filters(params)
-    params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(', ')
+    params.map { |af| t("admin.budget_investments.index.filters.#{af}") }.join(", ")
   end
 
   def link_to_investments_sorted_by(column)
@@ -10,7 +10,7 @@ module BudgetInvestmentsHelper
     translation = t("admin.budget_investments.index.list.#{column}")
 
     link_to(
-      "#{translation} <span class='#{icon}'></span>".html_safe,
+      "#{translation} <span class='icon-sortable #{icon}'></span>".html_safe,
       admin_budget_budget_investments_path(sort_by: column, direction: direction)
     )
   end
@@ -18,9 +18,9 @@ module BudgetInvestmentsHelper
   def set_sorting_icon(direction, sort_by)
     if sort_by.to_s == params[:sort_by]
       if direction == "desc"
-        "icon-arrow-top"
+        "desc"
       else
-        "icon-arrow-down"
+        "asc"
       end
     else
       ""

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -145,16 +145,15 @@ class Budget
       results.where("budget_investments.id IN (?)", ids)
     end
 
-    def self.order_filter(sorting_param, direction)
-      sorting_key = sorting_param.to_sym if sorting_param
-      allowed_sort_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+    def self.order_filter(params)
+      sorting_key = params[:sort_by].to_sym if params[:sort_by]
+      allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
 
-      if allowed_sort_option.present? then
-        direction = %w[asc desc].include?(direction) ? direction : "asc"
-        order("#{allowed_sort_option[sorting_key]} #{direction}")
-      else
-        order(cached_votes_up: :desc).order(id: :desc)
+      if allowed_sort_option.present?
+        direction = %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+        return order("#{allowed_sort_option[sorting_key]} #{direction}")
       end
+      order(cached_votes_up: :desc).order(id: :desc)
     end
 
     def self.limit_results(budget, params, results)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -147,11 +147,11 @@ class Budget
 
     def self.order_filter(sorting_param, direction)
       sorting_key = sorting_param.to_sym if sorting_param
-      available_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+      allowed_sort_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
 
-      if sorting_param.present? && available_option.present? then
+      if sorting_param.present? && allowed_sort_option.present? then
         direction = %w[asc desc].include?(direction) ? direction : "asc"
-        order("#{available_option[sorting_key]} #{direction}")
+        order("#{allowed_sort_option[sorting_key]} #{direction}")
       else
         order(cached_votes_up: :desc).order(id: :desc)
       end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -146,7 +146,7 @@ class Budget
     end
 
     def self.order_filter(params)
-      sorting_key = params[:sort_by].to_sym if params[:sort_by]
+      sorting_key = params[:sort_by].downcase.to_sym if params[:sort_by]
       allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
 
       if allowed_sort_option.present?

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -151,9 +151,10 @@ class Budget
 
       if allowed_sort_option.present?
         direction = params[:direction] == "desc" ? "desc" : "asc"
-        return order("#{allowed_sort_option} #{direction}")
+        order("#{allowed_sort_option} #{direction}")
+      else
+        order(cached_votes_up: :desc).order(id: :desc)
       end
-      order(cached_votes_up: :desc).order(id: :desc)
     end
 
     def self.limit_results(budget, params, results)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -150,7 +150,7 @@ class Budget
       allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
 
       if allowed_sort_option.present?
-        direction = %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+        direction = params[:direction] == "desc" ? "desc" : "asc"
         return order("#{allowed_sort_option[sorting_key]} #{direction}")
       end
       order(cached_votes_up: :desc).order(id: :desc)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ActiveRecord::Base
-    SORTING_OPTIONS = [{id: "id"}, {title: "title"}, {supports: "cached_votes_up"}].freeze
+    SORTING_OPTIONS = {id: "id", title: "title", supports: "cached_votes_up"}.freeze
 
     include Rails.application.routes.url_helpers
     include Measurable
@@ -146,12 +146,12 @@ class Budget
     end
 
     def self.order_filter(params)
-      sorting_key = params[:sort_by].downcase.to_sym if params[:sort_by]
-      allowed_sort_option = SORTING_OPTIONS.select { |so| so[sorting_key]}.reduce
+      sorting_key = params[:sort_by]&.downcase&.to_sym
+      allowed_sort_option = SORTING_OPTIONS[sorting_key]
 
       if allowed_sort_option.present?
         direction = params[:direction] == "desc" ? "desc" : "asc"
-        return order("#{allowed_sort_option[sorting_key]} #{direction}")
+        return order("#{allowed_sort_option} #{direction}")
       end
       order(cached_votes_up: :desc).order(id: :desc)
     end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -146,10 +146,11 @@ class Budget
     end
 
     def self.order_filter(sorting_param, direction)
-      sorting_key = sorting_param.to_sym
+      sorting_key = sorting_param.to_sym if sorting_param
       available_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+
       if sorting_param.present? && available_option.present? then
-        %w[asc desc].include?(direction) ? direction : "desc"
+        direction = %w[asc desc].include?(direction) ? direction : "asc"
         order("#{available_option[sorting_key]} #{direction}")
       else
         order(cached_votes_up: :desc).order(id: :desc)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -149,7 +149,7 @@ class Budget
       sorting_key = sorting_param.to_sym if sorting_param
       allowed_sort_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
 
-      if sorting_param.present? && allowed_sort_option.present? then
+      if allowed_sort_option.present? then
         direction = %w[asc desc].include?(direction) ? direction : "asc"
         order("#{allowed_sort_option[sorting_key]} #{direction}")
       else

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ActiveRecord::Base
-    SORTING_OPTIONS = [{"id": "id"}, {"title": "title"}, {"supports": "cached_votes_up"}].freeze
+    SORTING_OPTIONS = [{id: "id"}, {title: "title"}, {supports: "cached_votes_up"}].freeze
 
     include Rails.application.routes.url_helpers
     include Measurable

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ActiveRecord::Base
-    SORTING_OPTIONS = %w(id title supports).freeze
+    SORTING_OPTIONS = [{"id": "id"}, {"title": "title"}, {"supports": "cached_votes_up"}].freeze
 
     include Rails.application.routes.url_helpers
     include Measurable
@@ -145,9 +145,12 @@ class Budget
       results.where("budget_investments.id IN (?)", ids)
     end
 
-    def self.order_filter(sorting_param)
-      if sorting_param.present? && SORTING_OPTIONS.include?(sorting_param)
-        send("sort_by_#{sorting_param}")
+    def self.order_filter(sorting_param, direction)
+      sorting_key = sorting_param.to_sym
+      available_option = SORTING_OPTIONS.select { |sp| sp[sorting_key]}.reduce
+      if sorting_param.present? && available_option.present? then
+        %w[asc desc].include?(direction) ? direction : "desc"
+        order("#{available_option[sorting_key]} #{direction}")
       else
         order(cached_votes_up: :desc).order(id: :desc)
       end

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -26,9 +26,9 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.id")  %></th>
-        <th class="small-3"><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.title") %></th>
-        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.supports") %></th>
+        <th><%= link_to_investments_sorted_by :id  %></th>
+        <th class="small-3"><%= link_to_investments_sorted_by :title %></th>
+        <th><%= link_to_investments_sorted_by :supports %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
           <%= t("admin.budget_investments.index.list.valuation_group") %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -35,9 +35,9 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= link_to t("admin.budget_investments.index.list.id"), admin_budget_budget_investments_path(sort_by: "id")  %></th>
-        <th class="small-3"><%= link_to t("admin.budget_investments.index.list.title"), admin_budget_budget_investments_path(sort_by: "title") %></th>
-        <th><%= link_to t("admin.budget_investments.index.list.supports"), admin_budget_budget_investments_path(sort_by: "supports") %></th>
+        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.id")  %></th>
+        <th class="small-3"><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.title") %></th>
+        <th><%= link_to_investments_sorted_by t("admin.budget_investments.index.list.supports") %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
           <%= t("admin.budget_investments.index.list.valuation_group") %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -35,9 +35,9 @@
   <table class="table-for-mobile">
     <thead>
       <tr>
-        <th><%= t("admin.budget_investments.index.list.id") %></th>
-        <th class="small-3"><%= t("admin.budget_investments.index.list.title") %></th>
-        <th><%= t("admin.budget_investments.index.list.supports") %></th>
+        <th><%= link_to t("admin.budget_investments.index.list.id"), admin_budget_budget_investments_path(sort_by: "id")  %></th>
+        <th class="small-3"><%= link_to t("admin.budget_investments.index.list.title"), admin_budget_budget_investments_path(sort_by: "title") %></th>
+        <th><%= link_to t("admin.budget_investments.index.list.supports"), admin_budget_budget_investments_path(sort_by: "supports") %></th>
         <th><%= t("admin.budget_investments.index.list.admin") %></th>
         <th>
           <%= t("admin.budget_investments.index.list.valuation_group") %>

--- a/app/views/admin/budget_investments/_investments.html.erb
+++ b/app/views/admin/budget_investments/_investments.html.erb
@@ -1,12 +1,3 @@
-<%= form_tag(admin_budget_budget_investments_path(budget: @budget), method: :get) do %>
-  <div class="small-12 medium-3 column">
-    <%= select_tag :sort_by, options_for_select(budget_investments_sorting_options, params[:sort_by]),
-                   { prompt: t("admin.budget_investments.index.sort_by.placeholder"),
-                     label: false,
-                     class: "js-submit-on-change" } %>
-  </div>
-<% end %>
-
 <%= link_to t("admin.budget_investments.index.download_current_selection"),
             admin_budget_budget_investments_path(csv_params),
             class: "float-right small clear" %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -184,11 +184,6 @@ en:
         tags_filter_all: All tags
         advanced_filters: Advanced filters
         placeholder: Search projects
-        sort_by:
-          placeholder: Sort by
-          id: ID
-          title: Title
-          supports: Supports
         filters:
           all: All
           without_admin: Without assigned admin

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -184,11 +184,6 @@ es:
         tags_filter_all: Todas las etiquetas
         advanced_filters: Filtros avanzados
         placeholder: Buscar proyectos
-        sort_by:
-          placeholder: Ordenar por
-          id: ID
-          title: Título
-          supports: Apoyos
         filters:
           valuation_open: Abiertos
           all: Todos

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -692,7 +692,7 @@ feature 'Admin budget investments' do
       create(:budget_investment, title: 'C Third Investment', cached_votes_up: 10, budget: budget)
     end
 
-    scenario "Default sorting" do
+    scenario "Default" do
       create(:budget_investment, title: 'D Fourth Investment', cached_votes_up: 50, budget: budget)
 
       visit admin_budget_budget_investments_path(budget)
@@ -702,26 +702,76 @@ feature 'Admin budget investments' do
       expect('A Second Investment').to appear_before('C Third Investment')
     end
 
-    scenario 'Sort by ID' do
-      visit admin_budget_budget_investments_path(budget, sort_by: 'id')
+    context 'Ascending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'asc')
 
-      expect('C Third Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by title' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'asc')
+
+        expect('A Second Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by supports' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'asc')
+
+        expect('C Third Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('B First Investment')
+      end
     end
 
-    scenario 'Sort by title' do
-      visit admin_budget_budget_investments_path(budget, sort_by: 'title')
+    context 'Descending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'desc')
 
-      expect('A Second Investment').to appear_before('B First Investment')
-      expect('B First Investment').to appear_before('C Third Investment')
+        expect('C Third Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('B First Investment')
+      end
+
+      scenario 'Sort by title' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'desc')
+
+        expect('C Third Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('A Second Investment')
+      end
+
+      scenario 'Sort by supports' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'desc')
+
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+      end
     end
 
-    scenario 'Sort by supports' do
-      visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
+    context 'With no direction provided sorts ascending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id')
 
-      expect('B First Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('C Third Investment')
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by title' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'title')
+
+        expect('A Second Investment').to appear_before('B First Investment')
+        expect('B First Investment').to appear_before('C Third Investment')
+      end
+
+      scenario 'Sort by supports' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
+
+        expect('C Third Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('B First Investment')
+      end
     end
+
+
   end
 
   context 'Show' do

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -708,6 +708,9 @@ feature 'Admin budget investments' do
 
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by title' do
@@ -715,6 +718,9 @@ feature 'Admin budget investments' do
 
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
+        within('th', text: 'Title') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by supports' do
@@ -722,6 +728,9 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
+        within('th', text: 'Supports') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
     end
 
@@ -731,6 +740,9 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-down")
+        end
       end
 
       scenario 'Sort by title' do
@@ -738,6 +750,9 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('A Second Investment')
+        within('th', text: 'Title') do
+          expect(page).to have_css(".icon-arrow-down")
+        end
       end
 
       scenario 'Sort by supports' do
@@ -745,6 +760,9 @@ feature 'Admin budget investments' do
 
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'Supports') do
+          expect(page).to have_css(".icon-arrow-down")
+        end
       end
     end
 
@@ -754,6 +772,9 @@ feature 'Admin budget investments' do
 
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by title' do
@@ -761,6 +782,9 @@ feature 'Admin budget investments' do
 
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
+        within('th', text: 'Title') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
 
       scenario 'Sort by supports' do
@@ -768,10 +792,23 @@ feature 'Admin budget investments' do
 
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
+        within('th', text: 'Supports') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
       end
     end
 
+    context 'With incorrect direction provided sorts ascending' do
+      scenario 'Sort by ID' do
+        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'incorrect')
 
+        expect('B First Investment').to appear_before('A Second Investment')
+        expect('A Second Investment').to appear_before('C Third Investment')
+        within('th', text: 'ID') do
+          expect(page).to have_css(".icon-arrow-top")
+        end
+      end
+    end
   end
 
   context 'Show' do

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -1,10 +1,10 @@
-require 'rails_helper'
+require "rails_helper"
 
-feature 'Admin budget investments' do
+feature "Admin budget investments" do
 
   let(:budget) { create(:budget) }
   let(:administrator) do
-    create(:administrator, user: create(:user, username: 'Ana', email: 'ana@admins.org'))
+    create(:administrator, user: create(:user, username: "Ana", email: "ana@admins.org"))
   end
 
   it_behaves_like "admin_milestoneable",
@@ -12,21 +12,21 @@ feature 'Admin budget investments' do
                   "admin_budget_budget_investment_path"
 
   background do
-    @admin = create(:administrator)
-    login_as(@admin.user)
+    admin = create(:administrator)
+    login_as(admin.user)
   end
 
   context "Feature flag" do
 
     background do
-      Setting['feature.budgets'] = nil
+      Setting["feature.budgets"] = nil
     end
 
     after do
-      Setting['feature.budgets'] = true
+      Setting["feature.budgets"] = true
     end
 
-    scenario 'Disabled with a feature flag' do
+    scenario "Disabled with a feature flag" do
       expect{ visit admin_budgets_path }.to raise_exception(FeatureFlags::FeatureDisabled)
     end
 
@@ -62,7 +62,7 @@ feature 'Admin budget investments' do
 
   context "Index" do
 
-    scenario 'Displaying investments' do
+    scenario "Displaying investments" do
       budget_investment = create(:budget_investment, budget: budget, cached_votes_up: 77)
       visit admin_budget_budget_investments_path(budget_id: budget.id)
       expect(page).to have_content(budget_investment.title)
@@ -71,7 +71,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.total_votes)
     end
 
-    scenario 'If budget is finished do not show "Selected" button' do
+    scenario "If budget is finished do not show 'Selected' button" do
       finished_budget = create(:budget, :finished)
       budget_investment = create(:budget_investment, budget: finished_budget, cached_votes_up: 77)
 
@@ -86,14 +86,17 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario 'Display admin and valuator assignments' do
+    scenario "Display admin and valuator assignments" do
       budget_investment1 = create(:budget_investment, budget: budget)
       budget_investment2 = create(:budget_investment, budget: budget)
       budget_investment3 = create(:budget_investment, budget: budget)
 
-      valuator1 = create(:valuator, user: create(:user, username: 'Olga'), description: 'Valuator Olga')
-      valuator2 = create(:valuator, user: create(:user, username: 'Miriam'), description: 'Valuator Miriam')
-      admin = create(:administrator, user: create(:user, username: 'Gema'))
+
+      olga = create(:user, username: "Olga")
+      miriam = create(:user, username: "Miriam")
+      valuator1 = create(:valuator, user: olga, description: "Valuator Olga")
+      valuator2 = create(:valuator, user: miriam, description: "Valuator Miriam")
+      admin = create(:administrator, user: create(:user, username: "Gema"))
 
       budget_investment1.valuators << valuator1
       budget_investment2.valuators << valuator1
@@ -124,7 +127,7 @@ feature 'Admin budget investments' do
       end
     end
 
-    scenario 'Display valuator group assignments' do
+    scenario "Display valuator group assignments" do
       budget_investment1 = create(:budget_investment, budget: budget)
       budget_investment2 = create(:budget_investment, budget: budget)
       budget_investment3 = create(:budget_investment, budget: budget)
@@ -159,9 +162,12 @@ feature 'Admin budget investments' do
       group1_heading2 = create(:budget_heading, group: group1, name: "Mercy Street")
       group2_heading1 = create(:budget_heading, group: group2, name: "Central Park")
 
-      create(:budget_investment, title: "Realocate visitors", budget: budget, group: group1, heading: group1_heading1)
-      create(:budget_investment, title: "Change name", budget: budget, group: group1, heading: group1_heading2)
-      create(:budget_investment, title: "Plant trees", budget: budget, group: group2, heading: group2_heading1)
+      create(:budget_investment, title: "Realocate visitors", budget: budget, group: group1,
+                                                              heading: group1_heading1)
+      create(:budget_investment, title: "Change name", budget: budget, group: group1,
+                                                                       heading: group1_heading2)
+      create(:budget_investment, title: "Plant trees", budget: budget, group: group2,
+                                                                       heading: group2_heading1)
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
@@ -170,28 +176,28 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Plant trees")
 
       select "Central Park", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
       expect(page).not_to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
       select "All headings", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).to have_link("Realocate visitors")
       expect(page).to have_link("Change name")
       expect(page).to have_link("Plant trees")
 
       select "Streets: Main Avenue", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).to have_link("Realocate visitors")
       expect(page).not_to have_link("Change name")
       expect(page).not_to have_link("Plant trees")
 
       select "Streets: Mercy Street", from: "heading_id"
-      click_button 'Filter'
+      click_button "Filter"
 
       expect(page).not_to have_link("Realocate visitors")
       expect(page).to have_link("Change name")
@@ -200,10 +206,11 @@ feature 'Admin budget investments' do
 
     context "Filtering by admin" do
       background do
-        user = create(:user, username: 'Admin 1')
+        user = create(:user, username: "Admin 1")
         administrator = create(:administrator, user: user)
 
-        create(:budget_investment, title: "Realocate visitors", budget: budget, administrator: administrator)
+        create(:budget_investment, title: "Realocate visitors", budget: budget,
+                                                                administrator: administrator)
         create(:budget_investment, title: "Destroy the city", budget: budget)
 
         visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -216,25 +223,25 @@ feature 'Admin budget investments' do
 
       scenario "Should have specific admin budgets", :js do
         select "Admin 1", from: "administrator_id"
-        click_button 'Filter'
+        click_button "Filter"
 
-        expect(page).to have_content('There is 1 investment')
+        expect(page).to have_content("There is 1 investment")
         expect(page).not_to have_link("Destroy the city")
         expect(page).to have_link("Realocate visitors")
       end
 
       scenario "Should have all admins budgets", :js do
         select "All administrators", from: "administrator_id"
-        click_button 'Filter'
+        click_button "Filter"
 
-        expect(page).to have_content('There are 2 investments')
+        expect(page).to have_content("There are 2 investments")
         expect(page).to have_link("Destroy the city")
         expect(page).to have_link("Realocate visitors")
 
         select "Admin 1", from: "administrator_id"
-        click_button 'Filter'
+        click_button "Filter"
 
-        expect(page).to have_content('There is 1 investment')
+        expect(page).to have_content("There is 1 investment")
         expect(page).not_to have_link("Destroy the city")
         expect(page).to have_link("Realocate visitors")
       end
@@ -242,7 +249,7 @@ feature 'Admin budget investments' do
 
     scenario "Filtering by valuator", :js do
       user = create(:user)
-      valuator = create(:valuator, user: user, description: 'Valuator 1')
+      valuator = create(:valuator, user: user, description: "Valuator 1")
 
       budget_investment = create(:budget_investment, title: "Realocate visitors", budget: budget)
       budget_investment.valuators << valuator
@@ -254,29 +261,28 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Destroy the city")
 
       select "Valuator 1", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
 
       select "All valuators", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
       expect(page).to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
 
       select "Valuator 1", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).not_to have_link("Destroy the city")
       expect(page).to have_link("Realocate visitors")
     end
 
     scenario "Filtering by valuator group", :js do
-      user = create(:user)
       health_group = create(:valuator_group, name: "Health")
       culture_group = create(:valuator_group, name: "Culture")
 
@@ -292,33 +298,33 @@ feature 'Admin budget investments' do
       expect(page).to have_link("Build a theatre")
 
       select "Health", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).to have_link("Build a hospital")
       expect(page).not_to have_link("Build a theatre")
 
       select "All valuators", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
       expect(page).to have_link("Build a hospital")
       expect(page).to have_link("Build a theatre")
 
       select "Culture", from: "valuator_or_group_id"
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
       expect(page).to have_link("Build a theatre")
       expect(page).not_to have_link("Build a hospital")
     end
 
     scenario "Current filter is properly highlighted" do
-      filters_links = { 'all' => 'All',
-                        'without_admin' => 'Without assigned admin',
-                        'without_valuator' => 'Without assigned valuator',
-                        'under_valuation' => 'Under valuation',
-                        'valuation_finished' => 'Valuation finished' }
+      filters_links = { "all" => "All",
+                        "without_admin" => "Without assigned admin",
+                        "without_valuator" => "Without assigned valuator",
+                        "under_valuation" => "Under valuation",
+                        "valuation_finished" => "Valuation finished" }
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
@@ -344,19 +350,19 @@ feature 'Admin budget investments' do
       create(:budget_investment, title: "With group", budget: budget,
              valuator_groups: [create(:valuator_group)])
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'valuation_open')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "valuation_open")
 
       expect(page).to have_content("Assigned idea")
       expect(page).to have_content("Evaluating...")
       expect(page).to have_content("With group")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'without_admin')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "without_admin")
 
       expect(page).to have_content("Evaluating...")
       expect(page).to have_content("With group")
       expect(page).not_to have_content("Assigned idea")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'without_valuator')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "without_valuator")
 
       expect(page).to have_content("Assigned idea")
       expect(page).not_to have_content("Evaluating...")
@@ -364,52 +370,54 @@ feature 'Admin budget investments' do
     end
 
     scenario "Filtering by valuation status" do
-      valuating = create(:budget_investment, budget: budget, title: "Ongoing valuation", administrator: create(:administrator))
-      valuated = create(:budget_investment, budget: budget, title: "Old idea", valuation_finished: true)
+      valuating = create(:budget_investment, budget: budget, title: "Ongoing valuation",
+                                                             administrator: create(:administrator))
+      valuated = create(:budget_investment, budget: budget, title: "Old idea",
+                                                            valuation_finished: true)
       valuating.valuators.push(create(:valuator))
       valuated.valuators.push(create(:valuator))
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'under_valuation')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "under_valuation")
 
       expect(page).to have_content("Ongoing valuation")
       expect(page).not_to have_content("Old idea")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'valuation_finished')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "valuation_finished")
 
       expect(page).not_to have_content("Ongoing valuation")
       expect(page).to have_content("Old idea")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: 'all')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, filter: "all")
       expect(page).to have_content("Ongoing valuation")
       expect(page).to have_content("Old idea")
     end
 
     scenario "Filtering by tag" do
-      create(:budget_investment, budget: budget, title: 'Educate the children', tag_list: 'Education')
-      create(:budget_investment, budget: budget, title: 'More schools',         tag_list: 'Education')
-      create(:budget_investment, budget: budget, title: 'More hospitals',       tag_list: 'Health')
+      create(:budget_investment, budget: budget, title: "Educate children", tag_list: "Education")
+      create(:budget_investment, budget: budget, title: "More schools",     tag_list: "Education")
+      create(:budget_investment, budget: budget, title: "More hospitals",   tag_list: "Health")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
       expect(page).to have_css(".budget_investment", count: 3)
-      expect(page).to have_content("Educate the children")
+      expect(page).to have_content("Educate children")
       expect(page).to have_content("More schools")
       expect(page).to have_content("More hospitals")
 
-      visit admin_budget_budget_investments_path(budget_id: budget.id, tag_name: 'Education')
+      visit admin_budget_budget_investments_path(budget_id: budget.id, tag_name: "Education")
 
       expect(page).not_to have_content("More hospitals")
       expect(page).to have_css(".budget_investment", count: 2)
-      expect(page).to have_content("Educate the children")
+      expect(page).to have_content("Educate children")
       expect(page).to have_content("More schools")
     end
 
     scenario "Filtering by tag, display only valuation tags" do
-      investment1 = create(:budget_investment, budget: budget, tag_list: 'Education')
-      investment2 = create(:budget_investment, budget: budget, tag_list: 'Health')
+      investment1 = create(:budget_investment, budget: budget, tag_list: "Education")
+      investment2 = create(:budget_investment, budget: budget, tag_list: "Health")
 
-      investment1.set_tag_list_on(:valuation, 'Teachers')
-      investment2.set_tag_list_on(:valuation, 'Hospitals')
+      investment1.set_tag_list_on(:valuation, "Teachers")
+      investment2.set_tag_list_on(:valuation, "Hospitals")
 
       investment1.save
       investment2.save
@@ -421,11 +429,11 @@ feature 'Admin budget investments' do
 
     scenario "Filtering by tag, display only valuation tags of the current budget" do
       new_budget = create(:budget)
-      investment1 = create(:budget_investment, budget: budget, tag_list: 'Roads')
-      investment2 = create(:budget_investment, budget: new_budget, tag_list: 'Accessibility')
+      investment1 = create(:budget_investment, budget: budget, tag_list: "Roads")
+      investment2 = create(:budget_investment, budget: new_budget, tag_list: "Accessibility")
 
-      investment1.set_tag_list_on(:valuation, 'Roads')
-      investment2.set_tag_list_on(:valuation, 'Accessibility')
+      investment1.set_tag_list_on(:valuation, "Roads")
+      investment2.set_tag_list_on(:valuation, "Accessibility")
 
       investment1.save
       investment2.save
@@ -470,44 +478,44 @@ feature 'Admin budget investments' do
       roads   = create(:budget_heading, group: group_2)
       streets = create(:budget_heading, group: group_2)
 
-      create(:budget_investment, heading: parks, cached_votes_up: 40, title: "Park with 40 supports")
-      create(:budget_investment, heading: parks, cached_votes_up: 99, title: "Park with 99 supports")
-      create(:budget_investment, heading: roads, cached_votes_up: 100, title: "Road with 100 supports")
-      create(:budget_investment, heading: roads, cached_votes_up: 199, title: "Road with 199 supports")
-      create(:budget_investment, heading: streets, cached_votes_up: 200, title: "Street with 200 supports")
-      create(:budget_investment, heading: streets, cached_votes_up: 300, title: "Street with 300 supports")
+      create(:budget_investment, heading: parks, cached_votes_up: 40, title: "Park 40 supports")
+      create(:budget_investment, heading: parks, cached_votes_up: 99, title: "Park 99 supports")
+      create(:budget_investment, heading: roads, cached_votes_up: 100, title: "Road 100 supports")
+      create(:budget_investment, heading: roads, cached_votes_up: 199, title: "Road 199 supports")
+      create(:budget_investment, heading: streets, cached_votes_up: 200, title: "St. 200 supports")
+      create(:budget_investment, heading: streets, cached_votes_up: 300, title: "St. 300 supports")
 
       visit admin_budget_budget_investments_path(budget)
 
-      expect(page).to have_link("Park with 40 supports")
-      expect(page).to have_link("Park with 99 supports")
-      expect(page).to have_link("Road with 100 supports")
-      expect(page).to have_link("Road with 199 supports")
-      expect(page).to have_link("Street with 200 supports")
-      expect(page).to have_link("Street with 300 supports")
+      expect(page).to have_link("Park 40 supports")
+      expect(page).to have_link("Park 99 supports")
+      expect(page).to have_link("Road 100 supports")
+      expect(page).to have_link("Road 199 supports")
+      expect(page).to have_link("St. 200 supports")
+      expect(page).to have_link("St. 300 supports")
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
       fill_in "min_total_supports", with: 180
-      click_button 'Filter'
+      click_button "Filter"
 
-      expect(page).to have_content('There are 3 investments')
-      expect(page).to have_link("Road with 199 supports")
-      expect(page).to have_link("Street with 200 supports")
-      expect(page).to have_link("Street with 300 supports")
-      expect(page).not_to have_link("Park with 40 supports")
-      expect(page).not_to have_link("Park with 99 supports")
-      expect(page).not_to have_link("Road with 100 supports")
+      expect(page).to have_content("There are 3 investments")
+      expect(page).to have_link("Road 199 supports")
+      expect(page).to have_link("St. 200 supports")
+      expect(page).to have_link("St. 300 supports")
+      expect(page).not_to have_link("Park 40 supports")
+      expect(page).not_to have_link("Park 99 supports")
+      expect(page).not_to have_link("Road 100 supports")
     end
 
     scenario "Combination of checkbox with text search", :js do
-      user = create(:user, username: 'Admin 1')
+      user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      first_investment = create(:budget_investment, budget: budget, title: 'Educate the children',
+      first_investment = create(:budget_investment, budget: budget, title: "Educate the children",
                                                    administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More schools',
+      create(:budget_investment, budget: budget, title: "More schools",
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More hospitals')
+      create(:budget_investment, budget: budget, title: "More hospitals")
 
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -525,7 +533,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      fill_in 'title_or_id', with: first_investment.id
+      fill_in "title_or_id", with: first_investment.id
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 1)
@@ -533,18 +541,18 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      expect(page).to have_content('Selected')
+      expect(page).to have_content("Selected")
 
     end
 
     scenario "Combination of select with text search", :js do
-      first_investment = create(:budget_investment, budget: budget, title: 'Educate the children',
-                                 feasibility: 'feasible',
+      first_investment = create(:budget_investment, budget: budget, title: "Educate the children",
+                                 feasibility: "feasible",
                                  valuation_finished: true)
-      create(:budget_investment, budget: budget, title: 'More schools',
-                                 feasibility: 'feasible',
+      create(:budget_investment, budget: budget, title: "More schools",
+                                 feasibility: "feasible",
                                  valuation_finished: true)
-      create(:budget_investment, budget: budget, title: 'More hospitals')
+      create(:budget_investment, budget: budget, title: "More hospitals")
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
 
@@ -553,9 +561,9 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
       expect(page).to have_content("More hospitals")
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      page.check('advanced_filters_feasible')
+      page.check("advanced_filters_feasible")
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 2)
@@ -563,7 +571,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      fill_in 'title_or_id', with: first_investment.id
+      fill_in "title_or_id", with: first_investment.id
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 1)
@@ -571,25 +579,25 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More schools")
       expect(page).not_to have_content("More hospitals")
 
-      expect(page).to have_content('Selected')
+      expect(page).to have_content("Selected")
 
     end
 
     scenario "Combination of checkbox with text search and checkbox", :js do
-      user = create(:user, username: 'Admin 1')
+      user = create(:user, username: "Admin 1")
       administrator = create(:administrator, user: user)
 
-      first_investment = create(:budget_investment, budget: budget, title: 'Educate the children',
-                                 feasibility: 'feasible',
+      first_investment = create(:budget_investment, budget: budget, title: "Educate the children",
+                                 feasibility: "feasible",
                                  valuation_finished: true,
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More schools',
-                                 feasibility: 'feasible',
+      create(:budget_investment, budget: budget, title: "More schools",
+                                 feasibility: "feasible",
                                  valuation_finished: true,
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More hospitals',
+      create(:budget_investment, budget: budget, title: "More hospitals",
                                  administrator: administrator)
-      create(:budget_investment, budget: budget, title: 'More hostals')
+      create(:budget_investment, budget: budget, title: "More hostals")
 
 
       visit admin_budget_budget_investments_path(budget_id: budget.id)
@@ -609,10 +617,10 @@ feature 'Admin budget investments' do
       expect(page).to have_content("More hospitals")
       expect(page).not_to have_content("More hostals")
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_feasible') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_feasible") }
+      click_button("Filter")
 
       expect(page).to have_css(".budget_investment", count: 2)
       expect(page).to have_content("Educate the children")
@@ -620,7 +628,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More hospitals")
       expect(page).not_to have_content("More hostals")
 
-      fill_in 'title_or_id', with: first_investment.id
+      fill_in "title_or_id", with: first_investment.id
       click_button "Filter"
 
       expect(page).to have_css(".budget_investment", count: 1)
@@ -629,7 +637,7 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content("More hospitals")
       expect(page).not_to have_content("More hostals")
 
-      expect(page).to have_content('Selected')
+      expect(page).to have_content("Selected")
     end
 
     scenario "See results button appears when budget status is finished" do
@@ -649,176 +657,178 @@ feature 'Admin budget investments' do
 
   end
 
-  context 'Search' do
+  context "Search" do
     let!(:first_investment) do
-      create(:budget_investment, title: 'Some other investment', budget: budget)
+      create(:budget_investment, title: "Some other investment", budget: budget)
     end
 
     background do
-      create(:budget_investment, title: 'Some investment', budget: budget)
+      create(:budget_investment, title: "Some investment", budget: budget)
     end
 
     scenario "Search investments by title" do
       visit admin_budget_budget_investments_path(budget)
 
-      expect(page).to have_content('Some investment')
-      expect(page).to have_content('Some other investment')
+      expect(page).to have_content("Some investment")
+      expect(page).to have_content("Some other investment")
 
-      fill_in 'title_or_id', with: 'Some investment'
-      click_button 'Filter'
+      fill_in "title_or_id", with: "Some investment"
+      click_button "Filter"
 
-      expect(page).to have_content('Some investment')
-      expect(page).not_to have_content('Some other investment')
+      expect(page).to have_content("Some investment")
+      expect(page).not_to have_content("Some other investment")
     end
 
-    scenario 'Search investments by ID' do
+    scenario "Search investments by ID" do
       visit admin_budget_budget_investments_path(budget)
 
-      expect(page).to have_content('Some investment')
-      expect(page).to have_content('Some other investment')
+      expect(page).to have_content("Some investment")
+      expect(page).to have_content("Some other investment")
 
-      fill_in 'title_or_id', with: first_investment.id
-      click_button 'Filter'
+      fill_in "title_or_id", with: first_investment.id
+      click_button "Filter"
 
-      expect(page).to have_content('Some other investment')
-      expect(page).not_to have_content('Some investment')
+      expect(page).to have_content("Some other investment")
+      expect(page).not_to have_content("Some investment")
     end
   end
 
-  context 'Sorting' do
+  context "Sorting" do
+
     background do
-      create(:budget_investment, title: 'B First Investment', cached_votes_up: 50, budget: budget)
-      create(:budget_investment, title: 'A Second Investment', cached_votes_up: 25, budget: budget)
-      create(:budget_investment, title: 'C Third Investment', cached_votes_up: 10, budget: budget)
+      create(:budget_investment, title: "B First Investment", budget: budget, cached_votes_up: 50)
+      create(:budget_investment, title: "A Second Investment", budget: budget, cached_votes_up: 25)
+      create(:budget_investment, title: "C Third Investment", budget: budget, cached_votes_up: 10)
     end
 
     scenario "Default" do
-      create(:budget_investment, title: 'D Fourth Investment', cached_votes_up: 50, budget: budget)
+      create(:budget_investment, title: "D Fourth Investment", cached_votes_up: 50, budget: budget)
 
       visit admin_budget_budget_investments_path(budget)
 
-      expect('D Fourth Investment').to appear_before('B First Investment')
-      expect('B First Investment').to appear_before('A Second Investment')
-      expect('A Second Investment').to appear_before('C Third Investment')
+      expect("D Fourth Investment").to appear_before("B First Investment")
+      expect("B First Investment").to appear_before("A Second Investment")
+      expect("A Second Investment").to appear_before("C Third Investment")
     end
 
-    context 'Ascending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'asc')
+    context "Ascending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id", direction: "asc")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'ID') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by title' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'asc')
+      scenario "Sort by title" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "title", direction: "asc")
 
-        expect('A Second Investment').to appear_before('B First Investment')
-        expect('B First Investment').to appear_before('C Third Investment')
-        within('th', text: 'Title') do
+        expect("A Second Investment").to appear_before("B First Investment")
+        expect("B First Investment").to appear_before("C Third Investment")
+        within("th", text: "Title") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by supports' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'asc')
+      scenario "Sort by supports" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "supports", direction: "asc")
 
-        expect('C Third Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('B First Investment')
-        within('th', text: 'Supports') do
+        expect("C Third Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("B First Investment")
+        within("th", text: "Supports") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
 
-    context 'Descending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'desc')
+    context "Descending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id", direction: "desc")
 
-        expect('C Third Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('B First Investment')
-        within('th', text: 'ID') do
+        expect("C Third Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("B First Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
-      scenario 'Sort by title' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'title', direction: 'desc')
+      scenario "Sort by title" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "title", direction: "desc")
 
-        expect('C Third Investment').to appear_before('B First Investment')
-        expect('B First Investment').to appear_before('A Second Investment')
-        within('th', text: 'Title') do
+        expect("C Third Investment").to appear_before("B First Investment")
+        expect("B First Investment").to appear_before("A Second Investment")
+        within("th", text: "Title") do
           expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
-      scenario 'Sort by supports' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'supports', direction: 'desc')
+      scenario "Sort by supports" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "supports", direction: "desc")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'Supports') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "Supports") do
           expect(page).to have_css(".icon-sortable.asc")
         end
       end
     end
 
-    context 'With no direction provided sorts ascending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id')
+    context "With no direction provided sorts ascending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'ID') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by title' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'title')
+      scenario "Sort by title" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "title")
 
-        expect('A Second Investment').to appear_before('B First Investment')
-        expect('B First Investment').to appear_before('C Third Investment')
-        within('th', text: 'Title') do
+        expect("A Second Investment").to appear_before("B First Investment")
+        expect("B First Investment").to appear_before("C Third Investment")
+        within("th", text: "Title") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
-      scenario 'Sort by supports' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'supports')
+      scenario "Sort by supports" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "supports")
 
-        expect('C Third Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('B First Investment')
-        within('th', text: 'Supports') do
+        expect("C Third Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("B First Investment")
+        within("th", text: "Supports") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
 
-    context 'With incorrect direction provided sorts ascending' do
-      scenario 'Sort by ID' do
-        visit admin_budget_budget_investments_path(budget, sort_by: 'id', direction: 'incorrect')
+    context "With incorrect direction provided sorts ascending" do
+      scenario "Sort by ID" do
+        visit admin_budget_budget_investments_path(budget, sort_by: "id", direction: "incorrect")
 
-        expect('B First Investment').to appear_before('A Second Investment')
-        expect('A Second Investment').to appear_before('C Third Investment')
-        within('th', text: 'ID') do
+        expect("B First Investment").to appear_before("A Second Investment")
+        expect("A Second Investment").to appear_before("C Third Investment")
+        within("th", text: "ID") do
           expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
   end
 
-  context 'Show' do
-    scenario 'Show the investment details' do
-      valuator = create(:valuator, user: create(:user, username: 'Rachel', email: 'rachel@valuators.org'))
+  context "Show" do
+    scenario "Show the investment details" do
+      user = create(:user, username: "Rachel", email: "rachel@valuators.org")
+      valuator = create(:valuator, user: user)
       budget_investment = create(:budget_investment,
                                   price: 1234,
                                   price_first_year: 1000,
                                   feasibility: "unfeasible",
-                                  unfeasibility_explanation: 'It is impossible',
+                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
       budget_investment.valuators << valuator
 
@@ -830,27 +840,27 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.description)
       expect(page).to have_content(budget_investment.author.name)
       expect(page).to have_content(budget_investment.heading.name)
-      expect(page).to have_content('Without image')
-      expect(page).to have_content('Without documents')
-      expect(page).to have_content('1234')
-      expect(page).to have_content('1000')
-      expect(page).to have_content('Unfeasible')
-      expect(page).to have_content('It is impossible')
-      expect(page).to have_content('Ana (ana@admins.org)')
+      expect(page).to have_content("Without image")
+      expect(page).to have_content("Without documents")
+      expect(page).to have_content("1234")
+      expect(page).to have_content("1000")
+      expect(page).to have_content("Unfeasible")
+      expect(page).to have_content("It is impossible")
+      expect(page).to have_content("Ana (ana@admins.org)")
 
-      within('#assigned_valuators') do
-        expect(page).to have_content('Rachel (rachel@valuators.org)')
+      within("#assigned_valuators") do
+        expect(page).to have_content("Rachel (rachel@valuators.org)")
       end
 
       expect(page).to have_button "Publish comment"
     end
 
-    scenario 'Show image and documents on investment details' do
+    scenario "Show image and documents on investment details" do
       budget_investment = create(:budget_investment,
                                   price: 1234,
                                   price_first_year: 1000,
                                   feasibility: "unfeasible",
-                                  unfeasibility_explanation: 'It is impossible',
+                                  unfeasibility_explanation: "It is impossible",
                                   administrator: administrator)
       create(:image, imageable: budget_investment)
       document = create(:document, documentable: budget_investment)
@@ -863,13 +873,13 @@ feature 'Admin budget investments' do
       expect(page).to have_content(budget_investment.description)
       expect(page).to have_content(budget_investment.author.name)
       expect(page).to have_content(budget_investment.heading.name)
-      expect(page).to have_content('See image')
-      expect(page).to have_content('See documents (1)')
-      expect(page).to have_content('1234')
-      expect(page).to have_content('1000')
-      expect(page).to have_content('Unfeasible')
-      expect(page).to have_content('It is impossible')
-      expect(page).to have_content('Ana (ana@admins.org)')
+      expect(page).to have_content("See image")
+      expect(page).to have_content("See documents (1)")
+      expect(page).to have_content("1234")
+      expect(page).to have_content("1000")
+      expect(page).to have_content("Unfeasible")
+      expect(page).to have_content("It is impossible")
+      expect(page).to have_content("Ana (ana@admins.org)")
     end
 
     scenario "If budget is finished, investment cannot be edited or valuation comments created" do
@@ -899,34 +909,34 @@ feature 'Admin budget investments' do
       create(:budget_heading, group: budget_investment.group, name: "Barbate")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      fill_in 'budget_investment_title', with: 'Potatoes'
-      fill_in 'budget_investment_description', with: 'Carrots'
-      select "#{budget_investment.group.name}: Barbate", from: 'budget_investment[heading_id]'
-      fill_in 'budget_investment_organization_name', with: 'Vegetables'
+      fill_in "budget_investment_title", with: "Potatoes"
+      fill_in "budget_investment_description", with: "Carrots"
+      select "#{budget_investment.group.name}: Barbate", from: "budget_investment[heading_id]"
+      fill_in "budget_investment_organization_name", with: "Vegetables"
       uncheck "budget_investment_incompatible"
       check "budget_investment_selected"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Potatoes'
-      expect(page).to have_content 'Carrots'
-      expect(page).to have_content 'Barbate'
-      expect(page).to have_content 'Representing: Vegetables'
-      expect(page).to have_content 'Compatibility: Compatible'
-      expect(page).to have_content 'Selected'
+      expect(page).to have_content "Potatoes"
+      expect(page).to have_content "Carrots"
+      expect(page).to have_content "Barbate"
+      expect(page).to have_content "Representing: Vegetables"
+      expect(page).to have_content "Compatibility: Compatible"
+      expect(page).to have_content "Selected"
     end
 
-    scenario "Compatible non-winner can't edit incompatibility" do
+    scenario "Compatible non-winner can not edit incompatibility" do
       budget_investment = create(:budget_investment, :selected)
       create(:budget_heading, group: budget_investment.group, name: "Tetuan")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      expect(page).not_to have_content 'Compatibility'
-      expect(page).not_to have_content 'Mark as incompatible'
+      expect(page).not_to have_content "Compatibility"
+      expect(page).not_to have_content "Mark as incompatible"
     end
 
     scenario "Change visible label" do
@@ -934,51 +944,57 @@ feature 'Admin budget investments' do
       create(:budget_heading, group: budget_investment.group, name: "Patroclo")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      fill_in 'budget_investment_label', with: 'Heroe'
-      click_button 'Update'
+      fill_in "budget_investment_label", with: "Heroe"
+      click_button "Update"
 
       visit budget_investment_path(budget_investment.budget, budget_investment)
-      expect(page).to have_content 'Heroe'
+      expect(page).to have_content "Heroe"
     end
 
     scenario "Add administrator" do
       budget_investment = create(:budget_investment)
-      administrator = create(:administrator, user: create(:user, username: 'Marta', email: 'marta@admins.org'))
+      user = create(:user, username: "Marta", email: "marta@admins.org")
+      create(:administrator, user: user)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      select 'Marta (marta@admins.org)', from: 'budget_investment[administrator_id]'
-      click_button 'Update'
+      select "Marta (marta@admins.org)", from: "budget_investment[administrator_id]"
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
-      expect(page).to have_content 'Assigned administrator: Marta'
+      expect(page).to have_content "Investment project updated succesfully."
+      expect(page).to have_content "Assigned administrator: Marta"
     end
 
     scenario "Add valuators" do
       budget_investment = create(:budget_investment)
 
-      valuator1 = create(:valuator, user: create(:user, username: 'Valentina', email: 'v1@valuators.org'))
-      valuator2 = create(:valuator, user: create(:user, username: 'Valerian',  email: 'v2@valuators.org'))
-      valuator3 = create(:valuator, user: create(:user, username: 'Val',       email: 'v3@valuators.org'))
+      user1 = create(:user, username: "Valentina", email: "v1@valuators.org")
+      user2 = create(:user, username: "Valerian",  email: "v2@valuators.org")
+      user3 = create(:user, username: "Val",       email: "v3@valuators.org")
+
+      valuator1 = create(:valuator, user: user1)
+      valuator3 = create(:valuator, user: user3)
+      create(:valuator, user: user2)
+
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       check "budget_investment_valuator_ids_#{valuator1.id}"
       check "budget_investment_valuator_ids_#{valuator3.id}"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
-      within('#assigned_valuators') do
-        expect(page).to have_content('Valentina (v1@valuators.org)')
-        expect(page).to have_content('Val (v3@valuators.org)')
-        expect(page).not_to have_content('Undefined')
-        expect(page).not_to have_content('Valerian (v2@valuators.org)')
+      within("#assigned_valuators") do
+        expect(page).to have_content("Valentina (v1@valuators.org)")
+        expect(page).to have_content("Val (v3@valuators.org)")
+        expect(page).not_to have_content("Undefined")
+        expect(page).not_to have_content("Valerian (v2@valuators.org)")
       end
     end
 
@@ -986,24 +1002,24 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       health_group = create(:valuator_group, name: "Health")
-      economy_group = create(:valuator_group, name: "Economy")
       culture_group = create(:valuator_group, name: "Culture")
+      create(:valuator_group, name: "Economy")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       check "budget_investment_valuator_group_ids_#{health_group.id}"
       check "budget_investment_valuator_group_ids_#{culture_group.id}"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
-      within('#assigned_valuator_groups') do
-        expect(page).to have_content('Health')
-        expect(page).to have_content('Culture')
-        expect(page).not_to have_content('Undefined')
-        expect(page).not_to have_content('Economy')
+      within("#assigned_valuator_groups") do
+        expect(page).to have_content("Health")
+        expect(page).to have_content("Culture")
+        expect(page).not_to have_content("Undefined")
+        expect(page).not_to have_content("Economy")
       end
     end
 
@@ -1011,22 +1027,22 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       health_group = create(:valuator_group, name: "Health")
-      user = create(:user, username: 'Valentina', email: 'v1@valuators.org')
+      user = create(:user, username: "Valentina", email: "v1@valuators.org")
       create(:valuator, user: user, valuator_group: health_group)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       check "budget_investment_valuator_group_ids_#{health_group.id}"
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
-      within('#assigned_valuator_groups') { expect(page).to have_content('Health') }
-      within('#assigned_valuators') do
-        expect(page).to have_content('Undefined')
-        expect(page).not_to have_content('Valentina (v1@valuators.org)')
+      within("#assigned_valuator_groups") { expect(page).to have_content("Health") }
+      within("#assigned_valuators") do
+        expect(page).to have_content("Undefined")
+        expect(page).not_to have_content("Valentina (v1@valuators.org)")
       end
     end
 
@@ -1035,22 +1051,22 @@ feature 'Admin budget investments' do
       heading = create(:budget_heading, group: group)
 
       budget_investment1 = create(:budget_investment, heading: heading)
-      budget_investment1.set_tag_list_on(:valuation, 'Education, Health')
+      budget_investment1.set_tag_list_on(:valuation, "Education, Health")
       budget_investment1.save
 
       budget_investment2 = create(:budget_investment, heading: heading)
 
       visit edit_admin_budget_budget_investment_path(budget_investment2.budget, budget_investment2)
 
-      find('.js-add-tag-link', text: 'Education').click
+      find(".js-add-tag-link", text: "Education").click
 
-      click_button 'Update'
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
       within "#tags" do
-        expect(page).to have_content 'Education'
-        expect(page).not_to have_content 'Health'
+        expect(page).to have_content "Education"
+        expect(page).not_to have_content "Health"
       end
     end
 
@@ -1058,16 +1074,16 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      fill_in 'budget_investment_valuation_tag_list', with: 'Refugees, Solidarity'
-      click_button 'Update'
+      fill_in "budget_investment_valuation_tag_list", with: "Refugees, Solidarity"
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
       within "#tags" do
-        expect(page).to have_content 'Refugees'
-        expect(page).to have_content 'Solidarity'
+        expect(page).to have_content "Refugees"
+        expect(page).to have_content "Solidarity"
       end
     end
 
@@ -1082,15 +1098,15 @@ feature 'Admin budget investments' do
       heading2 = create(:budget_heading, group: group2)
 
       budget_investment1 = create(:budget_investment, heading: heading1)
-      budget_investment1.set_tag_list_on(:valuation, 'Education 2017')
+      budget_investment1.set_tag_list_on(:valuation, "Education 2017")
       budget_investment1.save
 
       budget_investment2 = create(:budget_investment, heading: heading2)
-      budget_investment2.set_tag_list_on(:valuation, 'Education 2018')
+      budget_investment2.set_tag_list_on(:valuation, "Education 2018")
       budget_investment2.save
 
       visit admin_budget_budget_investment_path(budget1, budget_investment1)
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
       within(".tags") do
         expect(page).to have_content "Education 2017"
@@ -1099,8 +1115,8 @@ feature 'Admin budget investments' do
     end
 
     scenario "Changes valuation and user generated tags" do
-      budget_investment = create(:budget_investment, tag_list: 'Park')
-      budget_investment.set_tag_list_on(:valuation, 'Education')
+      budget_investment = create(:budget_investment, tag_list: "Park")
+      budget_investment.set_tag_list_on(:valuation, "Education")
       budget_investment.save
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
@@ -1110,11 +1126,11 @@ feature 'Admin budget investments' do
         expect(page).to have_content "Park"
       end
 
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      fill_in 'budget_investment_tag_list', with: 'Park, Trees'
-      fill_in 'budget_investment_valuation_tag_list', with: 'Education, Environment'
-      click_button 'Update'
+      fill_in "budget_investment_tag_list", with: "Park, Trees"
+      fill_in "budget_investment_valuation_tag_list", with: "Education, Environment"
+      click_button "Update"
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
 
@@ -1132,16 +1148,16 @@ feature 'Admin budget investments' do
     end
 
     scenario "Maintains user tags" do
-      budget_investment = create(:budget_investment, tag_list: 'Park')
+      budget_investment = create(:budget_investment, tag_list: "Park")
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
 
-      click_link 'Edit classification'
+      click_link "Edit classification"
 
-      fill_in 'budget_investment_valuation_tag_list', with: 'Refugees, Solidarity'
-      click_button 'Update'
+      fill_in "budget_investment_valuation_tag_list", with: "Refugees, Solidarity"
+      click_button "Update"
 
-      expect(page).to have_content 'Investment project updated succesfully.'
+      expect(page).to have_content "Investment project updated succesfully."
 
       visit budget_investment_path(budget_investment.budget, budget_investment)
       expect(page).to have_content "Park"
@@ -1152,26 +1168,26 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit dossier'
+      click_link "Edit dossier"
 
-      expect(page).to have_content('Valuation finished')
+      expect(page).to have_content("Valuation finished")
 
-      accept_confirm { check('Valuation finished') }
+      accept_confirm { check("Valuation finished") }
 
-      expect(find('#js-investment-report-alert')).to be_checked
+      expect(find("#js-investment-report-alert")).to be_checked
     end
 
     # The feature tested in this scenario works as expected but some underlying reason
-    # we're not aware of makes it fail at random
+    # we"re not aware of makes it fail at random
     xscenario "Shows alert with unfeasible status when 'Valuation finished' is checked", :js do
       budget_investment = create(:budget_investment, :unfeasible)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit dossier'
+      click_link "Edit dossier"
 
-      expect(page).to have_content('Valuation finished')
-      valuation = find_field('budget_investment[valuation_finished]')
-      accept_confirm { check('Valuation finished') }
+      expect(page).to have_content("Valuation finished")
+      valuation = find_field("budget_investment[valuation_finished]")
+      accept_confirm { check("Valuation finished") }
 
       expect(valuation).to be_checked
     end
@@ -1180,22 +1196,22 @@ feature 'Admin budget investments' do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit dossier'
+      click_link "Edit dossier"
 
-      dismiss_confirm { check('Valuation finished') }
+      dismiss_confirm { check("Valuation finished") }
 
-      expect(find('#js-investment-report-alert')).not_to be_checked
+      expect(find("#js-investment-report-alert")).not_to be_checked
     end
 
     scenario "Errors on update" do
       budget_investment = create(:budget_investment)
 
       visit admin_budget_budget_investment_path(budget_investment.budget, budget_investment)
-      click_link 'Edit'
+      click_link "Edit"
 
-      fill_in 'budget_investment_title', with: ''
+      fill_in "budget_investment_title", with: ""
 
-      click_button 'Update'
+      click_button "Update"
 
       expect(page).to have_content "can't be blank"
     end
@@ -1204,27 +1220,33 @@ feature 'Admin budget investments' do
 
   context "Selecting" do
 
-    let!(:unfeasible_bi)  { create(:budget_investment, :unfeasible, budget: budget, title: "Unfeasible project") }
-    let!(:feasible_bi)    { create(:budget_investment, :feasible, budget: budget, title: "Feasible project") }
-    let!(:feasible_vf_bi) { create(:budget_investment, :feasible, :finished, budget: budget, title: "Feasible, VF project") }
-    let!(:selected_bi)    { create(:budget_investment, :selected, budget: budget, title: "Selected project") }
-    let!(:winner_bi)      { create(:budget_investment, :winner, budget: budget, title: "Winner project") }
-    let!(:undecided_bi)   { create(:budget_investment, :undecided, budget: budget, title: "Undecided project") }
+    let!(:unfeasible_bi)  { create(:budget_investment, :unfeasible, budget: budget,
+                                                                    title: "Unfeasible project") }
+    let!(:feasible_bi)    { create(:budget_investment, :feasible, budget: budget,
+                                                                  title: "Feasible project") }
+    let!(:feasible_vf_bi) { create(:budget_investment, :feasible, :finished, budget: budget,
+                                                                  title: "Feasible, VF project") }
+    let!(:selected_bi)    { create(:budget_investment, :selected, budget: budget,
+                                                                  title: "Selected project") }
+    let!(:winner_bi)      { create(:budget_investment, :winner, budget: budget,
+                                                                title: "Winner project") }
+    let!(:undecided_bi)   { create(:budget_investment, :undecided, budget: budget,
+                                                                   title: "Undecided project") }
 
     scenario "Filtering by valuation and selection", :js do
       visit admin_budget_budget_investments_path(budget)
 
-      within('#filter-subnav') { click_link 'Valuation finished' }
+      within("#filter-subnav") { click_link "Valuation finished" }
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
       expect(page).to have_content(feasible_vf_bi.title)
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_feasible') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_feasible") }
+      click_button("Filter")
 
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
@@ -1232,12 +1254,12 @@ feature 'Admin budget investments' do
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      within('#advanced_filters') do
-        check('advanced_filters_selected')
-        uncheck('advanced_filters_feasible')
+      within("#advanced_filters") do
+        check("advanced_filters_selected")
+        uncheck("advanced_filters_feasible")
       end
 
-      click_button('Filter')
+      click_button("Filter")
 
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
@@ -1245,7 +1267,7 @@ feature 'Admin budget investments' do
       expect(page).to have_content(selected_bi.title)
       expect(page).to have_content(winner_bi.title)
 
-      within('#filter-subnav') { click_link 'Winners' }
+      within("#filter-subnav") { click_link "Winners" }
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_bi.title)
       expect(page).not_to have_content(feasible_vf_bi.title)
@@ -1256,10 +1278,10 @@ feature 'Admin budget investments' do
     scenario "Aggregating results", :js do
       visit admin_budget_budget_investments_path(budget)
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_undecided') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_undecided") }
+      click_button("Filter")
 
       expect(page).to have_content(undecided_bi.title)
       expect(page).not_to have_content(winner_bi.title)
@@ -1268,8 +1290,8 @@ feature 'Admin budget investments' do
       expect(page).not_to have_content(unfeasible_bi.title)
       expect(page).not_to have_content(feasible_vf_bi.title)
 
-      within('#advanced_filters') { check('advanced_filters_unfeasible') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_unfeasible") }
+      click_button("Filter")
 
       expect(page).to have_content(undecided_bi.title)
       expect(page).to have_content(unfeasible_bi.title)
@@ -1283,23 +1305,23 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{unfeasible_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
 
       within("#budget_investment_#{feasible_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
-        expect(page).to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
 
       within("#budget_investment_#{selected_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).to have_link("Selected")
       end
     end
 
@@ -1307,42 +1329,42 @@ feature 'Admin budget investments' do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
-        click_link('Select')
-        expect(page).to have_link('Selected')
+        click_link("Select")
+        expect(page).to have_link("Selected")
       end
 
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_selected') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_selected") }
+      click_button("Filter")
 
       within("#budget_investment_#{feasible_vf_bi.id}") do
-        expect(page).not_to have_link('Select')
-        expect(page).to have_link('Selected')
+        expect(page).not_to have_link("Select")
+        expect(page).to have_link("Selected")
       end
     end
 
     scenario "Unselecting an investment", :js do
       visit admin_budget_budget_investments_path(budget)
-      click_link 'Advanced filters'
+      click_link "Advanced filters"
 
-      within('#advanced_filters') { check('advanced_filters_selected') }
-      click_button('Filter')
+      within("#advanced_filters") { check("advanced_filters_selected") }
+      click_button("Filter")
 
-      expect(page).to have_content('There are 2 investments')
+      expect(page).to have_content("There are 2 investments")
 
       within("#budget_investment_#{selected_bi.id}") do
-        click_link('Selected')
+        click_link("Selected")
       end
 
       expect(page).not_to have_content(selected_bi.title)
-      expect(page).to have_content('There is 1 investment')
+      expect(page).to have_content("There is 1 investment")
 
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{selected_bi.id}") do
-        expect(page).to have_link('Select')
-        expect(page).not_to have_link('Selected')
+        expect(page).to have_link("Select")
+        expect(page).not_to have_link("Selected")
       end
     end
   end
@@ -1364,7 +1386,7 @@ feature 'Admin budget investments' do
       investment2.update(administrator: admin)
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
       expect(page).not_to have_link("Under valuation")
 
       within("#budget_investment_#{investment1.id}") do
@@ -1372,7 +1394,7 @@ feature 'Admin budget investments' do
       end
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
 
       within("#budget_investment_#{investment1.id}") do
         expect(find("#budget_investment_visible_to_valuators")).to be_checked
@@ -1402,7 +1424,7 @@ feature 'Admin budget investments' do
     end
 
     scenario "Unmark as visible to valuator", :js do
-      budget.update(phase: 'valuating')
+      budget.update(phase: "valuating")
 
       investment1.valuators << valuator
       investment2.valuators << valuator
@@ -1410,7 +1432,7 @@ feature 'Admin budget investments' do
       investment2.update(administrator: admin, visible_to_valuators: true)
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
       expect(page).not_to have_link("Under valuation")
 
       within("#budget_investment_#{investment1.id}") do
@@ -1418,7 +1440,7 @@ feature 'Admin budget investments' do
       end
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
 
       within("#budget_investment_#{investment1.id}") do
         expect(find("#budget_investment_visible_to_valuators")).not_to be_checked
@@ -1439,15 +1461,15 @@ feature 'Admin budget investments' do
 
       expect(page).to have_css("#budget_investment_visible_to_valuators")
 
-      within('#filter-subnav') { click_link 'Under valuation' }
+      within("#filter-subnav") { click_link "Under valuation" }
 
       within("#budget_investment_#{investment1.id}") do
-        valuating_checkbox = find('#budget_investment_visible_to_valuators')
+        valuating_checkbox = find("#budget_investment_visible_to_valuators")
         expect(valuating_checkbox).to be_checked
       end
 
       within("#budget_investment_#{investment2.id}") do
-        valuating_checkbox = find('#budget_investment_visible_to_valuators')
+        valuating_checkbox = find("#budget_investment_visible_to_valuators")
         expect(valuating_checkbox).not_to be_checked
       end
     end
@@ -1456,8 +1478,8 @@ feature 'Admin budget investments' do
   context "Selecting csv" do
 
     scenario "Downloading CSV file" do
-      admin = create(:administrator, user: create(:user, username: 'Admin'))
-      valuator = create(:valuator, user: create(:user, username: 'Valuator'))
+      admin = create(:administrator, user: create(:user, username: "Admin"))
+      valuator = create(:valuator, user: create(:user, username: "Valuator"))
       valuator_group = create(:valuator_group, name: "Valuator Group")
       budget_group = create(:budget_group, name: "Budget Group", budget: budget)
       first_budget_heading = create(:budget_heading, group: budget_group, name: "Budget Heading")
@@ -1482,60 +1504,63 @@ feature 'Admin budget investments' do
 
       click_link "Download current selection"
 
-      header = page.response_headers['Content-Disposition']
+      header = page.response_headers["Content-Disposition"]
       expect(header).to match(/^attachment/)
       expect(header).to match(/filename="budget_investments.csv"$/)
 
       csv_contents = "ID,Title,Supports,Administrator,Valuator,Valuation Group,Scope of operation,"\
                      "Feasibility,Val. Fin.,Selected,Show to valuators,Author username\n"\
                      "#{first_investment.id},Le Investment,88,Admin,-,Valuator Group,"\
-                     "Budget Heading,Feasible (€99),Yes,Yes,Yes,#{first_investment.author.username}\n#{second_investment.id},"\
+                     "Budget Heading,Feasible (€99),Yes,Yes,Yes,"\
+                     "#{first_investment.author.username}\n#{second_investment.id},"\
                      "Alt Investment,66,No admin assigned,Valuator,-,Other Heading,"\
                      "Unfeasible,No,No,No,#{second_investment.author.username}\n"
       expect(page.body).to eq(csv_contents)
     end
 
     scenario "Downloading CSV file with applied filter" do
-      unfeasible_investment = create(:budget_investment, :unfeasible, budget: budget,
-                                                                      title: 'Unfeasible one')
-      finished_investment = create(:budget_investment, :finished, budget: budget,
-                                                                  title: 'Finished Investment')
+      create(:budget_investment, :unfeasible, budget: budget, title: "Unfeasible one")
+      create(:budget_investment, :finished, budget: budget, title: "Finished Investment")
 
       visit admin_budget_budget_investments_path(budget)
-      within('#filter-subnav') { click_link 'Valuation finished' }
+      within("#filter-subnav") { click_link "Valuation finished" }
 
       click_link "Download current selection"
 
-      expect(page).to have_content('Finished Investment')
-      expect(page).not_to have_content('Unfeasible one')
+      expect(page).to have_content("Finished Investment")
+      expect(page).not_to have_content("Unfeasible one")
     end
   end
 
-  context "Spending Proposals migrated to Budget Investments should keep the original IDs on lists & urls" do
-    let(:spending_proposal) { create(:spending_proposal, id: 9999, title: 'Le Spending Proposal') }
-    let(:spending_proposal_migrated_to_budget_investment_path) { "/admin/budgets/#{budget.id}/budget_investments/#{spending_proposal.id}" }
+  context "SPs migrated to Budget Investments should keep the original IDs on lists & urls" do
+    let(:spending_proposal) { create(:spending_proposal, id: 9999, title: "Le Spending Proposal") }
+    let(:spending_proposal_migrated_to_budget_investment_path) {
+      "/admin/budgets/#{budget.id}/budget_investments/#{spending_proposal.id}"
+    }
     let!(:associated_budget_investment) do
-      create(:budget_investment, id: 8888, budget: budget, title: 'Budget Investment child',
+      create(:budget_investment, id: 8888, budget: budget, title: "Budget Investment child",
                                  original_spending_proposal_id: spending_proposal.id)
     end
 
-    scenario "A Budget Investment generated from a Spending Proposal should be listed & linked with original Spending Proposal id" do
+    scenario "An investment generated from a SP should be listed & linked with original SP id" do
       visit admin_budget_budget_investments_path(budget)
 
       within("#budget_investment_#{associated_budget_investment.id}") do
-        expect(page).to have_link("Budget Investment child", href: spending_proposal_migrated_to_budget_investment_path)
+        expect(page).to have_link("Budget Investment child",
+                                  href: spending_proposal_migrated_to_budget_investment_path)
       end
     end
 
-    scenario "A Budget Investment generated from a Spending Proposal should be accesible by original Spending Proposal id" do
+    scenario "An investment generated from a SP should be accesible by original SP id" do
       visit admin_budget_budget_investment_path(budget_id: budget.id, id: spending_proposal.id)
 
-      expect(current_path).to eq(spending_proposal_migrated_to_budget_investment_path)
+      expect(page).to have_current_path(spending_proposal_migrated_to_budget_investment_path)
       expect(page).to have_content("Budget Investment child")
     end
 
-    scenario "A Budget Investment generated from a Spending Proposal should be accesible by its own id" do
-      visit admin_budget_budget_investment_path(budget_id: budget.id, id: associated_budget_investment.id)
+    scenario "An investment generated from a SP should be accesible by its own id" do
+      visit admin_budget_budget_investment_path(budget_id: budget.id,
+                                                id: associated_budget_investment.id)
 
       expect(page).to have_content("Budget Investment child")
     end

--- a/spec/features/admin/budget_investments_spec.rb
+++ b/spec/features/admin/budget_investments_spec.rb
@@ -709,7 +709,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -719,7 +719,7 @@ feature 'Admin budget investments' do
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
         within('th', text: 'Title') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -729,7 +729,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
         within('th', text: 'Supports') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
@@ -741,7 +741,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-down")
+          expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
@@ -751,7 +751,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('A Second Investment')
         within('th', text: 'Title') do
-          expect(page).to have_css(".icon-arrow-down")
+          expect(page).to have_css(".icon-sortable.asc")
         end
       end
 
@@ -761,7 +761,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'Supports') do
-          expect(page).to have_css(".icon-arrow-down")
+          expect(page).to have_css(".icon-sortable.asc")
         end
       end
     end
@@ -773,7 +773,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -783,7 +783,7 @@ feature 'Admin budget investments' do
         expect('A Second Investment').to appear_before('B First Investment')
         expect('B First Investment').to appear_before('C Third Investment')
         within('th', text: 'Title') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
 
@@ -793,7 +793,7 @@ feature 'Admin budget investments' do
         expect('C Third Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('B First Investment')
         within('th', text: 'Supports') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end
@@ -805,7 +805,7 @@ feature 'Admin budget investments' do
         expect('B First Investment').to appear_before('A Second Investment')
         expect('A Second Investment').to appear_before('C Third Investment')
         within('th', text: 'ID') do
-          expect(page).to have_css(".icon-arrow-top")
+          expect(page).to have_css(".icon-sortable.desc")
         end
       end
     end

--- a/spec/helpers/budget_investments_helper_spec.rb
+++ b/spec/helpers/budget_investments_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe BudgetInvestmentsHelper, type: :helper do
+
+  describe "#set_direction" do
+
+    it "returns ASC if current_direction is DESC" do
+      expect(set_direction("desc")).to eq "asc"
+    end
+
+    it "returns DESC if current_direction is ASC" do
+      expect(set_direction("asc")).to eq "desc"
+    end
+
+    it "returns DESC if current_direction is nil" do
+      expect(set_direction(nil)).to eq "desc"
+    end
+  end
+
+  describe "#set_sorting_icon" do
+    let(:sort_by) { "title" }
+    let(:params)  { { sort_by: sort_by } }
+
+    it "returns arrow down if current direction is ASC" do
+      expect(set_sorting_icon("asc", sort_by)).to eq "icon-arrow-down"
+    end
+
+    it "returns arrow top if current direction is DESC" do
+      expect(set_sorting_icon("desc", sort_by)).to eq "icon-arrow-top"
+    end
+
+    it "returns arrow down if sort_by present, but no direction" do
+      expect(set_sorting_icon(nil, sort_by)).to eq "icon-arrow-down"
+    end
+
+    it "returns no icon if sort_by and direction is missing" do
+      params[:sort_by] = nil
+      expect(set_sorting_icon(nil, sort_by)).to eq ""
+    end
+
+    it "returns no icon if sort_by is incorrect" do
+      params[:sort_by] = "random"
+      expect(set_sorting_icon("asc", sort_by)).to eq ""
+    end
+  end
+
+end

--- a/spec/helpers/budget_investments_helper_spec.rb
+++ b/spec/helpers/budget_investments_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe BudgetInvestmentsHelper, type: :helper do
 
@@ -22,15 +22,15 @@ RSpec.describe BudgetInvestmentsHelper, type: :helper do
     let(:params)  { { sort_by: sort_by } }
 
     it "returns arrow down if current direction is ASC" do
-      expect(set_sorting_icon("asc", sort_by)).to eq "icon-arrow-down"
+      expect(set_sorting_icon("asc", sort_by)).to eq "asc"
     end
 
     it "returns arrow top if current direction is DESC" do
-      expect(set_sorting_icon("desc", sort_by)).to eq "icon-arrow-top"
+      expect(set_sorting_icon("desc", sort_by)).to eq "desc"
     end
 
     it "returns arrow down if sort_by present, but no direction" do
-      expect(set_sorting_icon(nil, sort_by)).to eq "icon-arrow-down"
+      expect(set_sorting_icon(nil, sort_by)).to eq "asc"
     end
 
     it "returns no icon if sort_by and direction is missing" do


### PR DESCRIPTION
## References

* Pull request consul#3148
* Issue consul#2931

## Objectives

Use links in table headers to sort records instead of using a `select` field.

## Notes

This pull request only implements sorting by the columns we could already sort by.

## Visual changes

**Arrows icons indicate the sortable columns**
<img width="470" alt="no_order" src="https://user-images.githubusercontent.com/631897/53009617-34cc5800-343c-11e9-9f62-055b82a8a784.png">

**Active desc order**
<img width="473" alt="desc" src="https://user-images.githubusercontent.com/631897/53009621-385fdf00-343c-11e9-9134-21c1b0b3b673.png">

**Active asc order**
<img width="462" alt="asc" src="https://user-images.githubusercontent.com/631897/53009625-3a29a280-343c-11e9-914e-f98153f386f9.png">

## Backport to CONSUL?

Backport the last two commits.