### PR TITLE
Fix investment pagination tests

### DIFF
--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -632,9 +632,10 @@ feature "Budget Investments" do
 
   context "Orders" do
     before { budget.update(phase: "selecting") }
+    let(:per_page) { Budgets::InvestmentsController::PER_PAGE }
 
     scenario "Default order is random" do
-      10.times { create(:budget_investment) }
+      (per_page + 2).times { create(:budget_investment) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
       order = all(".budget-investment h3").collect {|i| i.text }
@@ -646,7 +647,7 @@ feature "Budget Investments" do
     end
 
     scenario "Random order after another order" do
-      10.times { create(:budget_investment) }
+      (per_page + 2).times { create(:budget_investment) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
       click_link "highest rated"
@@ -661,7 +662,6 @@ feature "Budget Investments" do
     end
 
     scenario "Random order maintained with pagination" do
-      per_page = Kaminari.config.default_per_page
       (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
@@ -679,7 +679,7 @@ feature "Budget Investments" do
     end
 
     scenario "Random order maintained when going back from show" do
-      10.times { |i| create(:budget_investment, heading: heading) }
+      per_page.times { |i| create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
@@ -693,8 +693,7 @@ feature "Budget Investments" do
     end
 
     scenario "Investments are not repeated with random order" do
-      12.times { create(:budget_investment, heading: heading) }
-      # 12 instead of per_page + 2 because in each page there are 10 (in this case), not 25
+      (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, order: "random")
 
@@ -732,7 +731,7 @@ feature "Budget Investments" do
     end
 
     scenario "Each user has a different and consistent random budget investment order" do
-      (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
+      (per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
         visit budget_investments_path(budget, heading: heading)
@@ -768,7 +767,7 @@ feature "Budget Investments" do
     end
 
     scenario "Each user has a equal and consistent budget investment order when the random_seed is equal" do
-      (Kaminari.config.default_per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
+      (per_page * 1.3).to_i.times { create(:budget_investment, heading: heading) }
 
       in_browser(:one) do
         visit budget_investments_path(budget, heading: heading, random_seed: "1")
@@ -787,10 +786,10 @@ feature "Budget Investments" do
       voter = create(:user, :level_two)
       login_as(voter)
 
-      10.times { create(:budget_investment, heading: heading) }
+      per_page.times { create(:budget_investment, heading: heading) }
 
       voted_investments = []
-      10.times do
+      per_page.times do
         investment = create(:budget_investment, heading: heading)
         create(:vote, votable: investment, voter: voter)
         voted_investments << investment
@@ -808,7 +807,7 @@ feature "Budget Investments" do
     end
 
     scenario "Order is random if budget is finished" do
-      10.times { create(:budget_investment) }
+      per_page.times { create(:budget_investment) }
 
       budget.update(phase: "finished")
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -635,30 +635,34 @@ feature "Budget Investments" do
     let(:per_page) { Budgets::InvestmentsController::PER_PAGE }
 
     scenario "Default order is random" do
-      (per_page + 2).times { create(:budget_investment) }
+      (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
-      order = all(".budget-investment h3").collect {|i| i.text }
+
+      within(".submenu .is-active") { expect(page).to have_content "random" }
+      order = all(".budget-investment h3").collect { |i| i.text }
+      expect(order).not_to be_empty
 
       visit budget_investments_path(budget, heading_id: heading.id)
-      new_order = eq(all(".budget-investment h3").collect {|i| i.text })
+      new_order = all(".budget-investment h3").collect { |i| i.text }
 
-      expect(order).not_to eq(new_order)
+      expect(order).to eq(new_order)
     end
 
     scenario "Random order after another order" do
-      (per_page + 2).times { create(:budget_investment) }
+      (per_page + 2).times { create(:budget_investment, heading: heading) }
 
       visit budget_investments_path(budget, heading_id: heading.id)
+      order = all(".budget-investment h3").collect { |i| i.text }
+      expect(order).not_to be_empty
+
       click_link "highest rated"
       click_link "random"
 
-      order = all(".budget-investment h3").collect {|i| i.text }
-
       visit budget_investments_path(budget, heading_id: heading.id)
-      new_order = eq(all(".budget-investment h3").collect {|i| i.text })
+      new_order = all(".budget-investment h3").collect { |i| i.text }
 
-      expect(order).not_to eq(new_order)
+      expect(order).to eq(new_order)
     end
 
     scenario "Random order maintained with pagination" do
@@ -666,7 +670,8 @@ feature "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      order = all(".budget-investment h3").collect {|i| i.text }
+      order = all(".budget-investment h3").collect { |i| i.text }
+      expect(order).not_to be_empty
 
       click_link "Next"
       expect(page).to have_content "You're on page 2"
@@ -674,7 +679,7 @@ feature "Budget Investments" do
       click_link "Previous"
       expect(page).to have_content "You're on page 1"
 
-      new_order = all(".budget-investment h3").collect {|i| i.text }
+      new_order = all(".budget-investment h3").collect { |i| i.text }
       expect(order).to eq(new_order)
     end
 
@@ -683,12 +688,13 @@ feature "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      order = all(".budget-investment h3").collect {|i| i.text }
+      order = all(".budget-investment h3").collect { |i| i.text }
+      expect(order).not_to be_empty
 
       click_link Budget::Investment.first.title
       click_link "Go back"
 
-      new_order = all(".budget-investment h3").collect {|i| i.text }
+      new_order = all(".budget-investment h3").collect { |i| i.text }
       expect(order).to eq(new_order)
     end
 
@@ -807,17 +813,18 @@ feature "Budget Investments" do
     end
 
     scenario "Order is random if budget is finished" do
-      per_page.times { create(:budget_investment) }
+      per_page.times { create(:budget_investment, :winner, heading: heading) }
 
       budget.update(phase: "finished")
 
       visit budget_investments_path(budget, heading_id: heading.id)
-      order = all(".budget-investment h3").collect {|i| i.text }
+      order = all(".budget-investment h3").collect { |i| i.text }
+      expect(order).not_to be_empty
 
       visit budget_investments_path(budget, heading_id: heading.id)
-      new_order = eq(all(".budget-investment h3").collect {|i| i.text })
+      new_order = all(".budget-investment h3").collect { |i| i.text }
 
-      expect(order).not_to eq(new_order)
+      expect(order).to eq(new_order)
     end
 
     scenario "Order always is random for unfeasible and unselected investments" do


### PR DESCRIPTION
## References

* Pull request consul#3405

## Objectives

* Fix tests which were accidentally passing because of typos
* Generate the right amount or records we need to test budget investment pagination

## Does this PR need a Backport to CONSUL?

No, the code is already there.