### PR TITLE
Add rake task to check for spending proposals

### DIFF
--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -106,4 +106,16 @@ namespace :spending_proposals do
     puts "Finished"
   end
 
+  desc "Check if there are any spending proposals in DB"
+  task check: :environment do
+    if Rails.env.production? && SpendingProposal.any?
+      puts "WARNING"
+      puts "You have spending proposals in your database."
+      puts "This model has been deprecated in favor of budget investments."
+      puts "In the next CONSUL release spending proposals will be deleted."
+      puts "If you do not need to keep this data, you don't have to do anything else."
+      print "If you would like to migrate the data from spending proposals to budget investments "
+      puts "please review this PR https://github.com/AyuntamientoMadrid/consul/pull/1776."
+    end
+  end
 end


### PR DESCRIPTION
## References

- [Migrate spending proposals to budget investments](https://github.com/AyuntamientoMadrid/consul/pull/1776)
- [Delete spending proposals](https://github.com/AyuntamientoMadrid/consul/pull/1937)

## Objectives

Add a rake task to be executed in the production environment with instrucction on how to migrate from `spending proposals` to `budget investments`

## Does this PR need a Backport to CONSUL?

Yes, the first CONSUL forks might have spending proposals in the production environment.

## Notes
The id of the PR in the warning message will probably change when backporting to CONSUL.

To run the the check for spending proposals run this rake task:

`bin/rake spending_proposals:check RAILS_ENV=production`