### PR TITLE
Expire stats cache

### DIFF
--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -149,6 +149,6 @@ class Budget::Stats
     stats_cache :voters, :participants, :authors, :balloters, :poll_ballot_voters
 
     def stats_cache(key, &block)
-      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v13", &block)
+      Rails.cache.fetch("budgets_stats/#{budget.id}/#{key}/v14", &block)
     end
 end


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Context

1 of the 3 servers has not picked up the new cache keys for budget investment stats.

## Objectives

Expire cache of all production servers.

## Does this PR need a Backport to CONSUL?

Sure, to maintain consistent cache versions.
