### PR TITLE
Show only existing stats

### DIFF
--- a/app/controllers/budgets/stats_controller.rb
+++ b/app/controllers/budgets/stats_controller.rb
@@ -6,15 +6,11 @@ module Budgets
 
     def show
       authorize! :read_stats, @budget
-      @stats = load_stats
+      @stats = Budget::Stats.new(@budget)
       @headings = @budget.headings.sort_by_name
     end
 
     private
-
-      def load_stats
-        Budget::Stats.new(@budget).generate
-      end
 
       def load_budget
         @budget = Budget.find_by_slug_or_id! params[:budget_id]

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -31,7 +31,7 @@ class PollsController < ApplicationController
   end
 
   def stats
-    @stats = Poll::Stats.new(@poll).generate
+    @stats = Poll::Stats.new(@poll)
   end
 
   def results

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -18,7 +18,7 @@ class Budget::Stats
   end
 
   def total_participants_support_phase
-    voters.uniq.count
+    voters.count
   end
 
   def total_participants_vote_phase
@@ -71,11 +71,11 @@ class Budget::Stats
     end
 
     def voters
-      supports(budget).pluck(:voter_id)
+      supports(budget).distinct.pluck(:voter_id)
     end
 
     def balloters
-      budget.ballots.where("ballot_lines_count > ?", 0).pluck(:user_id).compact
+      budget.ballots.where("ballot_lines_count > ?", 0).distinct.pluck(:user_id).compact
     end
 
     def poll_ballot_voters
@@ -84,21 +84,23 @@ class Budget::Stats
 
     def balloters_by_heading(heading_id)
       stats_cache("balloters_by_heading_#{heading_id}") do
-        budget.ballots.joins(:lines).where(budget_ballot_lines: {heading_id: heading_id}).pluck(:user_id)
+        budget.ballots.joins(:lines)
+                      .where(budget_ballot_lines: { heading_id: heading_id} )
+                      .distinct.pluck(:user_id)
       end
     end
 
     def voters_by_heading(heading)
       stats_cache("voters_by_heading_#{heading.id}") do
-        supports(heading).pluck(:voter_id)
+        supports(heading).distinct.pluck(:voter_id)
       end
     end
 
     def calculate_heading_totals(heading)
       {
         total_investments_count: heading.investments.count,
-        total_participants_support_phase: voters_by_heading(heading).uniq.count,
-        total_participants_vote_phase: balloters_by_heading(heading.id).uniq.count,
+        total_participants_support_phase: voters_by_heading(heading).count,
+        total_participants_vote_phase: balloters_by_heading(heading.id).count,
         total_participants_all_phase: voters_and_balloters_by_heading(heading)
       }
     end

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -13,35 +13,58 @@ class Budget::Stats
     User.where(id: (authors + voters + balloters + poll_ballot_voters).uniq.compact)
   end
 
+  def total_participants
+    participants.distinct.count
+  end
+
+  def total_participants_support_phase
+    voters.uniq.count
+  end
+
+  def total_participants_vote_phase
+    (balloters + poll_ballot_voters).uniq.count
+  end
+
+  def total_budget_investments
+    budget.investments.count
+  end
+
+  def total_votes
+    budget.ballots.pluck(:ballot_lines_count).inject(0) { |sum, x| sum + x }
+  end
+
+  def total_selected_investments
+    budget.investments.selected.count
+  end
+
+  def total_unfeasible_investments
+    budget.investments.unfeasible.count
+  end
+
+  def headings
+    groups = Hash.new(0)
+    budget.headings.order("id ASC").each do |heading|
+      groups[heading.id] = Hash.new(0).merge(calculate_heading_totals(heading))
+    end
+
+    groups[:total] = Hash.new(0)
+    groups[:total][:total_investments_count] = groups.collect {|_k, v| v[:total_investments_count]}.sum
+    groups[:total][:total_participants_support_phase] = groups.collect {|_k, v| v[:total_participants_support_phase]}.sum
+    groups[:total][:total_participants_vote_phase] = groups.collect {|_k, v| v[:total_participants_vote_phase]}.sum
+    groups[:total][:total_participants_all_phase] = groups.collect {|_k, v| v[:total_participants_all_phase]}.sum
+
+    budget.headings.each do |heading|
+      groups[heading.id].merge!(calculate_heading_stats_with_totals(groups[heading.id], groups[:total], heading.population))
+    end
+
+    groups[:total][:percentage_participants_support_phase] = groups.collect {|_k, v| v[:percentage_participants_support_phase]}.sum
+    groups[:total][:percentage_participants_vote_phase] = groups.collect {|_k, v| v[:percentage_participants_vote_phase]}.sum
+    groups[:total][:percentage_participants_all_phase] = groups.collect {|_k, v| v[:percentage_participants_all_phase]}.sum
+
+    groups
+  end
+
   private
-
-    def total_participants
-      participants.distinct.count
-    end
-
-    def total_participants_support_phase
-      voters.uniq.count
-    end
-
-    def total_participants_vote_phase
-      (balloters + poll_ballot_voters).uniq.count
-    end
-
-    def total_budget_investments
-      budget.investments.count
-    end
-
-    def total_votes
-      budget.ballots.pluck(:ballot_lines_count).inject(0) { |sum, x| sum + x }
-    end
-
-    def total_selected_investments
-      budget.investments.selected.count
-    end
-
-    def total_unfeasible_investments
-      budget.investments.unfeasible.count
-    end
 
     def authors
       budget.investments.pluck(:author_id)
@@ -69,29 +92,6 @@ class Budget::Stats
       stats_cache("voters_by_heading_#{heading.id}") do
         supports(heading).pluck(:voter_id)
       end
-    end
-
-    def headings
-      groups = Hash.new(0)
-      budget.headings.order('id ASC').each do |heading|
-        groups[heading.id] = Hash.new(0).merge(calculate_heading_totals(heading))
-      end
-
-      groups[:total] = Hash.new(0)
-      groups[:total][:total_investments_count] = groups.collect {|_k, v| v[:total_investments_count]}.sum
-      groups[:total][:total_participants_support_phase] = groups.collect {|_k, v| v[:total_participants_support_phase]}.sum
-      groups[:total][:total_participants_vote_phase] = groups.collect {|_k, v| v[:total_participants_vote_phase]}.sum
-      groups[:total][:total_participants_all_phase] = groups.collect {|_k, v| v[:total_participants_all_phase]}.sum
-
-      budget.headings.each do |heading|
-        groups[heading.id].merge!(calculate_heading_stats_with_totals(groups[heading.id], groups[:total], heading.population))
-      end
-
-      groups[:total][:percentage_participants_support_phase] = groups.collect {|_k, v| v[:percentage_participants_support_phase]}.sum
-      groups[:total][:percentage_participants_vote_phase] = groups.collect {|_k, v| v[:percentage_participants_vote_phase]}.sum
-      groups[:total][:percentage_participants_all_phase] = groups.collect {|_k, v| v[:percentage_participants_all_phase]}.sum
-
-      groups
     end
 
     def calculate_heading_totals(heading)

--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -130,7 +130,7 @@ class Budget::Stats
     end
 
     def supports(supportable)
-      ActsAsVotable::Vote.where(votable_type: 'Budget::Investment', votable_id: supportable.investments.pluck(:id))
+      Vote.where(votable: supportable.investments)
     end
 
     stats_cache(*stats_methods)

--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -9,7 +9,7 @@ module Statisticable
     end
 
     def generate
-      self.class.stats_methods.map { |stat_name| [stat_name, send(stat_name)] }.to_h
+      self.class.stats_methods.each { |stat_name| send(stat_name) }
     end
 
     def total_male_participants

--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -2,19 +2,19 @@ class Poll::Stats
   include Statisticable
   alias_method :poll, :resource
 
-  CHANNELS = %i[web booth mail]
+  CHANNELS = Poll::Voter::VALID_ORIGINS
 
   def self.stats_methods
     super +
       %i[total_valid_votes total_white_votes total_null_votes
          total_participants_web total_web_valid total_web_white total_web_null
          total_participants_booth total_booth_valid total_booth_white total_booth_null
-         total_participants_mail total_mail_valid total_mail_white total_mail_null
+         total_participants_letter total_letter_valid total_letter_white total_letter_null
          total_participants_web_percentage total_participants_booth_percentage
-         total_participants_mail_percentage
-         valid_percentage_web valid_percentage_booth valid_percentage_mail total_valid_percentage
-         white_percentage_web white_percentage_booth white_percentage_mail total_white_percentage
-         null_percentage_web null_percentage_booth null_percentage_mail total_null_percentage]
+         total_participants_letter_percentage
+         valid_percentage_web valid_percentage_booth valid_percentage_letter total_valid_percentage
+         white_percentage_web white_percentage_booth white_percentage_letter total_white_percentage
+         null_percentage_web null_percentage_booth null_percentage_letter total_null_percentage]
   end
 
   def total_participants
@@ -69,15 +69,15 @@ class Poll::Stats
     recounts.sum(:null_amount)
   end
 
-  def total_mail_valid
+  def total_letter_valid
     0 # TODO
   end
 
-  def total_mail_white
+  def total_letter_white
     0 # TODO
   end
 
-  def total_mail_null
+  def total_letter_null
     0 # TODO
   end
 

--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -116,7 +116,7 @@ class Poll::Stats
     end
 
     stats_cache(*stats_methods)
-    stats_cache :voters, :recounts
+    stats_cache :participants, :voters, :recounts
 
     def stats_cache(key, &block)
       Rails.cache.fetch("polls_stats/#{poll.id}/#{key}/v12", &block)

--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -21,6 +21,10 @@ class Poll::Stats
     total_participants_web + total_participants_booth
   end
 
+  def channels
+    CHANNELS.select { |channel| send(:"total_participants_#{channel}") > 0 }
+  end
+
   CHANNELS.each do |channel|
     define_method :"total_participants_#{channel}" do
       send(:"total_#{channel}_valid") +
@@ -70,7 +74,7 @@ class Poll::Stats
   end
 
   def total_letter_valid
-    0 # TODO
+    voters.where(origin: "letter").count # TODO: count only valid votes
   end
 
   def total_letter_white

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -42,7 +42,7 @@
 
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">
-      <%= render "shared/stats/links" %>
+      <%= render "shared/stats/links", stats: @stats %>
 
       <p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
       <ul class="menu vertical">

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -10,183 +10,181 @@
             og_image_url: 'social_budget_2018_stats.png' %>
 <% end %>
 
-<% cache [@stats] do %>
-  <div class="participation-stats budgets-stats">
-    <div class="expanded no-margin-top padding header">
-      <div class="row">
-        <div class="small-12 column">
-          <%= back_link_to budgets_path %>
-          <h2 class="margin-top">
-            <%= t("stats.title") %><br>
-            <span><%= @budget.name %></span>
-          </h2>
-        </div>
-      </div>
-    </div>
-
-    <div class="row margin-top">
+<div class="participation-stats budgets-stats">
+  <div class="expanded no-margin-top padding header">
+    <div class="row">
       <div class="small-12 column">
-        <ul class="tabs">
-          <li class="tabs-title">
-            <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-            <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget) %>
-          </li>
-          <li class="tabs-title is-active">
-            <%= link_to t("stats.budgets.link"), custom_budget_stats_path(@budget), class: "is-active" %>
-          </li>
-          <li class="tabs-title">
-            <%= link_to t("budgets.executions.link"), custom_budget_executions_path(@budget) %>
-          </li>
-        </ul>
+        <%= back_link_to budgets_path %>
+        <h2 class="margin-top">
+          <%= t("stats.title") %><br>
+          <span><%= @budget.name %></span>
+        </h2>
       </div>
     </div>
+  </div>
 
-    <div class="row margin">
-      <div class="small-12 medium-3 column sidebar">
-        <%= render "shared/stats/links" %>
+  <div class="row margin-top">
+    <div class="small-12 column">
+      <ul class="tabs">
+        <li class="tabs-title">
+          <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
+          <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget) %>
+        </li>
+        <li class="tabs-title is-active">
+          <%= link_to t("stats.budgets.link"), custom_budget_stats_path(@budget), class: "is-active" %>
+        </li>
+        <li class="tabs-title">
+          <%= link_to t("budgets.executions.link"), custom_budget_executions_path(@budget) %>
+        </li>
+      </ul>
+    </div>
+  </div>
 
-        <p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
-        <ul class="menu vertical">
-          <li>
-            <%= link_to t("stats.budgets.total_investments"), "#total_investments"%>
-          </li>
-          <li>
-            <%= link_to t("stats.budgets.by_phase"), "#stats_by_phase"%>
-          </li>
-          <li>
-            <%= link_to t("stats.budgets.by_heading"), "#stats_by_heading"%>
-          </li>
-        </ul>
-      </div>
+  <div class="row margin">
+    <div class="small-12 medium-3 column sidebar">
+      <%= render "shared/stats/links" %>
 
-      <div class="small-12 medium-9 column stats-content">
-        <%= render "shared/stats/participation", stats: @stats %>
+      <p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
+      <ul class="menu vertical">
+        <li>
+          <%= link_to t("stats.budgets.total_investments"), "#total_investments" %>
+        </li>
+        <li>
+          <%= link_to t("stats.budgets.by_phase"), "#stats_by_phase" %>
+        </li>
+        <li>
+          <%= link_to t("stats.budgets.by_heading"), "#stats_by_heading" %>
+        </li>
+      </ul>
+    </div>
 
-        <div id="advanced_statistics">
-          <h3 class="section-title"><%= t("stats.advanced") %></h3>
+    <div class="small-12 medium-9 column stats-content">
+      <%= render "shared/stats/participation", stats: @stats %>
 
-          <div id="total_investments" class="stats-group">
-            <h4><%= t("stats.budgets.total_investments") %></h4>
+      <div id="advanced_statistics">
+        <h3 class="section-title"><%= t("stats.advanced") %></h3>
 
-            <%= number_with_info_tags(
-              @stats[:total_budget_investments],
-              t("stats.budgets.total_investments"),
-              html_class: "total-investments"
-            ) %>
+        <div id="total_investments" class="stats-group">
+          <h4><%= t("stats.budgets.total_investments") %></h4>
 
-            <%= number_with_info_tags(@stats[:total_unfeasible_investments],
-                                      t("stats.budgets.total_unfeasible_investments")) %>
-            <%= number_with_info_tags(@stats[:total_selected_investments],
-                                      t("stats.budgets.total_selected_investments")) %>
-          </div>
+          <%= number_with_info_tags(
+            @stats.total_budget_investments,
+            t("stats.budgets.total_investments"),
+            html_class: "total-investments"
+          ) %>
 
-          <div id="stats_by_phase" class="stats-group">
-            <h4><%= t("stats.budgets.by_phase") %></h4>
-
-            <%= number_with_info_tags(@stats[:total_participants_support_phase],
-                                      t("stats.budgets.participants_support_phase")) %>
-            <%= number_with_info_tags(@stats[:total_participants_vote_phase],
-                                     t("stats.budgets.participants_voting_phase")) %>
-
-          </div>
-
-          <div id="stats_by_heading" class="stats-group">
-            <h4 class="margin-bottom"><%= t("stats.budgets.by_heading") %></h4>
-
-            <table class="stats-districts survey-districts">
-              <thead>
-                <tr>
-                  <th scope="col" rowspan="2"><%= t("stats.budgets.heading") %></th>
-                  <th scope="col" rowspan="2"><%= t("stats.budgets.investments_sent_html") %></th>
-                  <th scope="col" colspan="3"><%= t("stats.budgets.participants_support_phase") %></th>
-                  <th scope="col" colspan="3"><%= t("stats.budgets.participants_voting_phase") %></th>
-                  <th scope="col" colspan="3"><%= t("stats.budgets.participants_total") %></th>
-                </tr>
-                <tr>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.total") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.percent_total_participants_html") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.percent_heading_census_html") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.total") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.percent_total_participants_html") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.percent_heading_census_html") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.total") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.percent_total_participants_html") %></th>
-                  <th scope="col" class="tiny"><%= t("stats.budgets.percent_heading_census_html") %></th>
-                </tr>
-              </thead>
-              <tbody id="headings">
-                <% @headings.each do |heading| %>
-                  <tr id="<%= heading.name.parameterize %>">
-                    <td class="border-left">
-                      <strong><%= heading.name %></strong>
-                    </td>
-                    <td id="total_spending_proposals_heading_<%= heading.id %>"
-                        class="text-center border-left border-right">
-                      <%= @stats[:headings][heading.id][:total_investments_count] %>
-                    </td>
-
-                    <% ["support", "vote", "all"].each do |phase| %>
-                      <td id="total_participants_<%= phase %>_phase_heading_<%= heading.id %>"
-                          class="border-left text-center">
-                        <%= @stats[:headings][heading.id]["total_participants_#{phase}_phase".to_sym] %>
-                      </td>
-                      <td id="percentage_participants_<%= phase %>_phase_heading_<%= heading.id %>"
-                          class="border-left border-right text-center">
-                        <%= number_to_stats_percentage(@stats[:headings][heading.id]["percentage_participants_#{phase}_phase".to_sym]) %>
-                      </td>
-                      <td id="percentage_district_population_<%= phase %>_phase_heading_<%= heading.id %>"
-                          class="text-center border-right">
-                        <%= number_to_stats_percentage(@stats[:headings][heading.id]["percentage_district_population_#{phase}_phase".to_sym]) %>
-                      </td>
-                    <% end %>
-                  </tr>
-                <% end %>
-
-                <%# THIS TOTALS ROW IS JUST FOR INTERNAL DEBUGGING %>
-                <% if false %>
-                  <tr id="headings_totals">
-                    <td class="border-left-success success">
-                      <strong><%= t("stats.budgets.total").upcase %></strong>
-                    </td>
-                    <td id="total_spending_proposals_heading_total"
-                        class="text-center success">
-                      <strong><%= @stats[:headings][:total][:total_investments_count] %></strong>
-                    </td>
-
-                    <% ["support", "vote", "all"].each do |phase| %>
-                      <td id="total_participants_<%= phase %>_phase_heading_total"
-                          class="text-center success">
-                        <strong><%= @stats[:headings][:total]["total_participants_#{phase}_phase".to_sym] %></strong>
-                      </td>
-                      <td id="percentage_participants_<%= phase %>_phase_heading_total"
-                          class="text-center success">
-                        <strong><%= number_to_stats_percentage(@stats[:headings][:total]["percentage_participants_#{phase}_phase".to_sym]) %></strong>
-                      </td>
-                      <td class="text-center success <%= phase == 'all' ? 'border-right-success ' : '' %>"></td>
-                    <% end %>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+          <%= number_with_info_tags(@stats.total_unfeasible_investments,
+                                    t("stats.budgets.total_unfeasible_investments")) %>
+          <%= number_with_info_tags(@stats.total_selected_investments,
+                                    t("stats.budgets.total_selected_investments")) %>
         </div>
 
-        <div class="row margin">
-          <div class="small-12 column">
-            <div id="total_unknown_gender_or_age">
-              <p class="help-text">
-                <%= t("stats.budgets.no_demographic_data", total: @stats[:total_unknown_gender_or_age]) %>
-              </p>
-              <p class="help-text">
-                  <%= t("stats.budgets.participatory_disclaimer") %>
-              </p>
-              <p class="help-text">
-                  <%= t("stats.budgets.heading_disclaimer") %>
-              </p>
-            </div>
+        <div id="stats_by_phase" class="stats-group">
+          <h4><%= t("stats.budgets.by_phase") %></h4>
+
+          <%= number_with_info_tags(@stats.total_participants_support_phase,
+                                    t("stats.budgets.participants_support_phase")) %>
+          <%= number_with_info_tags(@stats.total_participants_vote_phase,
+                                   t("stats.budgets.participants_voting_phase")) %>
+
+        </div>
+
+        <div id="stats_by_heading" class="stats-group">
+          <h4 class="margin-bottom"><%= t("stats.budgets.by_heading") %></h4>
+
+          <table class="stats-districts survey-districts">
+            <thead>
+              <tr>
+                <th scope="col" rowspan="2"><%= t("stats.budgets.heading") %></th>
+                <th scope="col" rowspan="2"><%= t("stats.budgets.investments_sent_html") %></th>
+                <th scope="col" colspan="3"><%= t("stats.budgets.participants_support_phase") %></th>
+                <th scope="col" colspan="3"><%= t("stats.budgets.participants_voting_phase") %></th>
+                <th scope="col" colspan="3"><%= t("stats.budgets.participants_total") %></th>
+              </tr>
+              <tr>
+                <th scope="col" class="tiny"><%= t("stats.budgets.total") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.percent_total_participants_html") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.percent_heading_census_html") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.total") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.percent_total_participants_html") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.percent_heading_census_html") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.total") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.percent_total_participants_html") %></th>
+                <th scope="col" class="tiny"><%= t("stats.budgets.percent_heading_census_html") %></th>
+              </tr>
+            </thead>
+            <tbody id="headings">
+              <% @headings.each do |heading| %>
+                <tr id="<%= heading.name.parameterize %>">
+                  <td class="border-left">
+                    <strong><%= heading.name %></strong>
+                  </td>
+                  <td id="total_spending_proposals_heading_<%= heading.id %>"
+                      class="text-center border-left border-right">
+                    <%= @stats.headings[heading.id][:total_investments_count] %>
+                  </td>
+
+                  <% ["support", "vote", "all"].each do |phase| %>
+                    <td id="total_participants_<%= phase %>_phase_heading_<%= heading.id %>"
+                        class="border-left text-center">
+                      <%= @stats.headings[heading.id]["total_participants_#{phase}_phase".to_sym] %>
+                    </td>
+                    <td id="percentage_participants_<%= phase %>_phase_heading_<%= heading.id %>"
+                        class="border-left border-right text-center">
+                      <%= number_to_stats_percentage(@stats.headings[heading.id]["percentage_participants_#{phase}_phase".to_sym]) %>
+                    </td>
+                    <td id="percentage_district_population_<%= phase %>_phase_heading_<%= heading.id %>"
+                        class="text-center border-right">
+                      <%= number_to_stats_percentage(@stats.headings[heading.id]["percentage_district_population_#{phase}_phase".to_sym]) %>
+                    </td>
+                  <% end %>
+                </tr>
+              <% end %>
+
+              <%# THIS TOTALS ROW IS JUST FOR INTERNAL DEBUGGING %>
+              <% if false %>
+                <tr id="headings_totals">
+                  <td class="border-left-success success">
+                    <strong><%= t("stats.budgets.total").upcase %></strong>
+                  </td>
+                  <td id="total_spending_proposals_heading_total"
+                      class="text-center success">
+                    <strong><%= @stats.headings[:total][:total_investments_count] %></strong>
+                  </td>
+
+                  <% ["support", "vote", "all"].each do |phase| %>
+                    <td id="total_participants_<%= phase %>_phase_heading_total"
+                        class="text-center success">
+                      <strong><%= @stats.headings[:total]["total_participants_#{phase}_phase".to_sym] %></strong>
+                    </td>
+                    <td id="percentage_participants_<%= phase %>_phase_heading_total"
+                        class="text-center success">
+                      <strong><%= number_to_stats_percentage(@stats.headings[:total]["percentage_participants_#{phase}_phase".to_sym]) %></strong>
+                    </td>
+                    <td class="text-center success <%= phase == 'all' ? 'border-right-success ' : '' %>"></td>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="row margin">
+        <div class="small-12 column">
+          <div id="total_unknown_gender_or_age">
+            <p class="help-text">
+              <%= t("stats.budgets.no_demographic_data", total: @stats.total_unknown_gender_or_age) %>
+            </p>
+            <p class="help-text">
+                <%= t("stats.budgets.participatory_disclaimer") %>
+            </p>
+            <p class="help-text">
+                <%= t("stats.budgets.heading_disclaimer") %>
+            </p>
           </div>
         </div>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -29,7 +29,7 @@
         <div id="stats_by_channel" class="stats-group">
           <h4><%= t("stats.polls.by_channel") %></h4>
 
-          <% Poll::Stats::CHANNELS.each do |channel| %>
+          <% @stats.channels.each do |channel| %>
             <%= number_with_info_tags(
               @stats.send("total_participants_#{channel}"),
               t("stats.polls.#{channel}_percentage",
@@ -47,7 +47,7 @@
             <thead>
               <tr>
                 <th scope="col"><%= t("polls.show.stats.votes") %></th>
-                <% Poll::Stats::CHANNELS.each do |channel| %>
+                <% @stats.channels.each do |channel| %>
                   <th scope="col"><%= t("polls.show.stats.#{channel}") %></th>
                 <% end %>
                 <th scope="col"><%= t("polls.show.stats.total") %></th>
@@ -57,7 +57,7 @@
               <tr>
                 <th scope="row"><%= t("polls.show.stats.valid") %></th>
 
-                <% Poll::Stats::CHANNELS.each do |channel| %>
+                <% @stats.channels.each do |channel| %>
                   <td>
                     <%= @stats.send(:"total_#{channel}_valid") %>
                     <small><em>(<%= @stats.send(:"valid_percentage_#{channel}").round(2) %>%)</em></small>
@@ -73,7 +73,7 @@
               <tr>
                 <th scope="row"><%= t("polls.show.stats.white") %></th>
 
-                <% Poll::Stats::CHANNELS.each do |channel| %>
+                <% @stats.channels.each do |channel| %>
                   <td>
                     <%= @stats.send(:"total_#{channel}_white") %>
                     <small><em>(<%= @stats.send(:"white_percentage_#{channel}").round(2) %>%)</em></small>
@@ -87,7 +87,7 @@
               <tr>
                 <th scope="row"><%= t("polls.show.stats.null_votes") %></th>
 
-                <% Poll::Stats::CHANNELS.each do |channel| %>
+                <% @stats.channels.each do |channel| %>
                   <td>
                     <%= @stats.send(:"total_#{channel}_null") %>
                     <small><em>(<%= @stats.send(:"null_percentage_#{channel}").round(2) %>%)</em></small>
@@ -102,7 +102,7 @@
               <tr>
                 <th scope="row"><%= t("polls.show.stats.total") %></th>
 
-                <% Poll::Stats::CHANNELS.each do |channel| %>
+                <% @stats.channels.each do |channel| %>
                   <td>
                     <%= @stats.send(:"total_participants_#{channel}") %>
                     <small><em>(<%= @stats.send(:"total_participants_#{channel}_percentage").round(2) %>%)</em></small>

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -7,7 +7,7 @@
 
   <div class="row margin">
     <div class="small-12 medium-3 column sidebar">
-      <%= render "shared/stats/links" %>
+      <%= render "shared/stats/links", stats: @stats %>
 
       <p><strong><%= link_to t("stats.advanced"), "#advanced_statistics" %></strong></p>
       <ul class="menu vertical">

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -31,9 +31,9 @@
 
           <% Poll::Stats::CHANNELS.each do |channel| %>
             <%= number_with_info_tags(
-              @stats[:"total_participants_#{channel}"],
+              @stats.send("total_participants_#{channel}"),
               t("stats.polls.#{channel}_percentage",
-                percentage: number_to_stats_percentage(@stats[:"total_participants_#{channel}_percentage"])
+                percentage: number_to_stats_percentage(@stats.send(:"total_participants_#{channel}_percentage"))
               ),
               html_class: channel
             ) %>
@@ -59,14 +59,14 @@
 
                 <% Poll::Stats::CHANNELS.each do |channel| %>
                   <td>
-                    <%= @stats[:"total_#{channel}_valid"] %>
-                    <small><em>(<%= @stats[:"valid_percentage_#{channel}"].round(2) %>%)</em></small>
+                    <%= @stats.send(:"total_#{channel}_valid") %>
+                    <small><em>(<%= @stats.send(:"valid_percentage_#{channel}").round(2) %>%)</em></small>
                   </td>
                 <% end %>
 
                 <td>
-                  <%= @stats[:total_valid_votes] %>
-                  <small><em>(<%= @stats[:total_valid_percentage].round(2) %>%)</em></small>
+                  <%= @stats.total_valid_votes %>
+                  <small><em>(<%= @stats.total_valid_percentage.round(2) %>%)</em></small>
                 </td>
 
               </tr>
@@ -75,13 +75,13 @@
 
                 <% Poll::Stats::CHANNELS.each do |channel| %>
                   <td>
-                    <%= @stats[:"total_#{channel}_white"] %>
-                    <small><em>(<%= @stats[:"white_percentage_#{channel}"].round(2) %>%)</em></small>
+                    <%= @stats.send(:"total_#{channel}_white") %>
+                    <small><em>(<%= @stats.send(:"white_percentage_#{channel}").round(2) %>%)</em></small>
                   </td>
                 <% end %>
 
-                <td><%= @stats[:total_white_votes] %>
-                  <small><em>(<%= @stats[:total_white_percentage].round(2) %>%)</em></small>
+                <td><%= @stats.total_white_votes %>
+                  <small><em>(<%= @stats.total_white_percentage.round(2) %>%)</em></small>
                 </td>
               </tr>
               <tr>
@@ -89,14 +89,14 @@
 
                 <% Poll::Stats::CHANNELS.each do |channel| %>
                   <td>
-                    <%= @stats[:"total_#{channel}_null"] %>
-                    <small><em>(<%= @stats[:"null_percentage_#{channel}"].round(2) %>%)</em></small>
+                    <%= @stats.send(:"total_#{channel}_null") %>
+                    <small><em>(<%= @stats.send(:"null_percentage_#{channel}").round(2) %>%)</em></small>
                   </td>
                 <% end %>
 
                 <td>
-                  <%= @stats[:total_null_votes] %>
-                  <small><em>(<%= @stats[:total_null_percentage].round(2) %>%)</em></small>
+                  <%= @stats.total_null_votes %>
+                  <small><em>(<%= @stats.total_null_percentage.round(2) %>%)</em></small>
                 </td>
               </tr>
               <tr>
@@ -104,12 +104,12 @@
 
                 <% Poll::Stats::CHANNELS.each do |channel| %>
                   <td>
-                    <%= @stats[:"total_participants_#{channel}"] %>
-                    <small><em>(<%= @stats[:"total_participants_#{channel}_percentage"].round(2) %>%)</em></small>
+                    <%= @stats.send(:"total_participants_#{channel}") %>
+                    <small><em>(<%= @stats.send(:"total_participants_#{channel}_percentage").round(2) %>%)</em></small>
                   </td>
                 <% end %>
 
-                <td><%= @stats[:total_participants] %></td>
+                <td><%= @stats.total_participants %></td>
               </tr>
             </tbody>
           </table>

--- a/app/views/shared/stats/_age.html.erb
+++ b/app/views/shared/stats/_age.html.erb
@@ -1,0 +1,28 @@
+<div id="participants_by_age" class="stats-group">
+  <h4><%= t("stats.by_age") %></h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th class="small-4"><%= t("stats.age") %></th>
+        <th><%= t("stats.total") %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% stats.participants_by_age.values.each do |group| %>
+        <tr>
+          <td><%= group[:range] %></td>
+          <td>
+            <strong>
+              <%= "#{group[:count]} (#{number_to_stats_percentage(group[:percentage])})" %>
+            </strong>
+            <div class="progress" tabindex="0">
+              <span class="progress-meter" style="width: <%= group[:percentage] %>%"></span>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/shared/stats/_gender.html.erb
+++ b/app/views/shared/stats/_gender.html.erb
@@ -1,0 +1,15 @@
+<div id="participants_by_gender" class="stats-group">
+  <h4><%= t("stats.by_gender") %></h4>
+
+  <%= number_with_info_tags(
+    stats.total_male_participants,
+    t("stats.men_percentage", percentage: number_to_stats_percentage(stats.male_percentage)),
+    html_class: "participants male"
+  ) %>
+
+  <%= number_with_info_tags(
+    stats.total_female_participants,
+    t("stats.women_percentage", percentage: number_to_stats_percentage(stats.female_percentage)),
+    html_class: "participants female"
+  ) %>
+</div>

--- a/app/views/shared/stats/_geozone.html.erb
+++ b/app/views/shared/stats/_geozone.html.erb
@@ -1,0 +1,23 @@
+<div id="participants_by_geozone" class="stats-group">
+  <h4><%= t("stats.by_geozone") %></h4>
+
+  <table>
+    <thead>
+      <tr>
+        <th><%= t("stats.geozone") %></th>
+        <th><%= t("stats.total") %></th>
+        <th><%= t("stats.geozone_participation") %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% stats.participants_by_geozone.each do |geozone, participants| %>
+        <tr>
+          <td><%= geozone %></td>
+          <td><%= "#{participants[:total][:count]} (#{number_to_stats_percentage(participants[:total][:percentage])})" %></td>
+          <td><%= number_to_stats_percentage(participants[:percentage]) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/shared/stats/_links.html.erb
+++ b/app/views/shared/stats/_links.html.erb
@@ -3,13 +3,10 @@
   <li>
     <%= link_to t("stats.total_participants"), "#total_participants" %>
   </li>
-  <li>
-    <%= link_to t("stats.by_gender"), "#participants_by_gender" %>
-  </li>
-  <li>
-    <%= link_to t("stats.by_age"), "#participants_by_age" %>
-  </li>
-  <li>
-    <%= link_to t("stats.by_geozone"), "#participants_by_geozone" %>
-  </li>
+
+  <% stats.participations.each do |stat| %>
+    <li>
+      <%= link_to t("stats.by_#{stat}"), "#participants_by_#{stat}" %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/shared/stats/_participation.html.erb
+++ b/app/views/shared/stats/_participation.html.erb
@@ -11,73 +11,7 @@
     ) %>
   </div>
 
-  <div id="participants_by_gender" class="stats-group">
-    <h4><%= t("stats.by_gender") %></h4>
-
-    <%= number_with_info_tags(
-      stats.total_male_participants,
-      t("stats.men_percentage", percentage: number_to_stats_percentage(stats.male_percentage)),
-      html_class: "participants male"
-    ) %>
-
-    <%= number_with_info_tags(
-      stats.total_female_participants,
-      t("stats.women_percentage", percentage: number_to_stats_percentage(stats.female_percentage)),
-      html_class: "participants female"
-    ) %>
-  </div>
-
-  <div id="participants_by_age" class="stats-group">
-    <h4><%= t("stats.by_age") %></h4>
-
-    <table>
-      <thead>
-        <tr>
-          <th class="small-4"><%= t("stats.age") %></th>
-          <th><%= t("stats.total") %></th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% stats.participants_by_age.values.each do |group| %>
-          <tr>
-            <td><%= group[:range] %></td>
-            <td>
-              <strong>
-                <%= "#{group[:count]} (#{number_to_stats_percentage(group[:percentage])})" %>
-              </strong>
-              <div class="progress" tabindex="0">
-                <span class="progress-meter" style="width: <%= group[:percentage] %>%">
-                </span>
-              </div>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-
-  <div id="participants_by_geozone" class="stats-group">
-    <h4><%= t("stats.by_geozone") %></h4>
-
-    <table>
-      <thead>
-        <tr>
-          <th><%= t("stats.geozone") %></th>
-          <th><%= t("stats.total") %></th>
-          <th><%= t("stats.geozone_participation") %></th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% stats.participants_by_geozone.each do |geozone, participants| %>
-          <tr>
-            <td><%= geozone %></td>
-            <td><%= "#{participants[:total][:count]} (#{number_to_stats_percentage(participants[:total][:percentage])})" %></td>
-            <td><%= number_to_stats_percentage(participants[:percentage]) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+  <% stats.participations.each do |participation| %>
+    <%= render "shared/stats/#{participation}", stats: stats %>
+  <% end %>
 </div>

--- a/app/views/shared/stats/_participation.html.erb
+++ b/app/views/shared/stats/_participation.html.erb
@@ -5,7 +5,7 @@
     <h4><%= t("stats.total_participants") %></h4>
 
     <%= number_with_info_tags(
-      stats[:total_participants],
+      stats.total_participants,
       "",
       html_class: "participants total-participants"
     ) %>
@@ -15,14 +15,14 @@
     <h4><%= t("stats.by_gender") %></h4>
 
     <%= number_with_info_tags(
-      stats[:total_male_participants],
-      t("stats.men_percentage", percentage: number_to_stats_percentage(stats[:male_percentage])),
+      stats.total_male_participants,
+      t("stats.men_percentage", percentage: number_to_stats_percentage(stats.male_percentage)),
       html_class: "participants male"
     ) %>
 
     <%= number_with_info_tags(
-      stats[:total_female_participants],
-      t("stats.women_percentage", percentage: number_to_stats_percentage(stats[:female_percentage])),
+      stats.total_female_participants,
+      t("stats.women_percentage", percentage: number_to_stats_percentage(stats.female_percentage)),
       html_class: "participants female"
     ) %>
   </div>
@@ -39,7 +39,7 @@
       </thead>
 
       <tbody>
-        <% stats[:participants_by_age].values.each do |group| %>
+        <% stats.participants_by_age.values.each do |group| %>
           <tr>
             <td><%= group[:range] %></td>
             <td>
@@ -70,7 +70,7 @@
       </thead>
 
       <tbody>
-        <% stats[:participants_by_geozone].each do |geozone, participants| %>
+        <% stats.participants_by_geozone.each do |geozone, participants| %>
           <tr>
             <td><%= geozone %></td>
             <td><%= "#{participants[:total][:count]} (#{number_to_stats_percentage(participants[:total][:percentage])})" %></td>

--- a/config/locales/en/stats.yml
+++ b/config/locales/en/stats.yml
@@ -38,4 +38,4 @@ en:
       vote_by_channel: "Vote type by channel"
       web_percentage: "%{percentage} Web"
       booth_percentage: "%{percentage} Booths"
-      mail_percentage: "%{percentage} Mail"
+      letter_percentage: "%{percentage} Mail"

--- a/config/locales/es/stats.yml
+++ b/config/locales/es/stats.yml
@@ -38,4 +38,4 @@ es:
       vote_by_channel: "Votos emitidos por medio"
       web_percentage: "%{percentage} Web"
       booth_percentage: "%{percentage} Urnas"
-      mail_percentage: "%{percentage} Correo"
+      letter_percentage: "%{percentage} Correo"

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -33,7 +33,7 @@ describe Budget::Stats do
       expect(stats.participants).to match_array(
         [author, author_and_voter, voter, voter_and_balloter, balloter, poll_balloter]
       )
-      expect(stats.generate[:total_participants]).to be 6
+      expect(stats.total_participants).to be 6
     end
   end
 
@@ -42,7 +42,7 @@ describe Budget::Stats do
       2.times { create(:vote, votable: investment) }
       create(:budget_ballot_line, investment: investment)
 
-      expect(stats.generate[:total_participants_support_phase]).to be 2
+      expect(stats.total_participants_support_phase).to be 2
     end
 
     it "counts a user who is voter and balloter" do
@@ -50,7 +50,7 @@ describe Budget::Stats do
       create(:vote, votable: investment, voter: voter_and_balloter)
       create(:budget_ballot_line, investment: investment, user: voter_and_balloter)
 
-      expect(stats.generate[:total_participants_support_phase]).to be 1
+      expect(stats.total_participants_support_phase).to be 1
     end
   end
 
@@ -59,7 +59,7 @@ describe Budget::Stats do
       2.times { create(:budget_ballot_line, investment: investment) }
       create(:vote, votable: investment)
 
-      expect(stats.generate[:total_participants_vote_phase]).to be 2
+      expect(stats.total_participants_vote_phase).to be 2
     end
 
     it "counts a user who is voter and balloter" do
@@ -67,14 +67,14 @@ describe Budget::Stats do
       create(:vote, votable: investment, voter: voter_and_balloter)
       create(:budget_ballot_line, investment: investment, user: voter_and_balloter)
 
-      expect(stats.generate[:total_participants_vote_phase]).to be 1
+      expect(stats.total_participants_vote_phase).to be 1
     end
 
     it "includes balloters and poll balloters" do
       create(:budget_ballot_line, investment: investment)
       create(:poll_voter, :from_booth, budget: budget)
 
-      expect(stats.generate[:total_participants_vote_phase]).to be 2
+      expect(stats.total_participants_vote_phase).to be 2
     end
 
     it "counts once a user who is balloter and poll balloter" do
@@ -82,7 +82,7 @@ describe Budget::Stats do
       create(:budget_ballot_line, investment: investment, user: poller_and_balloter)
       create(:poll_voter, :from_booth, user: poller_and_balloter, budget: budget)
 
-      expect(stats.generate[:total_participants_vote_phase]).to be 1
+      expect(stats.total_participants_vote_phase).to be 1
     end
 
     it "doesn't count nil user ids" do
@@ -90,7 +90,7 @@ describe Budget::Stats do
         ballot: create(:budget_ballot, budget: budget, user: nil)
       )
 
-      expect(stats.generate[:total_participants_vote_phase]).to be 0
+      expect(stats.total_participants_vote_phase).to be 0
     end
   end
 
@@ -99,7 +99,7 @@ describe Budget::Stats do
       2.times { create(:budget_investment, budget: budget) }
       create(:budget_investment, budget: create(:budget))
 
-      expect(stats.generate[:total_budget_investments]).to be 2
+      expect(stats.total_budget_investments).to be 2
     end
   end
 
@@ -108,7 +108,7 @@ describe Budget::Stats do
       create(:budget_ballot_line, investment: investment)
       create(:budget_ballot_line, investment: create(:budget_investment, :selected, budget: budget))
 
-      expect(stats.generate[:total_votes]).to be 2
+      expect(stats.total_votes).to be 2
     end
   end
 
@@ -118,7 +118,7 @@ describe Budget::Stats do
       create(:budget_investment, :selected, budget: create(:budget))
       create(:budget_investment, :unfeasible, budget: budget)
 
-      expect(stats.generate[:total_selected_investments]).to be 3
+      expect(stats.total_selected_investments).to be 3
     end
   end
 
@@ -128,7 +128,7 @@ describe Budget::Stats do
       create(:budget_investment, :unfeasible, budget: create(:budget))
       create(:budget_investment, :selected, budget: budget)
 
-      expect(stats.generate[:total_unfeasible_investments]).to be 3
+      expect(stats.total_unfeasible_investments).to be 3
     end
   end
 
@@ -143,31 +143,31 @@ describe Budget::Stats do
 
     describe "#total_male_participants" do
       it "returns the number of total male participants" do
-        expect(stats.generate[:total_male_participants]).to be 3
+        expect(stats.total_male_participants).to be 3
       end
     end
 
     describe "#total_female_participants" do
       it "returns the number of total female participants" do
-        expect(stats.generate[:total_female_participants]).to be 2
+        expect(stats.total_female_participants).to be 2
       end
     end
 
     describe "#total_unknown_gender_or_age" do
       it "returns the number of total unknown participants' gender or age" do
-        expect(stats.generate[:total_unknown_gender_or_age]).to be 1
+        expect(stats.total_unknown_gender_or_age).to be 1
       end
     end
 
     describe "#male_percentage" do
       it "returns the percentage of male participants" do
-        expect(stats.generate[:male_percentage]).to be 60.0
+        expect(stats.male_percentage).to be 60.0
       end
     end
 
     describe "#female_percentage" do
       it "returns the percentage of female participants" do
-        expect(stats.generate[:female_percentage]).to be 40.0
+        expect(stats.female_percentage).to be 40.0
       end
     end
   end
@@ -182,18 +182,18 @@ describe Budget::Stats do
     end
 
     it "returns the age groups hash" do
-      expect(stats.generate[:participants_by_age]["16 - 19"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["20 - 24"][:count]).to be 4
-      expect(stats.generate[:participants_by_age]["25 - 29"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["30 - 34"][:count]).to be 1
-      expect(stats.generate[:participants_by_age]["35 - 39"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["40 - 44"][:count]).to be 3
-      expect(stats.generate[:participants_by_age]["45 - 49"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["50 - 54"][:count]).to be 2
-      expect(stats.generate[:participants_by_age]["55 - 59"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["60 - 64"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["65 - 69"][:count]).to be 0
-      expect(stats.generate[:participants_by_age]["70 - 74"][:count]).to be 0
+      expect(stats.participants_by_age["16 - 19"][:count]).to be 0
+      expect(stats.participants_by_age["20 - 24"][:count]).to be 4
+      expect(stats.participants_by_age["25 - 29"][:count]).to be 0
+      expect(stats.participants_by_age["30 - 34"][:count]).to be 1
+      expect(stats.participants_by_age["35 - 39"][:count]).to be 0
+      expect(stats.participants_by_age["40 - 44"][:count]).to be 3
+      expect(stats.participants_by_age["45 - 49"][:count]).to be 0
+      expect(stats.participants_by_age["50 - 54"][:count]).to be 2
+      expect(stats.participants_by_age["55 - 59"][:count]).to be 0
+      expect(stats.participants_by_age["60 - 64"][:count]).to be 0
+      expect(stats.participants_by_age["65 - 69"][:count]).to be 0
+      expect(stats.participants_by_age["70 - 74"][:count]).to be 0
     end
   end
 
@@ -206,7 +206,7 @@ describe Budget::Stats do
     end
 
     it "returns headings data" do
-      heading_stats = stats.generate[:headings][investment.heading.id]
+      heading_stats = stats.headings[investment.heading.id]
       expect(heading_stats[:total_investments_count]).to be 2
       expect(heading_stats[:total_participants_support_phase]).to be 2
       expect(heading_stats[:total_participants_vote_phase]).to be 1

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -183,4 +183,50 @@ describe Poll::Stats do
       expect(stats.participants_by_geozone["Midgar"][:percentage]).to eq(33.333)
     end
   end
+
+  describe "#channels" do
+    context "no participants" do
+      it "returns no channels" do
+        expect(stats.channels).to eq []
+      end
+    end
+
+    context "only participants from web" do
+      before { create(:poll_voter, :from_web, poll: poll) }
+
+      it "returns the web channel" do
+        expect(stats.channels).to eq ["web"]
+      end
+    end
+
+    context "only participants from booth" do
+      before do
+        create(:poll_recount, :from_booth, poll: poll, total_amount: 1)
+      end
+
+      it "returns the booth channel" do
+        expect(stats.channels).to eq ["booth"]
+      end
+    end
+
+    context "only participants from letter" do
+      before { create(:poll_voter, origin: "letter", poll: poll) }
+
+      it "returns the web channel" do
+        expect(stats.channels).to eq ["letter"]
+      end
+    end
+
+    context "participants from all channels" do
+      before do
+        create(:poll_voter, :from_web, poll: poll)
+        create(:poll_recount, :from_booth, poll: poll, total_amount: 1)
+        create(:poll_voter, origin: "letter", poll: poll)
+      end
+
+      it "returns all channels" do
+        expect(stats.channels).to eq %w[web booth letter]
+      end
+    end
+  end
 end

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -183,43 +183,4 @@ describe Poll::Stats do
       expect(stats.participants_by_geozone["Midgar"][:percentage]).to eq(33.333)
     end
   end
-
-  describe "#generate" do
-    it "generates the correct stats" do
-      poll = create(:poll)
-      2.times { create(:poll_voter, :from_web, poll: poll) }
-      create(:poll_recount, :from_booth, poll: poll,
-             white_amount: 1, null_amount: 0, total_amount: 2)
-
-      stats = Poll::Stats.new(poll).generate
-
-      expect(stats[:total_participants]).to eq(5)
-      expect(stats[:total_participants_web]).to eq(2)
-      expect(stats[:total_participants_booth]).to eq(3)
-      expect(stats[:total_valid_votes]).to eq(4)
-      expect(stats[:total_white_votes]).to eq(1)
-      expect(stats[:total_null_votes]).to eq(0)
-
-      expect(stats[:total_web_valid]).to eq(2)
-      expect(stats[:total_web_white]).to eq(0)
-      expect(stats[:total_web_null]).to eq(0)
-
-      expect(stats[:total_booth_valid]).to eq(2)
-      expect(stats[:total_booth_white]).to eq(1)
-      expect(stats[:total_booth_null]).to eq(0)
-
-      expect(stats[:total_participants_web_percentage]).to eq(40)
-      expect(stats[:total_participants_booth_percentage]).to eq(60)
-      expect(stats[:valid_percentage_web]).to eq(50)
-      expect(stats[:white_percentage_web]).to eq(0)
-      expect(stats[:null_percentage_web]).to eq(0)
-      expect(stats[:valid_percentage_booth]).to eq(50)
-      expect(stats[:white_percentage_booth]).to eq(100)
-      expect(stats[:null_percentage_booth]).to eq(0)
-      expect(stats[:total_valid_percentage]).to eq(80)
-      expect(stats[:total_white_percentage]).to eq(20)
-      expect(stats[:total_null_percentage]).to eq(0)
-    end
-  end
-
 end

--- a/spec/models/statisticable_spec.rb
+++ b/spec/models/statisticable_spec.rb
@@ -1,0 +1,148 @@
+require "rails_helper"
+
+describe Statisticable do
+  class DummyStats
+    include Statisticable
+
+    def participants
+      User.all
+    end
+  end
+
+  let(:stats) { DummyStats.new(nil) }
+
+  describe "#gender?" do
+    context "No participants" do
+      it "is false" do
+        expect(stats.gender?).to be false
+      end
+    end
+
+    context "All participants have no defined gender" do
+      before { create(:user, gender: nil) }
+
+      it "is false" do
+        expect(stats.gender?).to be false
+      end
+    end
+
+    context "There's a male participant" do
+      before { create(:user, gender: "male") }
+
+      it "is true" do
+        expect(stats.gender?).to be true
+      end
+    end
+
+    context "There's a female participant" do
+      before { create(:user, gender: "female") }
+
+      it "is true" do
+        expect(stats.gender?).to be true
+      end
+    end
+  end
+
+  describe "#age?" do
+    context "No participants" do
+      it "is false" do
+        expect(stats.age?).to be false
+      end
+    end
+
+    context "All participants have no defined age" do
+      before { create(:user, date_of_birth: nil) }
+
+      it "is false" do
+        expect(stats.age?).to be false
+      end
+    end
+
+    context "All participants have impossible ages" do
+      before do
+        create(:user, date_of_birth: 3.seconds.ago)
+        create(:user, date_of_birth: 3000.years.ago)
+      end
+
+      it "is false" do
+        expect(stats.age?).to be false
+      end
+    end
+
+    context "There's a participant with a defined age" do
+      before { create(:user, date_of_birth: 30.years.ago) }
+
+      it "is true" do
+        expect(stats.age?).to be true
+      end
+    end
+  end
+
+  describe "#geozone?" do
+    context "No participants" do
+      it "is false" do
+        expect(stats.geozone?).to be false
+      end
+    end
+
+    context "All participants have no defined geozone" do
+      before { create(:user, geozone: nil) }
+
+      it "is false" do
+        expect(stats.geozone?).to be false
+      end
+    end
+
+    context "There's a participant with a defined geozone" do
+      before { create(:user, geozone: create(:geozone)) }
+
+      it "is true" do
+        expect(stats.geozone?).to be true
+      end
+    end
+  end
+
+  describe "#stats_methods" do
+    it "includes total participants" do
+      expect(stats.stats_methods).to include(:total_participants)
+    end
+
+    context "no gender stats" do
+      before { allow(stats).to receive(:gender?).and_return(false) }
+
+      it "doesn't include gender methods" do
+        expect(stats.stats_methods).not_to include(:total_male_participants)
+      end
+    end
+
+    context "no age stats" do
+      before { allow(stats).to receive(:age?).and_return(false) }
+
+      it "doesn't include age methods" do
+        expect(stats.stats_methods).not_to include(:participants_by_age)
+      end
+    end
+
+    context "no geozone stats" do
+      before { allow(stats).to receive(:geozone?).and_return(false) }
+
+      it "doesn't include age methods" do
+        expect(stats.stats_methods).not_to include(:participants_by_geozone)
+      end
+    end
+
+    context "all gender, age and geozone stats" do
+      before do
+        allow(stats).to receive(:gender?).and_return(true)
+        allow(stats).to receive(:age?).and_return(true)
+        allow(stats).to receive(:geozone?).and_return(true)
+      end
+
+      it "includes all stats methods" do
+        expect(stats.stats_methods).to include(:total_male_participants)
+        expect(stats.stats_methods).to include(:participants_by_age)
+        expect(stats.stats_methods).to include(:participants_by_geozone)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## References

* Depends on pull request #1933

## Objectives

* Display only stats which are relevant to the budget or poll being shown. So if there's no gender, age, geozone or channel information, those stats are not displayed.

## Visual Changes

Before these changes:

![Mail stats are being shown even if there are no votes by mail](https://user-images.githubusercontent.com/35156/54555403-f5e7de80-49b6-11e9-9fc4-3f145022c3c8.png)

After these changes:

![Mail stats are not shown](https://user-images.githubusercontent.com/35156/54555431-05ffbe00-49b7-11e9-8b36-ac20941fbd18.png)

## Does this PR need a Backport to CONSUL?

Yes, backport when backporting everything related to stats.

## Notes

* The mehtods `gender?`, `age?` and `geozone?` might need to be changed because I haven't spent much time thinking about all possible scenarios.