### PR TITLE
Keep images uploaded with CKEditor when deploying

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :pty, true
 set :use_sudo, false
 
 set :linked_files, %w{config/database.yml config/secrets.yml}
-set :linked_dirs, %w{log tmp public/system public/assets}
+set :linked_dirs, %w{log tmp public/system public/assets public/ckeditor_assets}
 
 set :keep_releases, 5
 


### PR DESCRIPTION
## Objectives

Images uploaded with CKEditor go to a folder that was not linked, so every new deploy with capistrano the reference to those images was lost.

By linking the directory the references to the images remain after a new deploy.

## Does this PR need a Backport to CONSUL?

Sure! ☺️ 