### PR TITLE
Spending proposals pre and post migration actions

### DIFF
--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -5,4 +5,102 @@ class Migrations::SpendingProposal::Budget
     @budget = find_budget
   end
 
+  def pre_rake_tasks
+    update_heading_price
+    update_heading_population
+    update_selected_investments
+  end
+  private
+
+    def update_heading_price
+      update_city_heading_price
+      update_district_heading_price
+    end
+
+    def update_city_heading_price
+      budget.headings.where(name: "Toda la ciudad").first&.update(price: 24000000)
+    end
+
+    def update_district_heading_price
+      price_by_heading.each do |heading_name, price|
+        budget.headings.where(name: heading_name).first&.update(price: price)
+      end
+    end
+
+    def price_by_heading
+      {
+        "Arganzuela"          => 1556169,
+        "Barajas"             => 433589,
+        "Carabanchel"         => 3247830,
+        "Centro"              => 1353966,
+        "Chamartín"           => 1313747,
+        "Chamberí"            => 1259587,
+        "Ciudad Lineal"       => 2287757,
+        "Fuencarral-El Pardo" => 2441608,
+        "Hortaleza"           => 1827228,
+        "Latina"              => 2927200,
+        "Moncloa-Aravaca"     => 1129851,
+        "Moratalaz"           => 1067341,
+        "Puente de Vallecas"  => 3349186,
+        "Retiro"              => 1075155,
+        "Salamanca"           => 1286657,
+        "San Blas-Canillejas" => 1712043,
+        "Tetuán"              => 1677256,
+        "Usera"               => 1923216,
+        "Vicálvaro"           => 879529,
+        "Villa de Vallecas"   => 1220810,
+        "Villaverde"          => 2030275
+      }
+    end
+
+    def update_heading_population
+      update_city_heading_population
+      update_district_heading_population
+    end
+
+    def update_city_heading_population
+      budget.headings.where(name: "Toda la ciudad").first&.update(population: city_population)
+    end
+
+    def update_district_heading_population
+      population_by_heading.each do |heading_name, population|
+        budget.headings.where(name: heading_name).first&.update(population: population)
+      end
+    end
+
+    def city_population
+      population_by_heading.collect {|district, population| population}.sum
+    end
+
+    def population_by_heading
+      {
+        "Arganzuela"          => 131429,
+        "Barajas"             =>  37725,
+        "Carabanchel"         => 205197,
+        "Centro"              => 120867,
+        "Chamartín"           => 123099,
+        "Chamberí"            => 122280,
+        "Ciudad Lineal"       => 184285,
+        "Fuencarral-El Pardo" => 194232,
+        "Hortaleza"           => 146471,
+        "Latina"              => 204427,
+        "Moncloa-Aravaca"     =>  99274,
+        "Moratalaz"           =>  82741,
+        "Puente de Vallecas"  => 194314,
+        "Retiro"              => 103666,
+        "Salamanca"           => 126699,
+        "San Blas-Canillejas" => 127800,
+        "Tetuán"              => 133972,
+        "Usera"               => 112158,
+        "Vicálvaro"           =>  55783,
+        "Villa de Vallecas"   =>  82504,
+        "Villaverde"          => 117478
+      }
+    end
+
+    def update_selected_investments
+      SpendingProposal.feasible.valuation_finished.each do |spending_proposal|
+        find_budget_investment(spending_proposal).update(selected: true)
+      end
+    end
 end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -1,3 +1,5 @@
+require_dependency "spending_proposal"
+
 class Migrations::SpendingProposal::Budget
   attr_accessor :budget
 
@@ -108,8 +110,8 @@ class Migrations::SpendingProposal::Budget
     end
 
     def update_selected_investments
-      SpendingProposal.feasible.valuation_finished.each do |spending_proposal|
-        find_budget_investment(spending_proposal).update(selected: true)
+      ::SpendingProposal.feasible.valuation_finished.each do |spending_proposal|
+        find_budget_investment(spending_proposal)&.update(selected: true)
       end
     end
 
@@ -151,7 +153,7 @@ class Migrations::SpendingProposal::Budget
     end
 
     def find_budget
-      Budget.where(slug: 2016).first
+      ::Budget.where(slug: 2016).first
     end
 
 end

--- a/lib/migrations/spending_proposal/budget.rb
+++ b/lib/migrations/spending_proposal/budget.rb
@@ -1,0 +1,8 @@
+class Migrations::SpendingProposal::Budget
+  attr_accessor :budget
+
+  def initialize
+    @budget = find_budget
+  end
+
+end

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -37,11 +37,22 @@ namespace :spending_proposals do
 
   desc "Migrates all necessary data from spending proposals to budget investments"
   task migrate: [
+    "spending_proposals:pre_migrate",
     "spending_proposals:migrate_attributes",
     "spending_proposals:migrate_votes",
     "spending_proposals:migrate_ballots",
     "spending_proposals:migrate_delegated_ballots",
+    "spending_proposals:post_migrate",
   ]
+
+  desc "Run the required actions before the migration"
+  task pre_migrate: :environment do
+    require "migrations/spending_proposal/budget"
+
+    puts "Starting pre rake tasks"
+    Migrations::SpendingProposal::Budget.new.pre_rake_tasks
+    puts "Finished"
+  end
 
   desc "Migrates spending proposals attributes to budget investments attributes"
   task migrate_attributes: :environment do
@@ -76,6 +87,15 @@ namespace :spending_proposals do
 
     puts "Starting to migrate delegated ballots"
     Migrations::SpendingProposal::DelegatedBallots.new.migrate_all
+    puts "Finished"
+  end
+
+  desc "Run the required actions after the migration"
+  task post_migrate: :environment do
+    require "migrations/spending_proposal/budget"
+
+    puts "Starting post rake tasks"
+    Migrations::SpendingProposal::Budget.new.post_rake_tasks
     puts "Finished"
   end
 

--- a/spec/lib/migrations/spending_proposals/budget_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+require "migrations/spending_proposal/budget"
+
+describe Migrations::SpendingProposal::Budget do
+
+  let!(:budget) { create(:budget, slug: "2016") }
+
+  describe "#initialize" do
+
+    it "initializes the budget to be migrated" do
+      migration = Migrations::SpendingProposal::Budget.new
+
+      expect(migration.budget).to eq(budget)
+    end
+
+  end

--- a/spec/lib/migrations/spending_proposals/budget_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_spec.rb
@@ -14,3 +14,86 @@ describe Migrations::SpendingProposal::Budget do
     end
 
   end
+
+  describe "#pre_rake_tasks" do
+
+    let!(:city_group)   { create(:budget_group, budget: budget) }
+    let!(:city_heading) { create(:budget_heading, group: city_group, name: "Toda la ciudad") }
+
+    let!(:district_group)    { create(:budget_group, budget: budget) }
+    let!(:district_heading1) { create(:budget_heading, group: district_group, name: "Arganzuela") }
+    let!(:district_heading2) { create(:budget_heading, group: district_group, name: "Barajas") }
+
+    context "heading price" do
+
+      it "updates the city heading's price" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        city_heading.reload
+        expect(city_heading.price).to eq(24000000)
+      end
+
+      it "updates the district headings' price" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        district_heading1.reload
+        district_heading2.reload
+        expect(district_heading1.price).to eq(1556169)
+        expect(district_heading2.price).to eq(433589)
+      end
+    end
+
+    context "heading population" do
+
+      it "updates the city heading's population" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        city_heading.reload
+        expect(city_heading.population).to eq(2706401)
+      end
+
+      it "updates the district headings' population" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        district_heading1.reload
+        district_heading2.reload
+        expect(district_heading1.population).to eq(131429)
+        expect(district_heading2.population).to eq(37725)
+      end
+
+    end
+
+    context "selected investments" do
+
+      let!(:spending_proposal1) { create(:spending_proposal, feasible: true, valuation_finished: true) }
+      let!(:spending_proposal2) { create(:spending_proposal, feasible: true, valuation_finished: true) }
+      let!(:spending_proposal3) { create(:spending_proposal, feasible: true, valuation_finished: false) }
+      let!(:spending_proposal4) { create(:spending_proposal, feasible: false, valuation_finished: true) }
+
+      let!(:budget_investment1) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal1.id) }
+      let!(:budget_investment2) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal2.id) }
+      let!(:budget_investment3) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal3.id) }
+      let!(:budget_investment4) { create(:budget_investment, budget: budget, original_spending_proposal_id: spending_proposal4.id) }
+
+      it "marks feasible and valuation finished investments as selected" do
+        migration = Migrations::SpendingProposal::Budget.new
+        migration.pre_rake_tasks
+
+        budget_investment1.reload
+        budget_investment2.reload
+        budget_investment3.reload
+        budget_investment4.reload
+
+        expect(budget_investment1.selected).to eq(true)
+        expect(budget_investment2.selected).to eq(true)
+        expect(budget_investment3.selected).to eq(false)
+        expect(budget_investment4.selected).to eq(false)
+      end
+
+    end
+  end
+


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Objectives

Add the required actions to be executed before and after the migration.

Before:
- Update heading prices
- Update heading populations
- Update selected investments

After:
- Remove forum votes
- Remove forum ballots
- Update investment cached votes
- Update investment cached ballots
- Calculate winners

## Does this PR need a Backport to CONSUL?

Yes, but it's going to be tricky. This is very specific for Madrid's fork.