### PR TITLE
Display all polls for current booth

### DIFF
--- a/app/controllers/officing/voters_controller.rb
+++ b/app/controllers/officing/voters_controller.rb
@@ -8,8 +8,7 @@ class Officing::VotersController < Officing::BaseController
 
   def new
     @user = User.find(params[:id])
-    booths = current_user.poll_officer.shifts.current.vote_collection.pluck(:booth_id).uniq
-    @polls = Poll.answerable_by(@user).where(id: Poll::BoothAssignment.where(booth: booths).pluck(:poll_id).uniq)
+    @polls = current_booth.polls.current
   end
 
   def create

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -81,12 +81,12 @@ class Poll < ActiveRecord::Base
   end
 
   def votable_by?(user)
-    return false if user_has_an_online_ballot(user)
+    return false if user_has_an_online_ballot?(user)
     answerable_by?(user) &&
     not_voted_by?(user)
   end
 
-  def user_has_an_online_ballot(user)
+  def user_has_an_online_ballot?(user)
     budget.present? && budget.ballots.find_by(user: user)&.lines.present?
   end
 

--- a/app/views/officing/voters/_already_voted.html.erb
+++ b/app/views/officing/voters/_already_voted.html.erb
@@ -1,7 +1,5 @@
-<td>
+<td colspan="2">
   <p class="callout alert text-center">
     <strong><%= t("officing.voters.show.error_already_voted") %></strong>
   </p>
-</td>
-<td>
 </td>

--- a/app/views/officing/voters/_cannot_vote.html.erb
+++ b/app/views/officing/voters/_cannot_vote.html.erb
@@ -1,7 +1,5 @@
-<td>
+<td colspan="2">
   <p class="callout alert text-center">
     <strong><%= t("officing.voters.show.cannot_vote") %></strong>
   </p>
-</td>
-<td>
 </td>

--- a/app/views/officing/voters/_cannot_vote.html.erb
+++ b/app/views/officing/voters/_cannot_vote.html.erb
@@ -1,0 +1,7 @@
+<td>
+  <p class="callout alert text-center">
+    <strong><%= t("officing.voters.show.cannot_vote") %></strong>
+  </p>
+</td>
+<td>
+</td>

--- a/app/views/officing/voters/new.html.erb
+++ b/app/views/officing/voters/new.html.erb
@@ -19,7 +19,7 @@
           </td>
           <% if poll.votable_by?(@user) %>
             <%= render "can_vote", poll: poll %>
-          <% elsif poll.voted_by?(@user) %>
+          <% elsif poll.voted_by?(@user) || poll.user_has_an_online_ballot?(@user) %>
             <%= render "already_voted" %>
           <% else %>
             <%= render "cannot_vote" %>

--- a/app/views/officing/voters/new.html.erb
+++ b/app/views/officing/voters/new.html.erb
@@ -19,8 +19,10 @@
           </td>
           <% if poll.votable_by?(@user) %>
             <%= render "can_vote", poll: poll %>
-          <% else %>
+          <% elsif poll.voted_by?(@user) %>
             <%= render "already_voted" %>
+          <% else %>
+            <%= render "cannot_vote" %>
           <% end %>
         </tr>
         <% end %>

--- a/config/locales/en/officing.yml
+++ b/config/locales/en/officing.yml
@@ -90,6 +90,7 @@ en:
         not_to_vote: The person has decided not to vote at this time
       show:
         can_vote: Can vote
+        cannot_vote: The person cannot vote because they are not registered in the district(s) where the voting takes place.
         error_already_voted: Has already participated in this poll
         submit: Confirm vote
         success: "Vote introduced!"

--- a/config/locales/es/officing.yml
+++ b/config/locales/es/officing.yml
@@ -82,6 +82,7 @@ es:
         not_to_vote: La persona ha decidido no votar por el momento
       show:
         can_vote: Puede votar
+        cannot_vote: La persona no puede votar porque no está empadronada en el/los distrito/s en los que la votación tiene lugar.
         error_already_voted: Ya ha participado en esta votación.
         submit: Confirmar voto
         success: "¡Voto introducido!"

--- a/spec/features/officing/voters_spec.rb
+++ b/spec/features/officing/voters_spec.rb
@@ -36,7 +36,22 @@ feature 'Voters' do
     expect(Poll::Voter.last.officer_id).to eq(officer.id)
   end
 
-  scenario "Already voted", :js do
+  scenario "Cannot vote" do
+    unvotable_poll = create(:poll, :current, geozone_restricted: true, geozones: [create(:geozone, census_code: "02")])
+    booth_assignment = create(:poll_booth_assignment, poll: unvotable_poll, booth: booth)
+    officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+
+    set_officing_booth(booth)
+    visit new_officing_residence_path
+    officing_verify_residence
+
+    within("#poll_#{unvotable_poll.id}") do
+      expect(page).to have_content "The person cannot vote"
+      expect(page).not_to have_button "Confirm vote"
+    end
+  end
+
+  scenario "Already voted" do
     poll2 = create(:poll, :current)
     booth_assignment = create(:poll_booth_assignment, poll: poll2, booth: booth)
     officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
@@ -85,35 +100,89 @@ feature 'Voters' do
     # expect(page).to have_content poll.name
   end
 
-  scenario "Display only current polls on which officer has a voting shift today, and user can answer", :js do
-    poll_current = create(:poll, :current)
-    second_booth = create(:poll_booth)
-    booth_assignment = create(:poll_booth_assignment, poll: poll_current, booth: second_booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
-    create(:poll_shift, officer: officer, booth: second_booth, date: Date.current, task: :recount_scrutiny)
-    create(:poll_shift, officer: officer, booth: second_booth, date: Date.tomorrow, task: :vote_collection)
+  context "Polls displayed to officers" do
 
-    poll_expired = create(:poll, :expired)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: create(:poll_booth_assignment, poll: poll_expired, booth: booth))
+    scenario "Display current polls assigned to a booth" do
+      poll = create(:poll, :current)
+      booth_assignment = create(:poll_booth_assignment, poll: poll, booth: booth)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
 
-    poll_geozone_restricted_in = create(:poll, :current, geozone_restricted: true, geozones: [Geozone.first])
-    booth_assignment = create(:poll_booth_assignment, poll: poll_geozone_restricted_in, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      set_officing_booth(booth)
+      visit new_officing_residence_path
+      officing_verify_residence
 
-    poll_geozone_restricted_out = create(:poll, :current, geozone_restricted: true, geozones: [create(:geozone, census_code: "02")])
-    booth_assignment = create(:poll_booth_assignment, poll: poll_geozone_restricted_out, booth: booth)
-    create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+      expect(page).to have_content "Polls"
+      expect(page).to have_content poll.name
+    end
 
-    set_officing_booth(second_booth)
-    visit new_officing_residence_path
-    officing_verify_residence
+    scenario "Display polls that the user can vote" do
+      votable_poll = create(:poll, :current, geozone_restricted: true, geozones: [Geozone.first])
+      booth_assignment = create(:poll_booth_assignment, poll: votable_poll, booth: booth)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
 
-    expect(page).to have_content "Polls"
-    expect(page).to have_content poll.name
-    expect(page).not_to have_content poll_current.name
-    expect(page).not_to have_content poll_expired.name
-    expect(page).to have_content poll_geozone_restricted_in.name
-    expect(page).not_to have_content poll_geozone_restricted_out.name
+      set_officing_booth(booth)
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content "Polls"
+      expect(page).to have_content votable_poll.name
+    end
+
+    scenario "Display polls that the user cannot vote" do
+      unvotable_poll = create(:poll, :current, geozone_restricted: true, geozones: [create(:geozone, census_code: "02")])
+      booth_assignment = create(:poll_booth_assignment, poll: unvotable_poll, booth: booth)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+
+      set_officing_booth(booth)
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content "Polls"
+      expect(page).to have_content unvotable_poll.name
+    end
+
+    scenario "Do not display expired polls" do
+      expired_poll = create(:poll, :expired)
+      booth_assignment = create(:poll_booth_assignment, poll: expired_poll, booth: booth)
+      officer_assignment = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment)
+
+      set_officing_booth(booth)
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content "Polls"
+      expect(page).not_to have_content expired_poll.name
+    end
+
+    scenario "Do not display polls from other booths" do
+      poll1 = create(:poll, :current)
+      poll2 = create(:poll, :current)
+
+      booth1 = create(:poll_booth)
+      booth2 = create(:poll_booth)
+
+      booth_assignment1 = create(:poll_booth_assignment, poll: poll1, booth: booth1)
+      booth_assignment2 = create(:poll_booth_assignment, poll: poll2, booth: booth2)
+
+      officer_assignment1 = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment1)
+      officer_assignment2 = create(:poll_officer_assignment, officer: officer, booth_assignment: booth_assignment2)
+
+      set_officing_booth(booth1)
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content "Polls"
+      expect(page).to have_content poll1.name
+      expect(page).not_to have_content poll2.name
+
+      set_officing_booth(booth2)
+      visit new_officing_residence_path
+      officing_verify_residence
+
+      expect(page).to have_content "Polls"
+      expect(page).to have_content poll2.name
+      expect(page).not_to have_content poll1.name
+    end
   end
 
   xscenario "After voting, via nvotes or physical booth", :js do


### PR DESCRIPTION
## Context

Polls that were not votable by a user were not being displayed in the officing interface. Creating a confusing situation for officers.

## Objectives

Polls that are not votable by a user should be displayed and a corresponding message displayed explaining that a poll can only be voted by residents of a certain geozone.

## Visual Changes

![unvotable polls](https://user-images.githubusercontent.com/4169/54279128-8d52c900-4594-11e9-9318-231e5dcff5a2.png)

## Does this PR need a Backport to CONSUL?

Yes, officers should see polls that are not votable by a user in CONSUL too.
