### PR TITLE
Enable rubocop rules in config and seed files

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -7,9 +7,8 @@ AllCops:
     - '**/Rakefile'
     - '**/config.ru'
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
+    - "db/migrate/**/*"
+    - "db/schema.rb"
   TargetRubyVersion: 2.3
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.


### PR DESCRIPTION
## Objectives

Follow Ruby code conventions in all files having ruby code.

## Does this PR need a Backport to CONSUL?

Yes.

## Notes

We were unintentionally ignoring them while trying to ignore just the schema file, migration files, and initializers generated with `rails generate`