### PR TITLE
Add ERB Lint configuration file

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,14 @@
+---
+linters:
+  FinalNewline:
+    enabled: true
+  SpaceAroundErbTag:
+    enabled: true
+  SelfClosingTag:
+    enabled: false
+  Rubocop:
+    enabled: true
+    only:
+      - Layout/EndOfLine
+      - Lint/LiteralAsCondition
+      - Style/PercentLiteralDelimiters

--- a/.hound.yml
+++ b/.hound.yml
@@ -4,3 +4,6 @@ scss:
   config_file: .scss-lint.yml
 coffeescript:
   config_file: .coffeelint.json
+erblint:
+  enabled: true
+  config_file: .erb-lint.yml

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ group :development do
   gem 'capistrano-bundler', '~> 1.2', require: false
   gem 'capistrano-rails', '~> 1.4.0', require: false
   gem 'capistrano3-delayed-job', '~> 1.7.3'
+  gem "erb_lint", require: false
   gem 'mdl', '~> 0.5.0', require: false
   gem 'rubocop', '~> 0.54.0', require: false
   gem 'rubocop-rspec', '~> 1.26.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,14 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     bcrypt (3.1.11)
+    better_html (1.0.13)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     browser (2.5.3)
     builder (3.2.3)
     bullet (5.7.0)
@@ -150,6 +158,13 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.6)
+    erb_lint (0.0.28)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.51)
+      smart_properties
     errbase (0.0.3)
     erubi (1.7.1)
     erubis (2.7.0)
@@ -191,6 +206,7 @@ GEM
       builder (>= 2.1.2)
     hashie (3.5.7)
     highline (2.0.0)
+    html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpi (2.4.4)
       rack
@@ -431,6 +447,7 @@ GEM
     simplecov-html (0.10.2)
     sitemap_generator (6.0.1)
       builder (~> 3.0)
+    smart_properties (1.13.1)
     social-share-button (1.1.0)
       coffee-rails
     socksify (1.7.1)
@@ -524,6 +541,7 @@ DEPENDENCIES
   devise-async (~> 0.10.2)
   devise_security_extension (~> 0.10.0)
   email_spec (~> 2.1.0)
+  erb_lint
   factory_bot_rails (~> 4.8.2)
   faker (~> 1.8.7)
   foundation-rails (~> 6.4.3.0)
@@ -583,4 +601,4 @@ DEPENDENCIES
   whenever (~> 0.10.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.1


### PR DESCRIPTION
## Objectives

Automatically detect syntax not following our code conventions in ERB files.

## Does this PR need a Backport to CONSUL?

Yes.

## Notes

The rubocop linter cannot use the `rubocop_config` option because it's not compatible with Ruby 2.3. So we're setting the rubocop rules manually.
