### PR TITLE
Remove question and external_url fields from proposals and legislation proposals 

### DIFF
--- a/app/controllers/legislation/proposals_controller.rb
+++ b/app/controllers/legislation/proposals_controller.rb
@@ -53,7 +53,7 @@ class Legislation::ProposalsController < Legislation::BaseController
 
     def proposal_params
       params.require(:legislation_proposal).permit(:legislation_process_id, :title,
-                    :question, :summary, :description,  :video_url, :tag_list,
+                    :summary, :description,  :video_url, :tag_list,
                     :terms_of_service, :geozone_id, :proposal_type,
                     image_attributes: image_attributes,
                     documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id])

--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -37,7 +37,7 @@ class Management::ProposalsController < Management::BaseController
     end
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
+      params.require(:proposal).permit(:title, :summary, :description, :video_url,
                                        :responsible_name, :tag_list, :terms_of_service, :geozone_id)
     end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -111,7 +111,7 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
+      params.require(:proposal).permit(:title, :summary, :description, :video_url,
                                        :responsible_name, :tag_list, :terms_of_service, :geozone_id, :proceeding, :sub_proceeding, :skip_map,
                                        image_attributes: image_attributes,
                                        documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -66,7 +66,6 @@ class Legislation::Proposal < ActiveRecord::Base
 
   def searchable_values
     { title              => 'A',
-      question           => 'B',
       author.username    => 'B',
       tag_list.join(' ') => 'B',
       geozone.try(:name) => 'B',

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -100,7 +100,6 @@ class Proposal < ActiveRecord::Base
 
   def searchable_values
     { title              => 'A',
-      question           => 'B',
       author.username    => 'B',
       tag_list.join(' ') => 'B',
       geozone.try(:name) => 'B',
@@ -249,7 +248,6 @@ class Proposal < ActiveRecord::Base
     ["id",
      "title",
      "description",
-     "external_url",
      "cached_votes_up",
      "comments_count",
      "hot_score",

--- a/app/views/admin/hidden_proposals/index.html.erb
+++ b/app/views/admin/hidden_proposals/index.html.erb
@@ -22,13 +22,9 @@
           <div class="moderation-description">
             <p><small><%= proposal.summary %></small></p>
             <%= proposal.description %>
-            <% if proposal.external_url.present? %>
-              <p><%= text_with_links proposal.external_url %></p>
-            <% end %>
             <% if proposal.video_url.present? %>
               <p><%= text_with_links proposal.video_url %></p>
             <% end %>
-            <p><%= proposal.question %></p>
           </div>
         </td>
         <td class="align-top">

--- a/app/views/custom/legislation/proposals/show.html.erb
+++ b/app/views/custom/legislation/proposals/show.html.erb
@@ -62,16 +62,6 @@
 
         <%= safe_html_with_links @proposal.description %>
 
-        <% if @proposal.is_proposal? && @proposal.external_url.present? %>
-          <div class="document-link">
-            <p>
-              <span class="icon-document"></span>&nbsp;
-              <strong><%= t('proposals.show.title_external_url') %></strong>
-            </p>
-              <%= text_with_links @proposal.external_url %>
-          </div>
-        <% end %>
-
         <% if @proposal.is_proposal? && @proposal.video_url.present? %>
           <div class="video-link">
             <p>
@@ -82,8 +72,6 @@
           </div>
 
         <% end %>
-
-        <h4><%= @proposal.question %></h4>
 
         <% if @proposal.is_proposal? %>
           <% unless @process.film_library? %>

--- a/app/views/documents/_additional_documents.html.erb
+++ b/app/views/documents/_additional_documents.html.erb
@@ -4,7 +4,7 @@
       <div class="small-12 column">
         <div class="additional-document-link">
           <p>
-            <strong><%= t('proposals.show.title_external_url') %></strong>
+            <strong><%= t("documents.additional") %></strong>
           </p>
           <%= render partial: 'documents/additional_document', collection: documents, as: :document %>
         </div>

--- a/app/views/legislation/proposals/show.html.erb
+++ b/app/views/legislation/proposals/show.html.erb
@@ -59,16 +59,6 @@
 
         <%= safe_html_with_links @proposal.description %>
 
-        <% if @proposal.external_url.present? %>
-          <div class="document-link">
-            <p>
-              <span class="icon-document"></span>&nbsp;
-              <strong><%= t('proposals.show.title_external_url') %></strong>
-            </p>
-              <%= text_with_links @proposal.external_url %>
-          </div>
-        <% end %>
-
         <% if @proposal.video_url.present? %>
           <div class="video-link">
             <p>
@@ -79,8 +69,6 @@
           </div>
 
         <% end %>
-
-        <h4><%= @proposal.question %></h4>
 
         <% if feature?(:allow_attached_documents) %>
           <%= render 'documents/documents',

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -54,11 +54,6 @@
                                    aria: {describedby: "video-url-help-text"} %>
     </div>
 
-    <div class="small-12 column">
-      <%= f.label :external_url, t("proposals.form.proposal_external_url") %>
-      <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"), label: false %>
-    </div>
-
     <% if feature?(:allow_images) %>
       <div class="images small-12 column">
         <%= render 'images/nested_image', imageable: @proposal, f: f %>

--- a/app/views/proposals/_info.html.erb
+++ b/app/views/proposals/_info.html.erb
@@ -42,16 +42,6 @@
   </div>
 <% end %>
 
-<% if @proposal.external_url.present? %>
-  <div class="document-link">
-    <p>
-      <span class="icon-document"></span>&nbsp;
-      <strong><%= t('proposals.show.title_external_url') %></strong>
-    </p>
-      <%= text_with_links @proposal.external_url %>
-  </div>
-<% end %>
-
 <% if @proposal.video_url.present? %>
   <div class="video-link">
     <p>
@@ -60,10 +50,6 @@
     </p>
     <%= text_with_links @proposal.video_url %>
   </div>
-<% end %>
-
-<% if @proposal.question.present? %>
-  <h4><%= @proposal.question %></h4>
 <% end %>
 
 <% if @proposal.retired? %>

--- a/config/api.yml
+++ b/config/api.yml
@@ -27,7 +27,6 @@ Proposal:
     id:                   integer
     title:                string
     description:          string
-    external_url:         string
     cached_votes_up:      integer
     comments_count:       integer
     hot_score:            integer

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -2,6 +2,7 @@ en:
   documents:
     title: Documents
     max_documents_allowed_reached_html: You have reached the maximum number of documents allowed! <strong>You have to delete one before you can upload another.</strong>
+    additional: Additional documentation
     form:
       title: Documents
       title_placeholder: Add a descriptive title for the document

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -310,7 +310,6 @@ en:
       other: Other
     form:
       geozone: Scope of operation
-      proposal_external_url: Link to additional documentation
       proposal_responsible_name: Full name of the person submitting the proposal
       proposal_responsible_name_note: "(individually or as representative of a collective; will not be displayed publically)"
       proposal_summary: Proposal summary
@@ -434,7 +433,6 @@ en:
       send_notification: Send notification
       no_notifications: "This proposal has no notifications."
       embed_video_title: "Video on %{proposal}"
-      title_external_url: "Additional documentation"
       title_video_url: "External video"
       author: Author
     update:

--- a/config/locales/es/documents.yml
+++ b/config/locales/es/documents.yml
@@ -2,6 +2,7 @@ es:
   documents:
     title: Documentos
     max_documents_allowed_reached_html: '¡Has alcanzado el número máximo de documentos permitidos! <strong>Tienes que eliminar uno antes de poder subir otro.</strong>'
+    additional: Documentación adicional
     form:
       title: Documentos
       title_placeholder: Añade un título descriptivo para el documento

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -308,7 +308,6 @@ es:
       other: Otra
     form:
       geozone: Ámbito de actuación
-      proposal_external_url: Enlace a documentación adicional
       proposal_responsible_name: Nombre y apellidos de la persona que hace esta propuesta
       proposal_responsible_name_note: "(individualmente o como representante de un colectivo; no se mostrará públicamente)"
       proposal_summary: Resumen de la propuesta
@@ -432,7 +431,6 @@ es:
       send_notification: Enviar notificación
       no_notifications: "Esta propuesta no tiene notificaciones."
       embed_video_title: "Vídeo en %{proposal}"
-      title_external_url: "Documentación adicional"
       title_video_url: "Vídeo externo"
       author: Autor
     update:

--- a/db/dev_seeds/legislation_proposals.rb
+++ b/db/dev_seeds/legislation_proposals.rb
@@ -2,7 +2,6 @@ section "Creating legislation proposals" do
   10.times do
     Legislation::Proposal.create!(title: Faker::Lorem.sentence(3).truncate(60),
                                   description: Faker::Lorem.paragraphs.join("\n\n"),
-                                  question: Faker::Lorem.sentence(3),
                                   summary: Faker::Lorem.paragraph,
                                   author: User.all.sample,
                                   process: Legislation::Process.all.sample,

--- a/db/dev_seeds/proposals.rb
+++ b/db/dev_seeds/proposals.rb
@@ -28,10 +28,8 @@ section "Creating Proposals" do
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
-                                question: Faker::Lorem.sentence(3) + "?",
                                 summary: Faker::Lorem.sentence(3),
                                 responsible_name: Faker::Name.name,
-                                external_url: Faker::Internet.url,
                                 description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(","),
@@ -49,10 +47,8 @@ section "Creating Archived Proposals" do
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
-                                question: Faker::Lorem.sentence(3) + "?",
                                 summary: Faker::Lorem.sentence(3),
                                 responsible_name: Faker::Name.name,
-                                external_url: Faker::Internet.url,
                                 description: description,
                                 tag_list: tags.sample(3).join(","),
                                 geozone: Geozone.all.sample,
@@ -70,10 +66,8 @@ section "Creating Successful Proposals" do
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
-                                question: Faker::Lorem.sentence(3) + "?",
                                 summary: Faker::Lorem.sentence(3),
                                 responsible_name: Faker::Name.name,
-                                external_url: Faker::Internet.url,
                                 description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(","),
@@ -90,10 +84,8 @@ section "Creating Successful Proposals" do
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(4).truncate(60),
-                                question: Faker::Lorem.sentence(6) + "?",
                                 summary: Faker::Lorem.sentence(3),
                                 responsible_name: Faker::Name.name,
-                                external_url: Faker::Internet.url,
                                 description: description,
                                 created_at: rand((Time.current - 1.week)..Time.current),
                                 tag_list: tags.sample(3).join(","),
@@ -139,10 +131,8 @@ section "Creating Proposals for Human Right Proceeding" do
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     Proposal.create!(author: author,
                      title: Faker::Lorem.sentence(3).truncate(60),
-                     question: Faker::Lorem.sentence(3) + "?",
                      summary: Faker::Lorem.sentence(3),
                      responsible_name: Faker::Name.name,
-                     external_url: Faker::Internet.url,
                      description: description,
                      created_at: rand((Time.now - 1.week)..Time.now),
                      tag_list: tags.sample(3).join(","),
@@ -159,7 +149,6 @@ section "Open plenary proposal" do
     description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
     Proposal.create!(author: User.reorder("RANDOM()").first,
                      title: Faker::Lorem.sentence(3).truncate(60),
-                     question: Faker::Lorem.sentence(3),
                      summary: Faker::Lorem.sentence(3),
                      responsible_name: Faker::Name.name,
                      description: description,

--- a/db/migrate/20190307165132_remove_question_and_external_url_from_proposals.rb
+++ b/db/migrate/20190307165132_remove_question_and_external_url_from_proposals.rb
@@ -1,0 +1,6 @@
+class RemoveQuestionAndExternalUrlFromProposals < ActiveRecord::Migration
+  def change
+    remove_column :proposals, :question, :string
+    remove_column :proposals, :external_url, :string
+  end
+end

--- a/db/migrate/20190307165337_remove_question_and_external_url_from_legislation_proposals.rb
+++ b/db/migrate/20190307165337_remove_question_and_external_url_from_legislation_proposals.rb
@@ -1,0 +1,6 @@
+class RemoveQuestionAndExternalUrlFromLegislationProposals < ActiveRecord::Migration
+  def change
+    remove_column :legislation_proposals, :question, :string
+    remove_column :legislation_proposals, :external_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -794,7 +794,6 @@ ActiveRecord::Schema.define(version: 20190307165337) do
     t.integer  "legislation_process_id"
     t.text     "title"
     t.text     "description"
-    t.string   "question"
     t.integer  "author_id"
     t.datetime "hidden_at"
     t.integer  "flags_count",                       default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190131122858) do
+ActiveRecord::Schema.define(version: 20190307165337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -795,7 +795,6 @@ ActiveRecord::Schema.define(version: 20190131122858) do
     t.text     "title"
     t.text     "description"
     t.string   "question"
-    t.string   "external_url"
     t.integer  "author_id"
     t.datetime "hidden_at"
     t.integer  "flags_count",                       default: 0
@@ -1336,8 +1335,6 @@ ActiveRecord::Schema.define(version: 20190131122858) do
   create_table "proposals", force: :cascade do |t|
     t.string   "title",               limit: 80
     t.text     "description"
-    t.string   "question"
-    t.string   "external_url"
     t.integer  "author_id"
     t.datetime "hidden_at"
     t.integer  "flags_count",                    default: 0
@@ -1371,7 +1368,6 @@ ActiveRecord::Schema.define(version: 20190131122858) do
   add_index "proposals", ["hidden_at"], name: "index_proposals_on_hidden_at", using: :btree
   add_index "proposals", ["hot_score"], name: "index_proposals_on_hot_score", using: :btree
   add_index "proposals", ["proceeding"], name: "index_proposals_on_proceeding", using: :btree
-  add_index "proposals", ["question"], name: "index_proposals_on_question", using: :btree
   add_index "proposals", ["sub_proceeding"], name: "index_proposals_on_sub_proceeding", using: :btree
   add_index "proposals", ["summary"], name: "index_proposals_on_summary", using: :btree
   add_index "proposals", ["title"], name: "index_proposals_on_title", using: :btree

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -3,12 +3,11 @@ FactoryBot.define do
     sequence(:title)     { |n| "Proposal #{n} title" }
     sequence(:summary)   { |n| "In summary, what we want is... #{n}" }
     description          "Proposal description"
-    question             "Proposal question"
-    external_url         "http://external_documention.es"
     video_url            "https://youtu.be/nhuNb0XtRhQ"
     responsible_name     "John Snow"
     terms_of_service     "1"
     skip_map             "1"
+
     association :author, factory: :user
 
     trait :hidden do

--- a/spec/features/admin/hidden_proposals_spec.rb
+++ b/spec/features/admin/hidden_proposals_spec.rb
@@ -22,8 +22,6 @@ feature "Admin hidden proposals" do
     expect(page).to have_content(proposal.title)
     expect(page).to have_content(proposal.summary)
     expect(page).to have_content(proposal.description)
-    expect(page).to have_content(proposal.question)
-    expect(page).to have_content(proposal.external_url)
     expect(page).to have_content(proposal.video_url)
   end
 

--- a/spec/features/api/csv_exporter_spec.rb
+++ b/spec/features/api/csv_exporter_spec.rb
@@ -24,7 +24,6 @@ feature "CSV Exporter" do
         "id",
         "title",
         "description",
-        "external_url",
         "cached_votes_up",
         "comments_count",
         "hot_score",

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -24,7 +24,6 @@ feature "Proposals" do
       fill_in "proposal_title", with: "Help refugees"
       fill_in "proposal_summary", with: "In summary what we want is..."
       fill_in "proposal_description", with: "This is very important because..."
-      fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yRYFKcMa_Ek"
       check "proposal_terms_of_service"
 
@@ -35,7 +34,6 @@ feature "Proposals" do
       expect(page).to have_content "Help refugees"
       expect(page).to have_content "In summary what we want is..."
       expect(page).to have_content "This is very important because..."
-      expect(page).to have_content "http://rescue.org/refugees"
       expect(page).to have_content "https://www.youtube.com/watch?v=yRYFKcMa_Ek"
       expect(page).to have_content user.name
       expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -128,7 +128,6 @@ feature "Proposals" do
     expect(page).to have_content proposal.title
     expect(page).to have_content proposal.code
     expect(page).to have_content "Proposal description"
-    expect(page).to have_content "http://external_documention.es"
     expect(page).to have_content proposal.author.name
     expect(page).to have_content I18n.l(proposal.created_at.to_date)
     expect(page).to have_selector(avatar(proposal.author.name))
@@ -229,7 +228,6 @@ feature "Proposals" do
     fill_in "proposal_title", with: "Help refugees"
     fill_in "proposal_summary", with: "In summary what we want is..."
     fill_in "proposal_description", with: "This is very important because..."
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Refugees, Solidarity"
@@ -246,7 +244,6 @@ feature "Proposals" do
     expect(page).to have_content "Help refugees"
     expect(page).to have_content "In summary what we want is..."
     expect(page).to have_content "This is very important because..."
-    expect(page).to have_content "http://rescue.org/refugees"
     expect(page).to have_content "https://www.youtube.com/watch?v=yPQfcG-eimk"
     expect(page).to have_content author.name
     expect(page).to have_content "Refugees"
@@ -279,7 +276,6 @@ feature "Proposals" do
     fill_in "proposal_title", with: "Help refugees"
     fill_in "proposal_summary", with: "In summary, what we want is..."
     fill_in "proposal_description", with: "This is very important because..."
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     fill_in "proposal_tag_list", with: "Refugees, Solidarity"
@@ -306,7 +302,6 @@ feature "Proposals" do
     fill_in "proposal_subtitle", with: "This is the honeypot field"
     fill_in "proposal_summary", with: "This is the summary"
     fill_in "proposal_description", with: "This is the description"
-    fill_in "proposal_external_url", with: "http://google.com/robots.txt"
     fill_in "proposal_responsible_name", with: "Some other robot"
     check "proposal_terms_of_service"
 
@@ -360,7 +355,6 @@ feature "Proposals" do
     fill_in "proposal_title", with: "Help refugees"
     fill_in "proposal_summary", with: "In summary what we want is..."
     fill_in "proposal_description", with: "This is very important because..."
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     check "proposal_terms_of_service"
 
     click_button "Create proposal"
@@ -464,7 +458,6 @@ feature "Proposals" do
       fill_in "proposal_title", with: "Help refugees"
       fill_in "proposal_summary", with: "In summary what we want is..."
       fill_in_ckeditor "proposal_description", with: "A description with enough characters"
-      fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
       fill_in "proposal_responsible_name", with: "Isabel Garcia"
       check "proposal_terms_of_service"
@@ -695,7 +688,6 @@ feature "Proposals" do
     fill_in "proposal_title", with: "End child poverty"
     fill_in "proposal_summary", with: "Basically..."
     fill_in "proposal_description", with: "Let's do something to end child poverty"
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
 
     click_button "Save changes"
@@ -1895,7 +1887,6 @@ feature "Successful proposals" do
       fill_in "proposal_title", with: "Help refugees"
       fill_in "proposal_summary", with: "In summary what we want is..."
       fill_in "proposal_description", with: "This is very important because..."
-      fill_in "proposal_external_url", with: "http://rescue.org/refugees"
       fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
       fill_in "proposal_tag_list", with: "Refugees, Solidarity"
       check "proposal_terms_of_service"

--- a/spec/features/tags/proposals_spec.rb
+++ b/spec/features/tags/proposals_spec.rb
@@ -98,7 +98,6 @@ feature "Tags" do
     fill_in "proposal_title", with: "Help refugees"
     fill_in "proposal_summary", with: "In summary, what we want is..."
     fill_in_ckeditor "proposal_description", with: "A description with enough characters"
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=Ae6gQmhaMn4"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
@@ -142,7 +141,6 @@ feature "Tags" do
     fill_in "proposal_title", with: "A test of dangerous strings"
     fill_in "proposal_summary", with: "In summary, what we want is..."
     fill_in "proposal_description", with: "A description suitable for this test"
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -474,12 +474,6 @@ describe Proposal do
         expect(results).to eq([proposal])
       end
 
-      it "searches by question" do
-        proposal = create(:proposal, question: "to be or not to be")
-        results = described_class.search("to be or not to be")
-        expect(results).to eq([proposal])
-      end
-
       it "searches by author name" do
         author = create(:user, username: "Danny Trejo")
         proposal = create(:proposal, author: author)
@@ -558,7 +552,6 @@ describe Proposal do
     context "order" do
 
       it "orders by weight" do
-        proposal_question    = create(:proposal,  question:    "stop corruption")
         proposal_title       = create(:proposal,  title:       "stop corruption")
         proposal_description = create(:proposal,  description: "stop corruption")
         proposal_summary     = create(:proposal,  summary:     "stop corruption")
@@ -566,9 +559,8 @@ describe Proposal do
         results = described_class.search("stop corruption")
 
         expect(results.first).to eq(proposal_title)
-        expect(results.second).to eq(proposal_question)
-        expect(results.third).to eq(proposal_summary)
-        expect(results.fourth).to eq(proposal_description)
+        expect(results.second).to eq(proposal_summary)
+        expect(results.third).to eq(proposal_description)
       end
 
       it "orders by weight and then by votes" do

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -45,7 +45,6 @@ module CommonActions
     fill_in "proposal_title", with: "Help refugees"
     fill_in "proposal_summary", with: "In summary what we want is..."
     fill_in "proposal_description", with: "This is very important because..."
-    fill_in "proposal_external_url", with: "http://rescue.org/refugees"
     fill_in "proposal_video_url", with: "https://www.youtube.com/watch?v=yPQfcG-eimk"
     fill_in "proposal_responsible_name", with: "Isabel Garcia"
     check "proposal_terms_of_service"

--- a/spec/support/common_actions/proposals.rb
+++ b/spec/support/common_actions/proposals.rb
@@ -1,8 +1,8 @@
 module Proposals
   def create_successful_proposals
-    [create(:proposal, title: "Winter is coming", question: "Do you speak it?",
+    [create(:proposal, title: "Winter is coming",
                        cached_votes_up: Proposal.votes_needed_for_success + 100),
-     create(:proposal, title: "Fire and blood", question: "You talking to me?",
+     create(:proposal, title: "Fire and blood",
                        cached_votes_up: Proposal.votes_needed_for_success + 1)]
   end
 


### PR DESCRIPTION
## References

Related issue: https://github.com/consul/consul/issues/3182

## Objectives


- Remove `question` and `external_url` fields from **proposals**.
- Remove `question` and `external_url` fields from **legislation proposals**.

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.