### PR TITLE
Remove duplicate signatures

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -9,6 +9,7 @@ class Signature < ActiveRecord::Base
 
   scope :verified,   -> { where(verified: true) }
   scope :unverified, -> { where(verified: false) }
+  scope :for_budget, -> (budget) { where(signature_sheet: SignatureSheet.where(signable: budget.investments)) }
 
   delegate :signable, to: :signature_sheet
 

--- a/lib/duplicate_signatures_finder.rb
+++ b/lib/duplicate_signatures_finder.rb
@@ -1,6 +1,12 @@
 class DuplicateSignaturesFinder
+  attr_reader :scope
+
+  def initialize(scope = Signature.all)
+    @scope = scope
+  end
+
   def all
-    Signature.where(id: expendables)
+    scope.where(id: expendables)
   end
 
   private

--- a/lib/duplicate_signatures_finder.rb
+++ b/lib/duplicate_signatures_finder.rb
@@ -1,0 +1,33 @@
+class DuplicateSignaturesFinder
+  def all
+    Signature.where(id: expendables)
+  end
+
+  private
+
+    def duplicate_sheet_and_user_ids
+      Signature.select("signature_sheet_id, user_id, COUNT(*)")
+        .group("signature_sheet_id, user_id")
+        .where("user_id IS NOT NULL")
+        .having("COUNT(*) > 1")
+    end
+
+    def duplicate_groups
+      duplicate_sheet_and_user_ids.map do |duplicate|
+        Signature.where(
+          signature_sheet_id: duplicate.signature_sheet_id,
+          user_id: duplicate.user_id
+        )
+      end
+    end
+
+    def expendables
+      duplicate_groups.map do |signatures|
+        if Vote.where(signature: signatures).any?
+          signatures.where.not(id: Vote.where(signature: signatures).pluck(:signature_id))
+        else
+          signatures.order("created_at DESC").limit(signatures.count - 1)
+        end
+      end.flatten
+    end
+end

--- a/lib/tasks/sheets.rake
+++ b/lib/tasks/sheets.rake
@@ -1,0 +1,8 @@
+namespace :sheets do
+  desc "Remove duplicate signatures in signature sheets"
+  task :remove_duplicate_signatures do
+    ActiveRecord::Base.transaction do
+      DuplicateSignaturesFinder.new(Signature.for_budget(Budget.current)).all.each(&:destroy)
+    end
+  end
+end

--- a/spec/lib/duplicate_signatures_finder_spec.rb
+++ b/spec/lib/duplicate_signatures_finder_spec.rb
@@ -101,4 +101,27 @@ describe DuplicateSignaturesFinder do
       end
     end
   end
+
+  describe "#scope" do
+    let(:finder) { DuplicateSignaturesFinder.new(Signature.where(signature_sheet: sheet)) }
+
+    context "records in the scope" do
+      let!(:first) { create :signature, signature_sheet: sheet, user: user }
+      let!(:duplicate) { create :signature, signature_sheet: sheet, user: user }
+
+      it "returns the duplicate signatures" do
+        expect(finder.all).not_to include first
+        expect(finder.all).to eq [duplicate]
+      end
+    end
+
+    context "records not in the scope" do
+      let(:another_sheet) { create :signature_sheet, signable: investment }
+      before { 2.times { create :signature, signature_sheet: another_sheet, user: user } }
+
+      it "ignores the duplicate signatures" do
+        expect(finder.all).to be_empty
+      end
+    end
+  end
 end

--- a/spec/lib/duplicate_signatures_finder_spec.rb
+++ b/spec/lib/duplicate_signatures_finder_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+describe DuplicateSignaturesFinder do
+  let(:finder) { DuplicateSignaturesFinder.new }
+  let(:investment) { create :budget_investment }
+  let(:sheet) { create :signature_sheet, signable: investment }
+  let(:user) { create :user }
+
+  describe "#all" do
+    context "No signatures" do
+      it "returns no signatures" do
+        expect(finder.all).to be_empty
+      end
+    end
+
+    context "No duplicates" do
+      before do
+        create :signature, signature_sheet: sheet, user: user
+        create :signature, signature_sheet: sheet, user: create(:user)
+        create :signature, signature_sheet: create(:signature_sheet), user: user
+      end
+
+      it "returns no signatures" do
+        expect(finder.all).to be_empty
+      end
+    end
+
+    context "One duplicate without votes" do
+      let!(:first) { create :signature, signature_sheet: sheet, user: user }
+      let!(:duplicate) { create :signature, signature_sheet: sheet, user: user }
+
+      it "returns the duplicate but not the first signature" do
+        expect(finder.all).not_to include first
+        expect(finder.all).to eq [duplicate]
+      end
+    end
+
+    context "Several duplicate records without votes" do
+      let!(:first) { create :signature, signature_sheet: sheet, user: user }
+      let!(:duplicate) { create :signature, signature_sheet: sheet, user: user }
+      let!(:another_duplicate) { create :signature, signature_sheet: sheet, user: user }
+
+      it "returns the duplicate records but not the first signature" do
+        expect(finder.all).not_to include first
+        expect(finder.all).to eq [duplicate, another_duplicate]
+      end
+    end
+
+    context "One duplicate, one signature has a vote" do
+      let!(:without_vote) { create :signature, signature_sheet: sheet, user: user }
+      let!(:with_vote) { create :signature, signature_sheet: sheet, user: user }
+      before do
+        create(:vote, votable: investment, voter: user, signature: with_vote)
+      end
+
+      it "returns the signature without votes" do
+        expect(finder.all).not_to include with_vote
+        expect(finder.all).to eq [without_vote]
+      end
+    end
+
+    context "Several duplicate records, one signature has a vote" do
+      let!(:without_vote) { create :signature, signature_sheet: sheet, user: user }
+      let!(:with_vote) { create :signature, signature_sheet: sheet, user: user }
+      let!(:without_vote_either) { create :signature, signature_sheet: sheet, user: user }
+
+      before do
+        create(:vote, votable: investment, voter: user, signature: with_vote)
+      end
+
+      it "returns all signatures without votes" do
+        expect(finder.all).not_to include with_vote
+        expect(finder.all).to eq [without_vote, without_vote_either]
+      end
+    end
+
+    context "Several duplicate records for several signatures" do
+      let!(:first) { create :signature, signature_sheet: sheet, user: user }
+      let!(:duplicate) { create :signature, signature_sheet: sheet, user: user }
+      let!(:another_duplicate) { create :signature, signature_sheet: sheet, user: user }
+
+      let(:another_user) { create :user }
+      let!(:without_vote) { create :signature, signature_sheet: sheet, user: another_user }
+      let!(:with_vote) { create :signature, signature_sheet: sheet, user: another_user }
+      let!(:without_vote_either) { create :signature, signature_sheet: sheet, user: another_user }
+
+      before do
+        create(:vote, votable: investment, voter: another_user, signature: with_vote)
+      end
+
+      it "returns all duplicate signatures" do
+        expect(finder.all).not_to include first
+        expect(finder.all).not_to include with_vote
+
+        expect(finder.all).to match_array([
+          duplicate,
+          another_duplicate,
+          without_vote,
+          without_vote_either
+        ])
+      end
+    end
+  end
+end

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -299,4 +299,47 @@ describe Signature do
 
   end
 
+  describe ".for_budget" do
+    let!(:budget) { create(:budget) }
+    let!(:investment) { create(:budget_investment, budget: budget) }
+    let!(:sheet) { create(:signature_sheet, signable: investment) }
+    let!(:signature) { create(:signature, signature_sheet: sheet) }
+
+    context "only one signature and one sheet for the budget" do
+      it "returns the signature" do
+        expect(Signature.for_budget(budget)).to eq [signature]
+      end
+    end
+
+    context "several signatures for one sheet" do
+      let!(:another_signature) { create(:signature, signature_sheet: sheet) }
+
+      it "returns all signatures" do
+        expect(Signature.for_budget(budget)).to match_array([signature, another_signature])
+      end
+    end
+
+    context "signatures for several investments" do
+      let(:another_investment) { create(:budget_investment, budget: budget) }
+      let(:another_sheet) { create(:signature_sheet, signable: another_investment) }
+      let!(:another_signature) { create(:signature, signature_sheet: another_sheet) }
+
+      it "returns signatures for all investments" do
+        expect(Signature.for_budget(budget)).to match_array([signature, another_signature])
+      end
+    end
+
+    context "signatures for other budgets" do
+      let(:wrong_budget) { create(:budget) }
+      let(:wrong_investment) { create(:budget_investment, budget: wrong_budget) }
+      let(:wrong_sheet) { create(:signature_sheet, signable: wrong_investment) }
+      let!(:wrong_signature) { create(:signature, signature_sheet: wrong_sheet) }
+
+      it "does not return signatures for other budgets" do
+        expect(Signature.for_budget(budget)).to eq [signature]
+        expect(Signature.for_budget(budget)).not_to include wrong_signature
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## Objectives

* Remove duplicate signatures which had accidentally been added to the database

## Does this PR need a Backport to CONSUL?

Maybe :thinking:.

## Notes

* So far this pull request doesn't prevent a bug which allows to add multiple signatures for the same document number.