### PR TITLE
Include hidden users in stats

### DIFF
--- a/app/models/budget/stats.rb
+++ b/app/models/budget/stats.rb
@@ -37,10 +37,6 @@ class Budget::Stats
     budget.finished?
   end
 
-  def participants
-    User.where(id: phases.map { |phase| send("participant_ids_#{phase}_phase") }.flatten.uniq)
-  end
-
   def total_participants
     participants.distinct.count
   end
@@ -96,6 +92,10 @@ class Budget::Stats
 
     def phase_methods
       phases.map { |phase| self.class.send("#{phase}_phase_methods") }.flatten
+    end
+
+    def participant_ids
+      phases.map { |phase| send("participant_ids_#{phase}_phase") }.flatten.uniq
     end
 
     def participant_ids_support_phase

--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -33,6 +33,10 @@ module Statisticable
       participants.where(geozone: geozones).any?
     end
 
+    def participants
+      User.where(id: participant_ids)
+    end
+
     def total_male_participants
       participants.male.count
     end

--- a/app/models/concerns/statisticable.rb
+++ b/app/models/concerns/statisticable.rb
@@ -34,7 +34,7 @@ module Statisticable
     end
 
     def participants
-      User.where(id: participant_ids)
+      User.unscoped.where(id: participant_ids)
     end
 
     def total_male_participants

--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -103,8 +103,8 @@ class Poll::Stats
 
   private
 
-    def participants
-      User.where(id: voters.pluck(:user_id))
+    def participant_ids
+      voters.pluck(:user_id)
     end
 
     def voters

--- a/spec/models/budget/stats_spec.rb
+++ b/spec/models/budget/stats_spec.rb
@@ -7,10 +7,10 @@ describe Budget::Stats do
 
   describe "#participants" do
     let(:author) { investment.author }
-    let(:author_and_voter) { create(:user) }
+    let(:author_and_voter) { create(:user, hidden_at: Time.current) }
     let(:voter) { create(:user) }
     let(:voter_and_balloter) { create(:user) }
-    let(:balloter) { create(:user) }
+    let(:balloter) { create(:user, hidden_at: Time.current) }
     let(:poll_balloter) { create(:user, :level_two) }
     let(:non_participant) { create(:user, :level_two) }
 
@@ -29,7 +29,7 @@ describe Budget::Stats do
       create(:poll_voter, :from_booth, user: non_participant, budget: create(:budget))
     end
 
-    it "returns unique participants, including authors" do
+    it "returns unique participants, including authors and hidden users" do
       expect(stats.participants).to match_array(
         [author, author_and_voter, voter, voter_and_balloter, balloter, poll_balloter]
       )

--- a/spec/models/poll/stats_spec.rb
+++ b/spec/models/poll/stats_spec.rb
@@ -4,6 +4,15 @@ describe Poll::Stats do
   let(:poll) { create(:poll) }
   let(:stats) { Poll::Stats.new(poll) }
 
+  describe "#participants" do
+    it "includes hidden users" do
+      create(:poll_voter, poll: poll)
+      create(:poll_voter, poll: poll, user: create(:user, :level_two, hidden_at: Time.current))
+
+      expect(stats.participants.count).to eq(2)
+    end
+  end
+
   describe "total participants" do
     before { allow(stats).to receive(:total_web_white).and_return(1) }
 


### PR DESCRIPTION
## References

* Pull request #1834

## Objectives

Include hidden users in stats. Sometimes users participate in a process and a while after that they are hidden. We were modifying the stats when that happened, not counting the users who were hidden anymore.

## Does this PR need a Backport to CONSUL?

Yes, backport when we backport everything related to stats.