### PR TITLE
Update spending proposals results url

### DIFF
--- a/app/controllers/budgets/results_controller.rb
+++ b/app/controllers/budgets/results_controller.rb
@@ -18,9 +18,12 @@ module Budgets
 
       def load_heading
         if @budget.present?
-          headings = @budget.headings
-          @heading = headings.find_by_slug_or_id(params[:heading_id]) || headings.first
+          @heading = @budget.headings.find_by_slug_or_id(params[:heading_id]) || default_heading
         end
+      end
+
+      def default_heading
+        @budget.city_heading || @budget.headings.first
       end
 
   end

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -162,15 +162,10 @@
                     </div>
                     <div class="small-12 medium-6 column table" data-equalizer-watch>
                       <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
-                        <% if budget.name == "Presupuestos Participativos 2016" %>
-                          <%= link_to t("budgets.index.see_results"),
-                                      participatory_budget_results_path,
-                                      class: "button" %>
-                        <% else %>
-                          <%= link_to t("budgets.index.see_results"),
-                                      custom_budget_results_path(budget),
-                                      class: "button" %>
-                        <% end %>
+                        <%= link_to t("budgets.index.see_results"),
+                                    custom_budget_results_path(budget),
+                                    class: "button" %>
+                        
                         <% unless budget.name == "Presupuestos Participativos 2018" %>
                           <%= link_to t("budgets.index.milestones"),
                                       custom_budget_executions_path(budget, status: 1),

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -76,9 +76,28 @@ feature 'Results' do
     end
   end
 
-  scenario "Load first budget heading if not specified" do
+  scenario "Load city heading if not specified" do
+    city_heading = create(:budget_heading, group: group)
+    city_investment = create(:budget_investment, :winner, heading: city_heading)
+
     other_heading = create(:budget_heading, group: group)
     other_investment = create(:budget_investment, :winner, heading: other_heading)
+
+    allow_any_instance_of(Budget).to receive(:city_heading).and_return(city_heading)
+
+    visit custom_budget_results_path(budget)
+
+    within("#budget-investments-compatible") do
+      expect(page).to have_content city_investment.title
+      expect(page).not_to have_content other_investment.title
+    end
+  end
+
+  scenario "Load first budget heading if not specified and city heading does not exist" do
+    other_heading = create(:budget_heading, group: group)
+    other_investment = create(:budget_investment, :winner, heading: other_heading)
+
+    allow_any_instance_of(Budget).to receive(:city_heading).and_return(nil)
 
     visit custom_budget_results_path(budget)
 


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Objectives

- Remove custom link to 2016's results
- Use city heading as the default heading for results

## Does this PR need a Backport to CONSUL?

Maybe, but the city heading is something quite specific for Madrid's fork.
At least part of this PR should be backported to reduce differences with Upstream.