### PR TITLE
Add rake task to destroy all associated records

### DIFF
--- a/lib/migrations/spending_proposal/budget_investments.rb
+++ b/lib/migrations/spending_proposal/budget_investments.rb
@@ -12,6 +12,13 @@ class Migrations::SpendingProposal::BudgetInvestments
     end
   end
 
+  def destroy_associated
+    if spending_proposals.any?
+      Vote.where(votable: spending_proposals).destroy_all
+      Tagging.where(taggable: spending_proposals).destroy_all
+    end
+  end
+
   private
 
     def load_spending_proposals

--- a/lib/tasks/spending_proposals.rake
+++ b/lib/tasks/spending_proposals.rake
@@ -99,4 +99,11 @@ namespace :spending_proposals do
     puts "Finished"
   end
 
+  desc "Destoy all associated spending proposal records"
+  task :destroy_associated do
+    puts "Starting to destroy associated records"
+    Migrations::SpendingProposal::Investments.new.destroy_associated
+    puts "Finished"
+  end
+
 end

--- a/spec/lib/migrations/spending_proposals/budget_investments_spec.rb
+++ b/spec/lib/migrations/spending_proposals/budget_investments_spec.rb
@@ -49,4 +49,40 @@ describe Migrations::SpendingProposal::BudgetInvestments do
 
   end
 
+  describe "#destroy_associated" do
+
+    it "destroys spending proposals votes" do
+      investment = create(:budget_investment)
+      spending_proposal = create(:spending_proposal)
+
+      investment_vote = create(:vote, votable: investment)
+      spending_proposal_vote = create(:vote, votable: spending_proposal)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.destroy_associated
+
+      expect(Vote.count).to eq(1)
+      expect(Vote.first).to eq(investment_vote)
+    end
+
+    it "destroys spending proposals taggings" do
+      investment = create(:budget_investment)
+      spending_proposal = create(:spending_proposal)
+
+      health_tag = create(:tag, name: "Health")
+      investment_tagging = create(:tagging, taggable: investment, tag: health_tag)
+      spending_proposal_tagging = create(:tagging, taggable: spending_proposal, tag: health_tag)
+
+      migration = Migrations::SpendingProposal::BudgetInvestments.new
+      migration.destroy_associated
+
+      expect(Tagging.count).to eq(1)
+      expect(ActsAsTaggableOn::Tagging.first).to eq(investment_tagging)
+
+      expect(Tag.count).to eq(1)
+      expect(Tag.first).to eq(health_tag)
+    end
+
+  end
+
 end


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1776

## Context

There are some polymorphic tables that still hold records associated to spending proposals. So far we have migrated, copied or dismissed all of these records and associated them to their corresponding budget investments. Now it is time to complete delete any associated records to spending proposals.

## Objectives

Destroy all records associated to spending proposals:
- Supports
- Taggings

## Notes

Destroy all records associated to spending proposals run this rake task:
```
bin/rake spending_proposals:destroy_associated RAILS_ENV=production
```