### PR TITLE
Add rake to move external_url to description

### DIFF
--- a/lib/tasks/proposals.rake
+++ b/lib/tasks/proposals.rake
@@ -1,0 +1,23 @@
+namespace :proposals do
+
+  desc "Move external_url to description"
+  task move_external_url_to_description: :environment do
+    include ActionView::Helpers::SanitizeHelper
+    include TextWithLinksHelper
+
+    models = [Proposal, Legislation::Proposal]
+
+    models.each do |model|
+      print "Move external_url to description for #{model}s"
+      model.find_each do |resource|
+        if resource.external_url.present?
+          resource.update_columns(description: "#{resource.description} "\
+                                  "<p>#{text_with_links(resource.external_url)}</p>",
+                                  external_url: "")
+          print "."
+        end
+      end
+      puts " ✅ "
+    end
+  end
+end

--- a/spec/lib/tasks/proposals_spec.rb
+++ b/spec/lib/tasks/proposals_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe Proposals do
+
+  describe "Move external_url to description" do
+
+    let :run_rake_task do
+      Rake::Task["proposals:move_external_url_to_description"].reenable
+      Rake.application.invoke_task "proposals:move_external_url_to_description"
+    end
+
+    context "Move external_url to description for Proposals" do
+
+      it "When proposal has external_url" do
+        proposal = create(:proposal, description: "<p>Lorem ipsum dolor sit amet</p>",
+                                     external_url: "http://consul.dev")
+
+        run_rake_task
+        proposal.reload
+
+        expect(proposal.description).to eq "<p>Lorem ipsum dolor sit amet</p> "\
+                                           '<p><a href="http://consul.dev" '\
+                                           'target="_blank" rel="nofollow">'\
+                                           "http://consul.dev</a></p>"
+        expect(proposal.external_url).to eq ""
+      end
+
+      it "When proposal has not external_url" do
+        proposal = create(:proposal, description: "<p>Lorem ipsum dolor sit amet</p>",
+                                     external_url: "")
+
+        run_rake_task
+        proposal.reload
+
+        expect(proposal.description).to eq "<p>Lorem ipsum dolor sit amet</p>"
+        expect(proposal.external_url).to eq ""
+      end
+    end
+
+    context "Move external_url to description for Legislation proposals" do
+
+      it "When legislation proposal has external_url" do
+        legislation_proposal = create(:legislation_proposal, description: "<p>Ut enim ad minim</p>",
+                                       external_url: "http://consulproject.org")
+        run_rake_task
+        legislation_proposal.reload
+
+        expect(legislation_proposal.description).to eq "<p>Ut enim ad minim</p> "\
+                                                       '<p><a href="http://consulproject.org" '\
+                                                       'target="_blank" rel="nofollow">'\
+                                                       "http://consulproject.org</a></p>"
+        expect(legislation_proposal.external_url).to eq ""
+      end
+
+      it "When legislation proposal has not external_url" do
+        legislation_proposal = create(:legislation_proposal, description: "<p>Ut enim ad minim</p>",
+                                       external_url: "")
+        run_rake_task
+        legislation_proposal.reload
+
+        expect(legislation_proposal.description).to eq "<p>Ut enim ad minim</p>"
+        expect(legislation_proposal.external_url).to eq ""
+      end
+    end
+  end
+end


### PR DESCRIPTION
## References

Related issue: https://github.com/consul/consul/issues/3182

## Objectives

This rake move the content of `external_url` to `description` for **Proposals** and **Legislation proposals**.

## Visual Changes

**BEFORE**
![before_rake](https://user-images.githubusercontent.com/631897/54031260-9287d080-41ae-11e9-9b6e-9e9ef95bed5b.png)

**AFTER**
![after_rake](https://user-images.githubusercontent.com/631897/54031261-93b8fd80-41ae-11e9-92ee-f4ccf18c3a37.png)

## Does this PR need a Backport to CONSUL?

Backport to CONSUL.

## Release notes

⚠️ Run `bin/rake proposals:move_external_url_to_description RAILS_ENV=production` to move the content of external_url to description for Proposals and Legislation proposals.
