### PR TITLE
Remove deprecated settings

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -79,9 +79,6 @@ class ProposalsController < ApplicationController
   end
 
   def share
-    if Setting['proposal_improvement_path'].present?
-      @proposal_improvement_path = Setting['proposal_improvement_path']
-    end
   end
 
   def vote_featured

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -6,6 +6,10 @@ module VerificationHelper
      [t('verification.residence.new.document_type.residence_card'), 3]]
   end
 
+  def minimum_required_age
+    (Setting["min_age_to_participate"] || 16).to_i
+  end
+
   def mask_phone(number)
     match = number.match(/\d{3}$/)
     "******#{match}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -285,11 +285,7 @@ class User < ActiveRecord::Base
   end
 
   def self.minimum_required_age
-    (Setting['min_age_to_participate'] || 16).to_i
-  end
-
-  def self.minimum_required_age_for_verification
-    (Setting['min_age_to_verify'] || 16).to_i
+    (Setting["min_age_to_participate"] || 16).to_i
   end
 
   def show_welcome_screen?

--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -47,8 +47,9 @@ class Verification::Residence
   end
 
   def allowed_age
-    return if errors[:date_of_birth].any? ||  Age.in_years(date_of_birth) >= User.minimum_required_age_for_verification
-    errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age'))
+    return if errors[:date_of_birth].any? ||
+    Age.in_years(date_of_birth) >= User.minimum_required_age
+    errors.add(:date_of_birth, I18n.t("verification.residence.new.error_not_allowed_age"))
   end
 
   def document_number_uniqueness

--- a/app/views/admin/stats/show.html.erb
+++ b/app/views/admin/stats/show.html.erb
@@ -5,7 +5,7 @@
 
       <div class="float-right clear">
         <%= link_to t("admin.stats.show.external_stats"),
-                    setting['analytics_url'].try(:html_safe), target: '_blank', class: "button hollow" %>
+                    "https://webanalytics01.madrid.es", target: '_blank', class: "button hollow" %>
         <%= link_to t("admin.stats.show.polls"),
                     polls_admin_stats_path, class: "button hollow" %>
         <%= link_to t("admin.stats.show.participatory_budgets"),

--- a/app/views/custom/proposals/_kit_decide.html.erb
+++ b/app/views/custom/proposals/_kit_decide.html.erb
@@ -1,0 +1,4 @@
+<div class="callout highlight margin-top text-center">
+  <p class="lead"><strong><%= t("proposals.proposal.improve_info") %></strong></p>
+  <%= link_to t("proposals.proposal.improve_info_link"), kit_decide_path, class: "button" %>
+</div>

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -28,12 +28,7 @@
           mobile: @proposal.title
         } %>
 
-        <% if @proposal_improvement_path.present? %>
-          <div class="callout highlight margin-top text-center">
-            <p class="lead"><strong><%= t("proposals.proposal.improve_info") %></strong></p>
-            <%= link_to t("proposals.proposal.improve_info_link"), @proposal_improvement_path, class: "button" %>
-          </div>
-        <% end %>
+        <%= render "custom/proposals/kit_decide" %>
 
         <div class="small margin-bottom">
           <%= link_to t("proposals.proposal.share.view_proposal"), proposal_path(@proposal) %>

--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -65,7 +65,7 @@
       <%= f.label t("verification.residence.new.date_of_birth") %>
       <%= f.date_select :date_of_birth,
                         prompt: true,
-                        start_year: 1900, end_year: 16.years.ago.year,
+                        start_year: 1900, end_year: minimum_required_age.years.ago.year,
                         label: false %>
       </div>
 

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -66,6 +66,8 @@ en:
       reason_for_supports_necessary: 1% of Census
       successful: "This proposal has reached the required supports and will be voted in the %{voting}."
       voting: "next voting"
+      improve_info: "Improve your campaign and get more supports"
+      improve_info_link: "See more information"
   polls:
     index:
       title: Madrid City Council Citizen Consultations

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -70,6 +70,8 @@ es:
       reason_for_supports_necessary: 1% del Censo
       successful: "Esta propuesta ha alcanzado los apoyos necesarios y pasará a la %{voting}."
       voting: "próxima votación"
+      improve_info: "Mejora tu campaña y consigue más apoyos"
+      improve_info_link: "Ver más información"
   polls:
     index:
       title: Consultas ciudadanas del Ayuntamiento Madrid

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -392,8 +392,6 @@ en:
         guide: "Now you can share it so people can start supporting."
         edit: "Before it gets shared you'll be able to change the text as you like."
         view_proposal: Not now, go to my proposal
-      improve_info: "Improve your campaign and get more supports"
-      improve_info_link: "See more information"
       already_supported: You have already supported this proposal. Share it!
       comments:
         one: 1 comment

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -60,7 +60,6 @@ en:
     meta_keywords_description: 'Keywords <meta name="keywords">, used to improve SEO'
     min_age_to_participate: Minimum age needed to participate
     min_age_to_participate_description: "Users over this age can participate in all processes where a user verified account is needed"
-    analytics_url: "Analytics URL"
     verification_offices_url: Verification offices URL
     proposal_notification_minimum_interval_in_days: "Minimum interval (in days) for authors of proposals to send new proposal notifications"
     proposal_notification_minimum_interval_in_days_description: "The number of days user can send a notification for all supporters of their proposal"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -62,7 +62,6 @@ en:
     min_age_to_participate_description: "Users over this age can participate in all processes where a user verified account is needed"
     analytics_url: "Analytics URL"
     verification_offices_url: Verification offices URL
-    proposal_improvement_path: Proposal improvement info internal link
     proposal_notification_minimum_interval_in_days: "Minimum interval (in days) for authors of proposals to send new proposal notifications"
     proposal_notification_minimum_interval_in_days_description: "The number of days user can send a notification for all supporters of their proposal"
     direct_message_max_per_day: "Direct Message max number per day"

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -390,8 +390,6 @@ es:
         guide: "Compártela para que la gente empiece a apoyarla."
         edit: "Antes de que se publique podrás modificar el texto a tu gusto."
         view_proposal: Ahora no, ir a mi propuesta
-      improve_info: "Mejora tu campaña y consigue más apoyos"
-      improve_info_link: "Ver más información"
       already_supported: '¡Ya has apoyado esta propuesta, compártela!'
       comments:
         zero: Sin comentarios

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -60,7 +60,6 @@ es:
     meta_keywords_description: 'Palabras clave <meta name="keywords">, utilizadas para mejorar el SEO'
     min_age_to_participate: Edad mínima para participar
     min_age_to_participate_description: "Los usuarios mayores de esta edad podrán participar en todos los procesos donde se necesite una cueta verificada"
-    analytics_url: "URL de estadísticas externas"
     verification_offices_url: URL oficinas verificación
     proposal_notification_minimum_interval_in_days: "Intervalo mínimo (en días) para que los autores de propuestas puedan enviar nuevas notificaciones de propuesta"
     proposal_notification_minimum_interval_in_days_description: "El número de días en los que un usuario puede enviar una notificación a todos los que apoyan su propuesta"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -62,7 +62,6 @@ es:
     min_age_to_participate_description: "Los usuarios mayores de esta edad podrán participar en todos los procesos donde se necesite una cueta verificada"
     analytics_url: "URL de estadísticas externas"
     verification_offices_url: URL oficinas verificación
-    proposal_improvement_path: Link a información para mejorar propuestas
     proposal_notification_minimum_interval_in_days: "Intervalo mínimo (en días) para que los autores de propuestas puedan enviar nuevas notificaciones de propuesta"
     proposal_notification_minimum_interval_in_days_description: "El número de días en los que un usuario puede enviar una notificación a todos los que apoyan su propuesta"
     direct_message_max_per_day: "Mensajes directos máximos por día"

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -80,7 +80,6 @@ section "Creating Settings" do
   Setting.create(key: "direct_message_max_per_day", value: 3)
   Setting.create(key: "related_content_score_threshold", value: -0.3)
   Setting.create(key: "hot_score_period_in_days", value: 31)
-  Setting.create(key: "analytics_url", value: "")
 
   # piwik_tracking_code_head = "<!-- Piwik -->
   # <script type='text/javascript'>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -114,7 +114,6 @@ Setting["mailer_from_address"] = "noreply@consul.dev"
 # Verification settings
 Setting["verification_offices_url"] = "http://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Atencion-al-ciudadano/Oficinas-de-Atencion-al-Ciudadano?vgnextfmt=default&vgnextchannel=5b99cde2e09a4310VgnVCM1000000b205a0aRCRD"
 Setting["min_age_to_participate"] = 16
-Setting["min_age_to_verify"] = 16
 
 # Featured proposals
 Setting["featured_proposals_number"] = 3

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -119,9 +119,6 @@ Setting["min_age_to_verify"] = 16
 # Featured proposals
 Setting["featured_proposals_number"] = 3
 
-# Proposal improvement url path ('/help/proposal-improvement')
-Setting["proposal_improvement_path"] = nil
-
 # City map feature default configuration (Greenwich)
 Setting["map.latitude"] = 40.4332002
 Setting["map.longitude"] = -3.7009591

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -46,7 +46,10 @@ namespace :settings do
       "banner-style.banner-style-three",
       "banner-img.banner-img-one",
       "banner-img.banner-img-two",
-      "banner-img.banner-img-three"
+      "banner-img.banner-img-three",
+      "min_age_to_verify",
+      "proposal_improvement_path",
+      "analytics_url"
     ]
 
     deprecated_keys.each do |key|

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -268,7 +268,6 @@ feature "Proposals" do
   end
 
   scenario "Create with proposal improvement info link" do
-    Setting["proposal_improvement_path"] = "/more-information/proposal-improvement"
     author = create(:user)
     login_as(author)
 
@@ -285,12 +284,10 @@ feature "Proposals" do
 
     expect(page).to have_content "Proposal created successfully."
     expect(page).to have_content "Improve your campaign and get more supports"
-
+    expect(page).to have_link("See more information", href: "/mas-informacion/kit-decide")
     click_link "Not now, go to my proposal"
 
     expect(page).to have_content "Help refugees"
-
-    Setting["proposal_improvement_path"] = nil
   end
 
   scenario "Create with invisible_captcha honeypot field" do

--- a/spec/features/verification/residence_spec.rb
+++ b/spec/features/verification/residence_spec.rb
@@ -21,6 +21,21 @@ feature "Residence" do
     expect(page).to have_content "Residence verified"
   end
 
+  scenario "Residence form use min age to participate" do
+    min_age = (Setting["min_age_to_participate"] = 16).to_i
+    underage = min_age - 1
+    user = create(:user)
+    login_as(user)
+
+    visit account_path
+    click_link "Verify my account"
+
+    expect(page).to have_select("residence_date_of_birth_1i",
+                                 with_options: [min_age.years.ago.year])
+    expect(page).not_to have_select("residence_date_of_birth_1i",
+                                     with_options: [underage.years.ago.year])
+  end
+
   scenario "User document matches census API document" do
     user = create(:user)
     login_as(user)


### PR DESCRIPTION
## Objectives

Remove "deprecated" settings: `Setting["proposal_improvement_path"]` and `Setting["analytics_url"]`. These settings was only use once and doesn't make sense still being settings.

Also, remove "duplicated" `Setting['min_age_to_verify']`, already exists the setting `Setting["min_age_to_participate"]` with the same behaviour.

## Does this PR need a Backport to CONSUL?

Only backport the last commit to use `min age to participate` setting on verification residence form. The rest of settings doesn't exists on CONSUL.