### PR TITLE
[Upstream] Generalize i18n texts 

### DIFF
--- a/app/views/admin/legislation/processes/_form.html.erb
+++ b/app/views/admin/legislation/processes/_form.html.erb
@@ -24,7 +24,6 @@
 
   <div class="small-12 medium-3 column">
     <%= f.text_field :draft_start_date,
-                      label: t("admin.legislation.processes.form.start"),
                       value: format_date_for_calendar_form(@process.draft_start_date),
                       class: "js-calendar-full",
                       id: "draft_start_date" %>
@@ -32,7 +31,6 @@
 
   <div class="small-12 medium-3 column">
     <%= f.text_field :draft_end_date,
-                      label: t("admin.legislation.processes.form.end"),
                       value: format_date_for_calendar_form(@process.draft_end_date),
                       class: "js-calendar-full",
                       id: "draft_end_date" %>
@@ -50,18 +48,14 @@
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :start_date, t("admin.legislation.processes.form.start") %>
     <%= f.text_field :start_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.start_date),
                       class: "js-calendar-full",
                       id: "start_date" %>
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :end_date, t("admin.legislation.processes.form.end") %>
     <%= f.text_field :end_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.end_date),
                       class: "js-calendar-full",
                       id: "end_date" %>
@@ -79,18 +73,14 @@
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :debate_start_date, t("admin.legislation.processes.form.start") %>
     <%= f.text_field :debate_start_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.debate_start_date),
                       class: "js-calendar-full",
                       id: "debate_start_date" %>
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :debate_end_date, t("admin.legislation.processes.form.end") %>
     <%= f.text_field :debate_end_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.debate_end_date),
                       class: "js-calendar-full",
                       id: "debate_end_date" %>
@@ -108,18 +98,14 @@
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :proposals_phase_start_date, t("admin.legislation.processes.form.start") %>
     <%= f.text_field :proposals_phase_start_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.proposals_phase_start_date),
                       class: "js-calendar-full",
                       id: "proposals_phase_start_date" %>
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :proposals_phase_end_date, t("admin.legislation.processes.form.end") %>
     <%= f.text_field :proposals_phase_end_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.proposals_phase_end_date),
                       class: "js-calendar-full",
                       id: "proposals_phase_end_date" %>
@@ -137,18 +123,14 @@
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :allegations_start_date, t("admin.legislation.processes.form.start") %>
     <%= f.text_field :allegations_start_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.allegations_start_date),
                       class: "js-calendar-full",
                       id: "allegations_start_date" %>
   </div>
 
   <div class="small-12 medium-3 column">
-    <%= f.label :allegations_end_date, t("admin.legislation.processes.form.end") %>
     <%= f.text_field :allegations_end_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.allegations_end_date),
                       class: "js-calendar-full",
                       id: "allegations_end_date" %>
@@ -162,9 +144,7 @@
   </div>
 
   <div class="small-12 medium-3 column end">
-    <%= f.label :draft_publication_date %>
     <%= f.text_field :draft_publication_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.draft_publication_date),
                       class: "js-calendar-full",
                       id: "draft_publication_date" %>
@@ -178,9 +158,7 @@
   </div>
 
   <div class="small-12 medium-3 column end">
-    <%= f.label :result_publication_date %>
     <%= f.text_field :result_publication_date,
-                      label: false,
                       value: format_date_for_calendar_form(@process.result_publication_date),
                       class: "js-calendar-full",
                       id: "result_publication_date" %>

--- a/config/locales/custom/en/legislation.yml
+++ b/config/locales/custom/en/legislation.yml
@@ -8,6 +8,7 @@ en:
           help: Help about collaborative legislation
         section_footer:
           title: Help about collaborative legislation
+          description: Participate in the debates and processes prior to the approval of a ordinance or a municipal action. Your opinion will be considered by the City Council.
           help_text_1: "In participatory processes, the City Council offers to its citizens the opportunity to participate in the drafting and modification of regulations, affecting the city of Madrid and to be able to give their opinion on certain actions that it plans to carry out."
           help_text_2: "People registered in %{org} can participate with contributions in the public consultation of new ordinances, regulations and guidelines, among others. Your comments are analyzed by the corresponding area and considered for the final drafting of the ordinances. The subsidy ordinance, the Human Rights Plan, the draft Air Quality and Climate Change Plan, the new EMVS public housing award regulations, etc. have passed through this process."
           help_text_3: 'The City Council also opens processes to receive contributions and opinions on municipal actions. Examples of past processes are the change of denomination of the neighborhood "San Andrés", the convenience of creating new neighborhoods in the District of Vicálvaro, questions about the Linear Park of the Manzanares or the opinions about the remodeling of eleven squares of the city.'

--- a/config/locales/custom/es/legislation.yml
+++ b/config/locales/custom/es/legislation.yml
@@ -8,6 +8,7 @@ es:
           help: Ayuda sobre procesos participativos
         section_footer:
           title: Ayuda sobre procesos participativos
+          description: Participa en los debates y procesos previos a la aprobación de una norma o de una actuación municipal. Tu opinión será tenida en cuenta por el Ayuntamiento.
           help_text_1: "En los procesos participativos, el Ayuntamiento ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la ciudad de Madrid y de dar su opinión sobre ciertas actuaciones que tiene previsto llevar a cabo."
           help_text_2: "Las personas registradas en %{org} pueden participar con aportaciones en la consulta pública de nuevas ordenanzas, reglamentos y directrices, entre otros. Sus comentarios son analizados por el área correspondiente y tenidos en cuenta de cara a la redacción final de las normas. Han pasado por este proceso la ordenanza de subvenciones, el Plan de Derechos Humanos, el borrador de Plan de Calidad de Aire y Cambio Climático, el nuevo reglamento de adjudicación de viviendas públicas de la EMVS, etc."
           help_text_3: 'El Ayuntamiento también abre procesos para recibir aportaciones y opiniones sobre actuaciones municipales. Son ejemplo de procesos pasados el cambio de denominación del barrio "San Andrés", la conveniencia de crear nuevos barrios en el Distrito de Vicálvaro, preguntas sobre el Parque Lineal del Manzanares o las opiniones acerca de la remodelación de once plazas de la ciudad.'

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -244,15 +244,17 @@ en:
         summary: Summary
         description: Description
         additional_info: Additional info
-        start_date: Start date
-        end_date: End date
-        debate_start_date: Debate start date
-        debate_end_date: Debate end date
-        draft_start_date: Draft start date
-        draft_end_date: Draft end date
+        start_date: Start
+        end_date: End
+        debate_start_date: Start
+        debate_end_date: End
+        draft_start_date: Start
+        draft_end_date: End
         draft_publication_date: Draft publication date
-        allegations_start_date: Allegations start date
-        allegations_end_date: Allegations end date
+        allegations_start_date: Start
+        allegations_end_date: End
+        proposals_phase_start_date: Start
+        proposals_phase_end_date: End
         result_publication_date: Final result publication date
         background_color: Background color
         font_color: Font color
@@ -368,7 +370,7 @@ en:
             draft_end_date:
               invalid_date_range: must be on or after the draft start date
             allegations_end_date:
-              invalid_date_range: must be on or after the allegations start date
+              invalid_date_range: must be on or after the comments start date
         proposal:
           attributes:
             tag_list:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -445,8 +445,6 @@ en:
           draft_phase_description: If this phase is active, the process won't be listed on processes index. Allow to preview the process and create content before the start.
           allegations_phase: Comments phase
           proposals_phase: Proposals phase
-          start: Start
-          end: End
           use_markdown: Use Markdown to format the text
           title_placeholder: The title of the process
           summary_placeholder: Short summary of the description

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -73,7 +73,7 @@ en:
       index:
         title: Participatory budgeting
         unfeasible: Unfeasible investment projects
-        unfeasible_text: "The investments must meet a number of criteria (legality, concreteness, be the responsibility of the city, not exceed the limit of the budget) to be declared viable and reach the stage of final vote. All investments don't meet these criteria are marked as unfeasible and published in the following list, along with its report of infeasibility."
+        unfeasible_text: "The investments must meet a number of criteria (legality, concreteness, not exceed the limit of the budget) to be declared viable and reach the stage of final vote. All investments don't meet these criteria are marked as unfeasible and published in the following list, along with its report of infeasibility."
         by_heading: "Investment projects with scope: %{heading}"
         search_form:
           button: Search

--- a/config/locales/en/legislation.yml
+++ b/config/locales/en/legislation.yml
@@ -71,7 +71,7 @@ en:
           help: Help about collaborative legislation
         section_footer:
           title: Help about collaborative legislation
-          description: Participate in the debates and processes prior to the approval of a ordinance or a municipal action. Your opinion will be considered by the City Council.
+          description: Participate in the debates and processes prior to the approval of new regulations or strategies. Your opinion will be considered.
       phase_not_open:
         not_open: This phase is not open yet
       phase_empty:

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -79,7 +79,7 @@ en:
     direct_message_max_per_day_description: "Number max of direct messages one user can send per day"
     feature:
       budgets: "Participatory budgeting"
-      budgets_description: "With participatory budgets, citizens decide which projects presented by their neighbours will receive a part of the municipal budget"
+      budgets_description: "With participatory budgets, citizens decide which projects presented by their neighbours will receive a part of the budget"
       twitter_login: "Twitter login"
       twitter_login_description: "Allow users to sign up with their Twitter account"
       facebook_login: "Facebook login"
@@ -87,7 +87,7 @@ en:
       google_login: "Google login"
       google_login_description: "Allow users to sign up with their Google Account"
       proposals: "Proposals"
-      proposals_description: "Citizens' proposals are an opportunity for neighbours and collectives to decide directly how they want their city to be, after getting sufficient support and submitting to a citizens' vote"
+      proposals_description: "Citizens' proposals are an opportunity for neighbours and collectives to decide directly how they want their society to be, after getting sufficient support and submitting to a citizens' vote"
       featured_proposals: "Featured proposals"
       featured_proposals_description: "Shows featured proposals on index proposals page"
       debates: "Debates"
@@ -97,7 +97,7 @@ en:
       signature_sheets: "Signature sheets"
       signature_sheets_description: "It allows adding from the Administration panel signatures collected on-site to Proposals and investment projects of the Participative Budgets"
       legislation: "Legislation"
-      legislation_description: "In participatory processes, citizens are offered the opportunity to participate in the drafting and modification of regulations that affect the city and to give their opinion on certain actions that are planned to be carried out"
+      legislation_description: "In participatory processes, citizens are offered the opportunity to participate in the drafting and modification of regulations and to give their opinion on certain actions that are planned to be carried out"
       spending_proposals: "Spending proposals"
       spending_proposals_description: "⚠️ NOTE: This functionality has been replaced by Participatory Budgeting and will disappear in new versions"
       spending_proposal_features:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -244,15 +244,17 @@ es:
         summary: Resumen
         description: En qué consiste
         additional_info: Información adicional
-        start_date: Fecha de inicio del proceso
-        end_date: Fecha de fin del proceso
-        debate_start_date: Fecha de inicio del debate
-        debate_end_date: Fecha de fin del debate
-        draft_start_date: Fecha de inicio del borrador
-        draft_end_date: Fecha de fin del borrador
+        start_date: Inicio
+        end_date: Fin
+        debate_start_date: Inicio
+        debate_end_date: Fin
+        draft_start_date: Inicio
+        draft_end_date: Fin
         draft_publication_date: Fecha de publicación del borrador
-        allegations_start_date: Fecha de inicio de alegaciones
-        allegations_end_date: Fecha de fin de alegaciones
+        allegations_start_date: Inicio
+        allegations_end_date: Fin
+        proposals_phase_start_date: Inicio
+        proposals_phase_end_date: Fin
         result_publication_date: Fecha de publicación del resultado final
         background_color: Color del fondo
         font_color: Color del texto
@@ -368,7 +370,7 @@ es:
             draft_end_date:
               invalid_date_range: tiene que ser igual o posterior a la fecha de inicio del borrador
             allegations_end_date:
-              invalid_date_range: tiene que ser igual o posterior a la fecha de inicio de las alegaciones
+              invalid_date_range: tiene que ser igual o posterior a la fecha de inicio de los comentarios
         proposal:
           attributes:
             tag_list:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -445,8 +445,6 @@ es:
           draft_phase_description: Si esta fase está activa, el proceso no aparecerá en la página de procesos. Permite previsualizar el proceso y crear contenido antes del inicio.
           allegations_phase: Fase de comentarios
           proposals_phase: Fase de propuestas
-          start: Inicio
-          end: Fin
           use_markdown: Usa Markdown para formatear el texto
           title_placeholder: Escribe el título del proceso
           summary_placeholder: Resumen corto de la descripción

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -73,7 +73,7 @@ es:
       index:
         title: Presupuestos participativos
         unfeasible: Proyectos de gasto no viables
-        unfeasible_text: "Los proyectos presentados deben cumplir una serie de criterios (legalidad, concreción, ser competencia del Ayuntamiento, no superar el tope del presupuesto) para ser declarados viables y llegar hasta la fase de votación final. Todos los proyectos que no cumplen estos criterios son marcados como inviables y publicados en la siguiente lista, junto con su informe de inviabilidad."
+        unfeasible_text: "Los proyectos presentados deben cumplir una serie de criterios (legalidad, concreción, no superar el tope del presupuesto) para ser declarados viables y llegar hasta la fase de votación final. Todos los proyectos que no cumplen estos criterios son marcados como inviables y publicados en la siguiente lista, junto con su informe de inviabilidad."
         by_heading: "Proyectos de gasto con ámbito: %{heading}"
         search_form:
           button: Buscar

--- a/config/locales/es/legislation.yml
+++ b/config/locales/es/legislation.yml
@@ -71,7 +71,7 @@ es:
           help: Ayuda sobre legislación colaborativa
         section_footer:
           title: Ayuda sobre Legislación colaborativa
-          description: Participa en los debates y procesos previos a la aprobación de una norma o de una actuación municipal. Tu opinión será tenida en cuenta por el Ayuntamiento.
+          description: Participa en los debates y procesos previos a la aprobación de nuevas normas o planes. Tu opinión será tenida en cuenta.
       phase_not_open:
         not_open: Esta fase del proceso todavía no está abierta
       phase_empty:

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -79,7 +79,7 @@ es:
     direct_message_max_per_day_description: "Número de mensajes directos máximos que un usuario puede enviar por día"
     feature:
       budgets: "Presupuestos participativos"
-      budgets_description: "Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto municipal"
+      budgets_description: "Con los presupuestos participativos la ciudadanía decide a qué proyectos presentados por los vecinos y vecinas va destinada una parte del presupuesto"
       twitter_login: "Registro con Twitter"
       twitter_login_description: "Permitir que los usuarios se registren con su cuenta de Twitter"
       facebook_login: "Registro con Facebook"
@@ -87,7 +87,7 @@ es:
       google_login: "Registro con Google"
       google_login_description: "Permitir que los usuarios se registren con su cuenta de Google"
       proposals: "Propuestas"
-      proposals_description: "Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su ciudad, después de conseguir los apoyos suficientes y de someterse a votación ciudadana"
+      proposals_description: "Las propuestas ciudadanas son una oportunidad para que los vecinos y colectivos decidan directamente cómo quieren que sea su sociedad, después de conseguir los apoyos suficientes y de someterse a votación ciudadana"
       featured_proposals: "Propuestas destacadas"
       featured_proposals_description: "Muestra propuestas destacadas en la página principal de propuestas"
       debates: "Debates"
@@ -97,7 +97,7 @@ es:
       signature_sheets: "Hojas de firmas"
       signature_sheets_description: "Permite añadir desde el panel de Administración firmas recogidas de forma presencial a Propuestas y proyectos de gasto de los Presupuestos participativos"
       legislation: "Legislación"
-      legislation_description: "En los procesos participativos se ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa que afecta a la ciudad y de dar su opinión sobre ciertas actuaciones que se tiene previsto llevar a cabo"
+      legislation_description: "En los procesos participativos se ofrece a la ciudadanía la oportunidad de participar en la elaboración y modificación de normativa y de dar su opinión sobre ciertas actuaciones que se tiene previsto llevar a cabo"
       spending_proposals: "Propuestas de inversión"
       spending_proposals_description: "⚠️ NOTA: Esta funcionalidad ha sido sustituida por Pesupuestos Participativos y desaparecerá en nuevas versiones"
       spending_proposal_features:

--- a/spec/models/legislation/process_spec.rb
+++ b/spec/models/legislation/process_spec.rb
@@ -82,7 +82,7 @@ describe Legislation::Process do
                                             allegations_end_date: Date.current - 1.day)
       expect(process).to be_invalid
       expect(process.errors.messages[:allegations_end_date])
-      .to include("must be on or after the allegations start date")
+      .to include("must be on or after the comments start date")
     end
 
     it "is valid if allegations_end_date is the same as allegations_start_date" do


### PR DESCRIPTION
## References

Upstream from https://github.com/consul/consul/pull/3337

## Objectives

This PR **generalizes some i18n keys**, moves customised ones to custom files. Also replaces translations on admin legislation processes to use _activerecord_ translations.

## Does this PR need a Backport to CONSUL?

No, this code it's already on CONSUL. 😌 