### PR TITLE
Order headings by name and group

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -8,6 +8,7 @@ module Budgets
     def show
       authorize! :read_results, @budget
       @investments = Budget::Result.new(@budget, @heading).investments
+      @headings = @budget.headings.sort_by_name
     end
 
     private

--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -7,6 +7,7 @@ module Budgets
     def show
       authorize! :read_stats, @budget
       @stats = load_stats
+      @headings = @budget.headings.sort_by_name
     end
 
     private

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -49,8 +49,8 @@
     <h3 class="margin-bottom">
       <%= t("budgets.results.heading_selection_title") %>
     </h3>
-    <ul class="menu vertical no-margin-top no-padding-top">
-      <% @budget.headings.order('id ASC').each do |heading| %>
+    <ul id="headings" class="menu vertical no-margin-top no-padding-top">
+      <% @headings.each do |heading| %>
         <li>
           <%= link_to heading.name,
                       custom_budget_heading_result_path(@budget, heading_id: heading.to_param),

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -201,8 +201,8 @@
               <th scope="col" class="tiny"><%= t("budgets.stats.percent_heading_census_html") %></th>
             </tr>
           </thead>
-          <tbody>
-            <% @budget.headings.order('id ASC').each do |heading| %>
+          <tbody id="headings">
+            <% @headings.each do |heading| %>
               <tr id="<%= heading.name.parameterize %>">
                 <td class="border-left">
                   <strong><%= heading.name %></strong>

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -144,6 +144,28 @@ feature 'Results' do
       expect(page).to have_content "Results"
     end
 
-  end
+    context "headings" do
 
+      scenario "Displays headings ordered by name with city heading first" do
+        budget.update(phase: "finished")
+
+        district_group = create(:budget_group, budget: budget)
+        create(:budget_heading, group: district_group, name: "Brooklyn")
+        create(:budget_heading, group: district_group, name: "Queens")
+        create(:budget_heading, group: district_group, name: "Manhattan")
+
+        city_group = create(:budget_group, budget: budget)
+        city_heading = create(:budget_heading, group: city_group, name: "City of New York")
+
+        visit budget_results_path(budget)
+
+        within("#headings") do
+          expect("City of New York").to appear_before("Brooklyn")
+          expect("Brooklyn").to appear_before("Manhattan")
+          expect("Manhattan").to appear_before("Queens")
+        end
+      end
+    end
+
+  end
 end

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -56,6 +56,28 @@ feature 'Stats' do
       expect(page).to have_content "Stats"
     end
 
-  end
+    context "headings" do
 
+      scenario "Displays headings ordered by name with city heading first" do
+        budget.update(phase: "finished")
+
+        district_group = create(:budget_group, budget: budget)
+        create(:budget_heading, group: district_group, name: "Brooklyn")
+        create(:budget_heading, group: district_group, name: "Queens")
+        create(:budget_heading, group: district_group, name: "Manhattan")
+
+        city_group = create(:budget_group, budget: budget)
+        city_heading = create(:budget_heading, group: city_group, name: "City of New York")
+
+        visit budget_stats_path(budget)
+
+        within("#headings") do
+          expect("City of New York").to appear_before("Brooklyn")
+          expect("Brooklyn").to appear_before("Manhattan")
+          expect("Manhattan").to appear_before("Queens")
+        end
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Objectives

Display headings in stats and results ordered by heading name and group

## Does this PR need a Backport to CONSUL?

Yes, more robust ordering would be good for CONSUL too. 