### PR TITLE
Use a single rake task to migrate spending proposals

### DIFF
--- a/lib/migrations/spending_proposal/budget_investment.rb
+++ b/lib/migrations/spending_proposal/budget_investment.rb
@@ -59,6 +59,7 @@ class Migrations::SpendingProposal::BudgetInvestment
       comment = new_valuation_comment
       if comment.save
         log(".")
+        return true
       else
         log("Error creating comment for budget investment: #{budget_investment.id}\n")
         log(comment.errors.messages)

--- a/lib/migrations/spending_proposal/vote.rb
+++ b/lib/migrations/spending_proposal/vote.rb
@@ -1,4 +1,5 @@
 class Migrations::SpendingProposal::Vote
+  include Migrations::Log
 
   def migrate_delegated_votes
     delegated_votes.each do |delegated_vote|
@@ -13,6 +14,7 @@ class Migrations::SpendingProposal::Vote
       delegated: true
     }
     Vote.create!(vote_attributes)
+    log(".")
   end
 
   def delegated_votes
@@ -44,6 +46,7 @@ class Migrations::SpendingProposal::Vote
   def create_budget_investment_votes
     spending_proposal_votes.each do |vote|
       create_budget_invesment_vote(vote)
+      log(".")
     end
   end
 

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -34,6 +34,14 @@ namespace :spending_proposals do
                       .update_all(winner: true, selected: true)
   end
 
+  desc "Migrates all necessary data from spending proposals to budget investments"
+  task migrate: [
+    "spending_proposals:migrate_attributes",
+    "spending_proposals:migrate_delegated_votes",
+    "spending_proposals:migrate_ballots",
+    "spending_proposals:migrate_delegated_ballots",
+  ]
+
   desc "Migrates delegated votes to represented user votes"
   task migrate_delegated_votes: :environment do
     require "migrations/spending_proposal/vote"

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -45,15 +45,21 @@ namespace :spending_proposals do
   desc "Migrates delegated votes to represented user votes"
   task migrate_delegated_votes: :environment do
     require "migrations/spending_proposal/vote"
+
+    puts "Starting to migrate delegated votes"
     Migrations::SpendingProposal::Vote.new.migrate_delegated_votes
+    puts "Finished"
+
+    puts "Starting to migrate votes"
     Migrations::SpendingProposal::Vote.new.create_budget_investment_votes
+    puts "Finished"
   end
 
   desc "Migrates spending proposals attributes to corresponding budget investments attributes"
-  task migrate_attributes_to_budget_investments: :environment do
+  task migrate_attributes: :environment do
     require "migrations/spending_proposal/budget_investments"
 
-    puts "Starting to migration attributes from spending proposals to budget investments"
+    puts "Starting to migrate attributes"
     Migrations::SpendingProposal::BudgetInvestments.new.update_all
     puts "Finished"
   end
@@ -62,7 +68,7 @@ namespace :spending_proposals do
   task migrate_ballots: :environment do
     require "migrations/spending_proposal/ballots"
 
-    puts "Starting to migrate spending proposal ballots"
+    puts "Starting to migrate ballots"
     Migrations::SpendingProposal::Ballots.new.migrate_all
     puts "Finished"
   end
@@ -72,7 +78,7 @@ namespace :spending_proposals do
   task migrate_delegated_ballots: :environment do
     require "migrations/spending_proposal/delegated_ballots"
 
-    puts "Starting to migrate spending proposals delegated ballots"
+    puts "Starting to migrate delegated ballots"
     Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
     puts "Finished"
   end


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Objectives

- Add a rake task to migrate all necessary data from spending proposals to budget investments.
- Make rake task logs more accurate

## Does this PR need a Backport to CONSUL?
Yes, a final rake task should be included in the backport to CONSUL. However not all task should be included, as for example, delegation is not present in CONSUL.

## Notes
To run this migration execute the following command:

`bin/rake spending_proposals:migrate`