### PR TITLE
[Upstream] Show results checkbox for voted polls

### DIFF
--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -11,13 +11,13 @@
     </div>
   <% end %>
 
-  <% if !@partial_results.empty? %>
+  <% if @partial_results.present? %>
     <%= render "recount", resource: @poll %>
     <%= render "result" %>
     <%= render "results_by_booth" %>
   <% end %>
 
-  <% if !@poll.voters.empty? %>
+  <% if @poll.voters.any? %>
     <%= render "show_results", resource: @poll %>
   <% end %>
 </div>

--- a/app/views/admin/poll/results/index.html.erb
+++ b/app/views/admin/poll/results/index.html.erb
@@ -5,14 +5,19 @@
 
   <h3><%= t("admin.results.index.title") %></h3>
 
-  <% if @partial_results.empty? %>
+  <% if @partial_results.empty? && @poll.voters.empty? %>
     <div class="callout primary margin-top">
       <%= t("admin.results.index.no_results") %>
     </div>
-  <% else %>
+  <% end %>
+
+  <% if !@partial_results.empty? %>
     <%= render "recount", resource: @poll %>
     <%= render "result" %>
     <%= render "results_by_booth" %>
+  <% end %>
+
+  <% if !@poll.voters.empty? %>
     <%= render "show_results", resource: @poll %>
   <% end %>
 </div>

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -96,6 +96,7 @@ FactoryBot.define do
 
     trait :from_booth do
       association :booth_assignment, factory: :poll_booth_assignment
+      origin "booth"
     end
 
     trait :valid_document do

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -97,6 +97,11 @@ FactoryBot.define do
     trait :from_booth do
       association :booth_assignment, factory: :poll_booth_assignment
       origin "booth"
+      before :create do |voter|
+        voter.officer_assignment = create(:poll_officer_assignment,
+                                          officer: voter.officer,
+                                          booth_assignment: voter.booth_assignment)
+      end
     end
 
     trait :valid_document do

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -105,59 +105,6 @@ feature 'Admin polls' do
     expect(page).to have_content I18n.l(end_date.to_date)
   end
 
-  scenario 'Enable stats and results' do
-    poll = create(:poll)
-
-    booth_assignment_1 = create(:poll_booth_assignment, poll: poll)
-    booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
-    booth_assignment_3 = create(:poll_booth_assignment, poll: poll)
-
-    question_1 = create(:poll_question, poll: poll)
-    create(:poll_question_answer, title: 'Oui', question: question_1)
-    create(:poll_question_answer, title: 'Non', question: question_1)
-
-    question_2 = create(:poll_question, poll: poll)
-    create(:poll_question_answer, title: "Aujourd'hui", question: question_2)
-    create(:poll_question_answer, title: 'Demain', question: question_2)
-
-    [booth_assignment_1, booth_assignment_2, booth_assignment_3].each do |ba|
-      create(:poll_partial_result,
-             booth_assignment: ba,
-             question: question_1,
-             answer: 'Oui',
-             amount: 11)
-
-      create(:poll_partial_result,
-             booth_assignment: ba,
-             question: question_2,
-             answer: 'Demain',
-             amount: 5)
-    end
-
-    create(:poll_recount,
-           booth_assignment: booth_assignment_1,
-           white_amount: 21,
-           null_amount: 44,
-           total_amount: 66)
-
-    visit admin_poll_results_path(poll)
-
-    expect(page).to have_field('poll_stats_enabled', checked: false)
-    expect(page).to have_field('poll_results_enabled', checked: false)
-
-    check 'poll_stats_enabled'
-    check 'poll_results_enabled'
-
-    click_button 'Update poll'
-
-    expect(page).to have_content('Poll updated successfully')
-
-    click_link 'Results'
-
-    expect(page).to have_field('poll_stats_enabled', checked: true)
-    expect(page).to have_field('poll_results_enabled', checked: true)
-  end
-
   scenario 'Edit from index' do
     poll = create(:poll)
     visit admin_polls_path
@@ -322,6 +269,63 @@ feature 'Admin polls' do
         click_link "Results"
 
         expect(page).to have_content "There are no results"
+      end
+
+      scenario 'Show partial results' do
+        poll = create(:poll)
+
+        booth_assignment_1 = create(:poll_booth_assignment, poll: poll)
+        booth_assignment_2 = create(:poll_booth_assignment, poll: poll)
+        booth_assignment_3 = create(:poll_booth_assignment, poll: poll)
+
+        question_1 = create(:poll_question, poll: poll)
+        create(:poll_question_answer, title: 'Oui', question: question_1)
+        create(:poll_question_answer, title: 'Non', question: question_1)
+
+        question_2 = create(:poll_question, poll: poll)
+        create(:poll_question_answer, title: "Aujourd'hui", question: question_2)
+        create(:poll_question_answer, title: 'Demain', question: question_2)
+
+        [booth_assignment_1, booth_assignment_2, booth_assignment_3].each do |ba|
+          create(:poll_partial_result,
+                 booth_assignment: ba,
+                 question: question_1,
+                 answer: 'Oui',
+                 amount: 11)
+
+          create(:poll_partial_result,
+                 booth_assignment: ba,
+                 question: question_2,
+                 answer: 'Demain',
+                 amount: 5)
+        end
+
+        create(:poll_recount,
+               booth_assignment: booth_assignment_1,
+               white_amount: 21,
+               null_amount: 44,
+               total_amount: 66)
+
+        visit admin_poll_results_path(poll)
+
+        expect(page).to have_content 'Results by booth'
+      end
+
+      scenario "Enable stats and results" do
+        poll = create(:poll)
+
+        visit admin_poll_results_path(poll)
+
+        expect(page).to have_content 'There are no results'
+        expect(page).not_to have_content 'Show results and stats'
+
+        poll_voter = create(:poll_voter)
+
+        visit admin_poll_results_path(poll_voter.poll)
+
+        expect(page).to have_content 'Show results and stats'
+        expect(page).not_to have_content 'There are no results'
+        expect(page).not_to have_content 'Results by booth'
       end
 
       scenario "Results by answer", :js do

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -271,7 +271,7 @@ feature 'Admin polls' do
         expect(page).to have_content "There are no results"
       end
 
-      scenario 'Show partial results' do
+      scenario "Show partial results" do
         poll = create(:poll)
 
         booth_assignment_1 = create(:poll_booth_assignment, poll: poll)
@@ -279,24 +279,24 @@ feature 'Admin polls' do
         booth_assignment_3 = create(:poll_booth_assignment, poll: poll)
 
         question_1 = create(:poll_question, poll: poll)
-        create(:poll_question_answer, title: 'Oui', question: question_1)
-        create(:poll_question_answer, title: 'Non', question: question_1)
+        create(:poll_question_answer, title: "Oui", question: question_1)
+        create(:poll_question_answer, title: "Non", question: question_1)
 
         question_2 = create(:poll_question, poll: poll)
         create(:poll_question_answer, title: "Aujourd'hui", question: question_2)
-        create(:poll_question_answer, title: 'Demain', question: question_2)
+        create(:poll_question_answer, title: "Demain", question: question_2)
 
         [booth_assignment_1, booth_assignment_2, booth_assignment_3].each do |ba|
           create(:poll_partial_result,
                  booth_assignment: ba,
                  question: question_1,
-                 answer: 'Oui',
+                 answer: "Oui",
                  amount: 11)
 
           create(:poll_partial_result,
                  booth_assignment: ba,
                  question: question_2,
-                 answer: 'Demain',
+                 answer: "Demain",
                  amount: 5)
         end
 
@@ -308,7 +308,7 @@ feature 'Admin polls' do
 
         visit admin_poll_results_path(poll)
 
-        expect(page).to have_content 'Results by booth'
+        expect(page).to have_content "Results by booth"
       end
 
       scenario "Enable stats and results for booth polls" do
@@ -339,14 +339,14 @@ feature 'Admin polls' do
 
         visit admin_poll_results_path(unvoted_poll)
 
-        expect(page).to have_content 'There are no results'
-        expect(page).not_to have_content 'Show results and stats'
+        expect(page).to have_content "There are no results"
+        expect(page).not_to have_content "Show results and stats"
 
         visit admin_poll_results_path(voted_poll)
 
-        expect(page).to have_content 'Show results and stats'
-        expect(page).not_to have_content 'There are no results'
-        expect(page).not_to have_content 'Results by booth'
+        expect(page).to have_content "Show results and stats"
+        expect(page).not_to have_content "There are no results"
+        expect(page).not_to have_content "Results by booth"
       end
 
       scenario "Results by answer", :js do

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -311,17 +311,38 @@ feature 'Admin polls' do
         expect(page).to have_content 'Results by booth'
       end
 
-      scenario "Enable stats and results" do
-        poll = create(:poll)
+      scenario "Enable stats and results for booth polls" do
+        unvoted_poll = create(:poll)
 
-        visit admin_poll_results_path(poll)
+        voted_poll = create(:poll)
+        booth_assignment = create(:poll_booth_assignment, poll: voted_poll)
+        create(:poll_voter, :from_booth, :valid_document,
+               booth_assignment: booth_assignment,
+               poll: voted_poll)
+
+        visit admin_poll_results_path(unvoted_poll)
+
+        expect(page).to have_content "There are no results"
+        expect(page).not_to have_content "Show results and stats"
+
+        visit admin_poll_results_path(voted_poll)
+
+        expect(page).to have_content "Show results and stats"
+        expect(page).not_to have_content "There are no results"
+      end
+
+      scenario "Enable stats and results for online polls" do
+        unvoted_poll = create(:poll)
+
+        voted_poll = create(:poll)
+        create(:poll_voter, poll: voted_poll)
+
+        visit admin_poll_results_path(unvoted_poll)
 
         expect(page).to have_content 'There are no results'
         expect(page).not_to have_content 'Show results and stats'
 
-        poll_voter = create(:poll_voter)
-
-        visit admin_poll_results_path(poll_voter.poll)
+        visit admin_poll_results_path(voted_poll)
 
         expect(page).to have_content 'Show results and stats'
         expect(page).not_to have_content 'There are no results'


### PR DESCRIPTION
## References

This is an upstream of https://github.com/consul/consul/pull/3155 & https://github.com/consul/consul/pull/3341

## Objectives

The options to display stats and results are now showing even when there are only web voters in a poll. They'll be shown independently from the partial results in the admin results page. 

## Does this PR need a Backport to CONSUL?
Only the last commit ☺️ 