### PR TITLE
Fix geozone population stats

### DIFF
--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -75,11 +75,8 @@ module Statisticable
         [
           geozone.name,
           {
-            total: {
-              count: count,
-              percentage: calculate_percentage(count, total_participants)
-            },
-            percentage: calculate_percentage(count, geozone.users.count)
+            count: count,
+            percentage: calculate_percentage(count, total_participants)
           }
         ]
       end.to_h

--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -41,8 +41,8 @@ module Statisticable
       participants.female.count
     end
 
-    def total_unknown_gender_or_age
-      participants.where("gender IS NULL OR date_of_birth is NULL").uniq.count
+    def total_no_demographic_data
+      participants.where("gender IS NULL OR date_of_birth IS NULL OR geozone_id IS NULL").count
     end
 
     def male_percentage
@@ -153,8 +153,7 @@ module Statisticable
     end
 
     def gender_methods
-      %i[total_male_participants total_female_participants total_unknown_gender_or_age
-         male_percentage female_percentage]
+      %i[total_male_participants total_female_participants male_percentage female_percentage]
     end
 
     def age_methods
@@ -162,7 +161,7 @@ module Statisticable
     end
 
     def geozone_methods
-      [:participants_by_geozone]
+      %i[participants_by_geozone total_no_demographic_data]
     end
 
     def stats_cache(*method_names)

--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -69,17 +69,19 @@ module Statisticable
     end
 
     def participants_by_geozone
-      geozones.map do |geozone|
-        count = participants.where(geozone: geozone).count
-
+      geozone_stats.map do |stats|
         [
-          geozone.name,
+          stats.name,
           {
-            count: count,
-            percentage: calculate_percentage(count, total_participants)
+            count: stats.count,
+            percentage: stats.percentage
           }
         ]
       end.to_h
+    end
+
+    def calculate_percentage(fraction, total)
+      PercentageCalculator.calculate(fraction, total)
     end
 
     private
@@ -124,10 +126,8 @@ module Statisticable
         Geozone.all.order("name")
       end
 
-      def calculate_percentage(fraction, total)
-        return 0.0 if total.zero?
-
-        (fraction * 100.0 / total).round(3)
+      def geozone_stats
+        geozones.map { |geozone| GeozoneStats.new(geozone, participants) }
       end
 
       def range_description(start, finish)

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -172,9 +172,9 @@
 
       <div class="row margin">
         <div class="small-12 column">
-          <div id="total_unknown_gender_or_age">
+          <div id="total_no_demographic_data">
             <p class="help-text">
-              <%= t("stats.budgets.no_demographic_data", total: @stats.total_unknown_gender_or_age) %>
+              <%= t("stats.no_demographic_data", total: @stats.total_no_demographic_data) %>
             </p>
             <p class="help-text">
                 <%= t("stats.budgets.participatory_disclaimer") %>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -174,7 +174,7 @@
         <div class="small-12 column">
           <div id="total_no_demographic_data">
             <p class="help-text">
-              <%= t("stats.no_demographic_data", total: @stats.total_no_demographic_data) %>
+              <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
             </p>
             <p class="help-text">
                 <%= t("stats.budgets.participatory_disclaimer") %>

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -117,7 +117,7 @@
 
         <div id="total_no_demographic_data">
           <p class="help-text">
-            <%= t("stats.no_demographic_data", total: @stats.total_no_demographic_data) %>
+            <%= t("stats.no_demographic_data", count: @stats.total_no_demographic_data) %>
           </p>
         </div>
       </div>

--- a/app/views/polls/stats.html.erb
+++ b/app/views/polls/stats.html.erb
@@ -114,6 +114,12 @@
             </tbody>
           </table>
         </div>
+
+        <div id="total_no_demographic_data">
+          <p class="help-text">
+            <%= t("stats.no_demographic_data", total: @stats.total_no_demographic_data) %>
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/stats/_geozone.html.erb
+++ b/app/views/shared/stats/_geozone.html.erb
@@ -6,7 +6,6 @@
       <tr>
         <th><%= t("stats.geozone") %></th>
         <th><%= t("stats.total") %></th>
-        <th><%= t("stats.geozone_participation") %></th>
       </tr>
     </thead>
 
@@ -14,8 +13,7 @@
       <% stats.participants_by_geozone.each do |geozone, participants| %>
         <tr>
           <td><%= geozone %></td>
-          <td><%= "#{participants[:total][:count]} (#{number_to_stats_percentage(participants[:total][:percentage])})" %></td>
-          <td><%= number_to_stats_percentage(participants[:percentage]) %></td>
+          <td><%= "#{participants[:count]} (#{number_to_stats_percentage(participants[:percentage])})" %></td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en/stats.yml
+++ b/config/locales/en/stats.yml
@@ -13,6 +13,7 @@ en:
     age_range: "%{start} - %{finish} years old"
     total: "Total"
     geozone: "District"
+    no_demographic_data: "* There is no demographic data for %{total} participants."
     budgets:
       link: "Stats"
       page_title: "%{budget} - Participation stats"
@@ -29,7 +30,6 @@ en:
       participants_total: "Total Participants"
       percent_total_participants_html: "% <br>Total<br>Participants"
       percent_heading_census_html: "% <br>Heading<br>Census"
-      no_demographic_data: "* There is no demographic data for %{total} participants."
       participatory_disclaimer: "** The numbers of total participants refer to persons that created, supported or voted investment proposals."
       heading_disclaimer: "*** Data about headings refer to the heading where each user voted, not necessarily the one that person is registered on."
     polls:

--- a/config/locales/en/stats.yml
+++ b/config/locales/en/stats.yml
@@ -13,7 +13,6 @@ en:
     age_range: "%{start} - %{finish} years old"
     total: "Total"
     geozone: "District"
-    geozone_participation: "% District population participants"
     budgets:
       link: "Stats"
       page_title: "%{budget} - Participation stats"

--- a/config/locales/en/stats.yml
+++ b/config/locales/en/stats.yml
@@ -13,7 +13,10 @@ en:
     age_range: "%{start} - %{finish} years old"
     total: "Total"
     geozone: "District"
-    no_demographic_data: "* There is no demographic data for %{total} participants."
+    no_demographic_data:
+      zero: ""
+      one: "* There is no demographic data for 1 participant."
+      other: "* There is no demographic data for %{count} participants."
     budgets:
       link: "Stats"
       page_title: "%{budget} - Participation stats"

--- a/config/locales/es/stats.yml
+++ b/config/locales/es/stats.yml
@@ -13,7 +13,6 @@ es:
     age_range: "De %{start} a %{finish} años"
     total: "Total"
     geozone: "Distrito"
-    geozone_participation: "% Participantes población del distrito"
     budgets:
       link: "Estadísticas"
       page_title: "%{budget} - Estadísticas de participación"

--- a/config/locales/es/stats.yml
+++ b/config/locales/es/stats.yml
@@ -13,7 +13,10 @@ es:
     age_range: "De %{start} a %{finish} años"
     total: "Total"
     geozone: "Distrito"
-    no_demographic_data: "* No se dispone de los datos demográficos de %{total} participantes."
+    no_demographic_data:
+      zero: ""
+      one: "* No se dispone de los datos demográficos de 1 participante."
+      other: "* No se dispone de los datos demográficos de %{count} participantes."
     budgets:
       link: "Estadísticas"
       page_title: "%{budget} - Estadísticas de participación"

--- a/config/locales/es/stats.yml
+++ b/config/locales/es/stats.yml
@@ -13,6 +13,7 @@ es:
     age_range: "De %{start} a %{finish} años"
     total: "Total"
     geozone: "Distrito"
+    no_demographic_data: "* No se dispone de los datos demográficos de %{total} participantes."
     budgets:
       link: "Estadísticas"
       page_title: "%{budget} - Estadísticas de participación"
@@ -29,7 +30,6 @@ es:
       participants_total: Total de participantes
       percent_total_participants_html: "% <br>Total<br>Participantes"
       percent_heading_census_html: "% <br>Censo<br>Distrito"
-      no_demographic_data: "* No se dispone de los datos demográficos de %{total} participantes."
       participatory_disclaimer: "** Las cifras de total de participantes se refieren a personas que han creado, apoyado o votado propuestas."
       heading_disclaimer: "*** Los datos de distrito se refieren al distrito en el que el usuario ha votado, no necesariamente en el que está empadronado."
     polls:

--- a/lib/geozone_stats.rb
+++ b/lib/geozone_stats.rb
@@ -1,0 +1,24 @@
+class GeozoneStats
+  attr_reader :geozone, :participants
+
+  def initialize(geozone, participants)
+    @geozone = geozone
+    @participants = participants
+  end
+
+  def geozone_participants
+    participants.where(geozone: geozone)
+  end
+
+  def name
+    geozone.name
+  end
+
+  def count
+    geozone_participants.count
+  end
+
+  def percentage
+    PercentageCalculator.calculate(count, participants.count)
+  end
+end

--- a/lib/percentage_calculator.rb
+++ b/lib/percentage_calculator.rb
@@ -1,0 +1,7 @@
+module PercentageCalculator
+  def self.calculate(fraction, total)
+    return 0.0 if total.zero?
+
+    (fraction * 100.0 / total).round(3)
+  end
+end

--- a/spec/lib/geozone_stats_spec.rb
+++ b/spec/lib/geozone_stats_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe GeozoneStats do
+  let(:winterfell) { create(:geozone, name: "Winterfell") }
+  let(:riverlands) { create(:geozone, name: "Riverlands") }
+
+  describe "#name" do
+    let(:stats) { GeozoneStats.new(winterfell, []) }
+
+    it "returns the geozone name" do
+      expect(stats.name).to eq "Winterfell"
+    end
+  end
+
+  describe "#count" do
+    before do
+      2.times { create(:user, geozone: winterfell) }
+      1.times { create(:user, geozone: riverlands) }
+    end
+
+    let(:winterfell_stats) { GeozoneStats.new(winterfell, User.all) }
+    let(:riverlands_stats) { GeozoneStats.new(riverlands, User.all) }
+
+    it "counts participants from the geozone" do
+      expect(winterfell_stats.count).to eq 2
+      expect(riverlands_stats.count).to eq 1
+    end
+  end
+
+  describe "#percentage" do
+    before do
+      2.times { create(:user, geozone: winterfell) }
+      1.times { create(:user, geozone: riverlands) }
+    end
+
+    let(:winterfell_stats) { GeozoneStats.new(winterfell, User.all) }
+    let(:riverlands_stats) { GeozoneStats.new(riverlands, User.all) }
+
+    it "calculates percentage relative to the amount of participants" do
+      expect(winterfell_stats.percentage).to eq 66.667
+      expect(riverlands_stats.percentage).to eq 33.333
+    end
+  end
+end

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -153,12 +153,6 @@ describe Budget::Stats do
       end
     end
 
-    describe "#total_unknown_gender_or_age" do
-      it "returns the number of total unknown participants' gender or age" do
-        expect(stats.total_unknown_gender_or_age).to be 1
-      end
-    end
-
     describe "#male_percentage" do
       it "returns the percentage of male participants" do
         expect(stats.male_percentage).to be 60.0

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -170,17 +170,10 @@ describe Poll::Stats do
       3.times { create :poll_voter, poll: poll, user: create(:user, :level_two, geozone: hobbiton) }
       2.times { create :poll_voter, poll: poll, user: create(:user, :level_two, geozone: rivendel) }
 
-      expect(stats.participants_by_geozone["Hobbiton"][:total]).to eq(count: 3, percentage: 60.0)
-      expect(stats.participants_by_geozone["Rivendel"][:total]).to eq(count: 2, percentage: 40.0)
-    end
-
-    it "calculates percentage relative to the geozone population" do
-      midgar = create(:geozone, name: "Midgar")
-
-      create(:poll_voter, poll: poll, user: create(:user, :level_two, geozone: midgar))
-      2.times { create :user, :level_two, geozone: midgar }
-
-      expect(stats.participants_by_geozone["Midgar"][:percentage]).to eq(33.333)
+      expect(stats.participants_by_geozone["Hobbiton"][:count]).to eq 3
+      expect(stats.participants_by_geozone["Hobbiton"][:percentage]).to eq 60.0
+      expect(stats.participants_by_geozone["Rivendel"][:count]).to eq 2
+      expect(stats.participants_by_geozone["Rivendel"][:percentage]).to eq 40.0
     end
   end
 

--- a/spec/models/statisticable_spec.rb
+++ b/spec/models/statisticable_spec.rb
@@ -102,6 +102,38 @@ describe Statisticable do
     end
   end
 
+  describe "#total_no_demographic_data" do
+    it "returns users with no defined gender" do
+      create(:user, gender: nil)
+
+      expect(stats.total_no_demographic_data).to be 1
+    end
+
+    it "returns users with no defined age" do
+      create(:user, gender: "female", date_of_birth: nil)
+
+      expect(stats.total_no_demographic_data).to be 1
+    end
+
+    it "returns users with no defined geozone" do
+      create(:user, gender: "female", geozone: nil)
+
+      expect(stats.total_no_demographic_data).to be 1
+    end
+
+    it "returns users with no defined gender, age nor geozone" do
+      create(:user, gender: nil, date_of_birth: nil, geozone: nil)
+
+      expect(stats.total_no_demographic_data).to be 1
+    end
+
+    it "doesn't return users with defined gender, age and geozone" do
+      create(:user, gender: "male", date_of_birth: 20.years.ago, geozone: create(:geozone))
+
+      expect(stats.total_no_demographic_data).to be 0
+    end
+  end
+
   describe "#stats_methods" do
     it "includes total participants" do
       expect(stats.stats_methods).to include(:total_participants)


### PR DESCRIPTION
## References

* Pull request #1789 

## Objectives

Fix geozone population stats. Currently we calculate the participation percentage related to the registered users from a geozone. However, we need to compare against the geozone population.

Currently, geozones don't store population information. So for polls we won't display this percentage, and for budgets we'll use the information stored in the headings.

## Does this PR need a Backport to CONSUL?

Yes, backport when we backport everything related to stats.