### PR TITLE
Expire budget investments' stats cache

### DIFF
--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -149,6 +149,6 @@ class Budget::Stats
     stats_cache :voters, :participants, :authors, :balloters, :poll_ballot_voters
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v10", &block)
+      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v11", &block)
     end
 end


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Objectives

Expire budget's stats cache

## Does this PR need a Backport to CONSUL?

Maybe. Consider expiring the budget's stats cache in the migration rake task instead.