### PR TITLE
[Upstream] Move recounts index translations to main files

### DIFF
--- a/config/locales/custom/en/admin.yml
+++ b/config/locales/custom/en/admin.yml
@@ -20,11 +20,6 @@ en:
     hidden_users:
       show:
         phone: 'Phone:'
-    recounts:
-      index:
-        all_booths_total: "Cumulative total from all booths:"
-        total_final: Final recounts
-        total_system: Votes (automatic)
     booths:
       new:
         physical: "Physical booth"

--- a/config/locales/custom/es/admin.yml
+++ b/config/locales/custom/es/admin.yml
@@ -20,11 +20,6 @@ es:
     hidden_users:
       show:
         phone: 'Teléfono:'
-    recounts:
-      index:
-        all_booths_total: "Acumulado en todas las urnas:"
-        total_final: Recuentos finales
-        total_system: Votos (automático)
     booths:
       new:
         physical: "Urna física"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1095,6 +1095,9 @@ en:
       index:
         title: "Recounts"
         no_recounts: "There is nothing to be recounted"
+        all_booths_total: "Cumulative total from all booths:"
+        total_final: "Final recounts"
+        total_system: "Votes (automatic)"
         table_booth_name: "Booth"
         table_total_recount: "Total recount (by officer)"
         table_system_count: "Votes (automatic)"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1094,6 +1094,9 @@ es:
       index:
         title: "Recuentos"
         no_recounts: "No hay nada de lo que hacer recuento"
+        all_booths_total: "Acumulado en todas las urnas:"
+        total_final: "Recuentos finales"
+        total_system: "Votos (automático)"
         table_booth_name: "Urna"
         table_total_recount: "Recuento total (presidente de mesa)"
         table_system_count: "Votos (automático)"


### PR DESCRIPTION
## References

* Pull request consul#3342

## Objectives

Move translations used in CONSUL from the `custom` folder to the main files.

## Does this PR need a Backport to CONSUL?

No, the code is already there.