### PR TITLE
Fix bug moderator can't print voted investments in balloting phase

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,4 +67,9 @@ module ApplicationHelper
     custom_partial_path = "custom/#{@virtual_path.remove(controller_action)}#{partial_name}"
     render custom_partial_path if lookup_context.exists?(custom_partial_path, [], true)
   end
+
+  def management_controller?
+    controller.class.to_s.include?("Management")
+  end
+
 end

--- a/app/views/budgets/investments/_investment.html.erb
+++ b/app/views/budgets/investments/_investment.html.erb
@@ -81,7 +81,7 @@
               </span>
             </div>
           </div>
-        <% elsif investment.should_show_ballots? %>
+        <% elsif investment.should_show_ballots? && !management_controller? %>
           <div id="<%= dom_id(investment) %>_ballot"
                 class="small-12 medium-3 column text-center"
                 <%= 'data-equalizer-watch' if feature?(:allow_images) && investment.image.present? %>>

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 feature "Budget Investments" do
 
-  background do
-    login_as_manager
-    @budget = create(:budget, phase: "selecting", name: "2033")
-    @group = create(:budget_group, budget: @budget, name: "Whole city")
-    @heading = create(:budget_heading, group: @group, name: "Health")
-  end
+  let(:manager) { create(:manager) }
+  let(:budget)  { create(:budget, phase: "selecting", name: "2033") }
+  let(:group)   { create(:budget_group, budget: budget, name: "Whole city") }
+  let(:heading) { create(:budget_heading, group: group, name: "Health") }
+
+  before { login_as_manager(manager) }
 
   it_behaves_like "mappable",
                   "budget_investment",
@@ -47,7 +47,7 @@ feature "Budget Investments" do
   end
 
   context "Create" do
-    before { @budget.update(phase: "accepting") }
+    before { heading.budget.update(phase: "accepting") }
 
     scenario "Creating budget investments on behalf of someone, selecting a budget" do
       user = create(:user, :level_two)
@@ -55,7 +55,7 @@ feature "Budget Investments" do
       login_managed_user(user)
 
       click_link "Create budget investment"
-      within "#budget_#{@budget.id}" do
+      within "#budget_#{budget.id}" do
         click_link "Create budget investment"
       end
 
@@ -84,7 +84,7 @@ feature "Budget Investments" do
       expect(page).to have_content "T.I.A."
       expect(page).to have_content "green"
       expect(page).to have_content user.name
-      expect(page).to have_content I18n.l(@budget.created_at.to_date)
+      expect(page).to have_content I18n.l(budget.created_at.to_date)
     end
 
     scenario "Should not allow unverified users to create budget investments" do
@@ -100,15 +100,15 @@ feature "Budget Investments" do
   context "Searching" do
 
     scenario "by title" do
-      budget_investment1 = create(:budget_investment, budget: @budget, title: "Show me what you got")
-      budget_investment2 = create(:budget_investment, budget: @budget, title: "Get Schwifty")
+      budget_investment1 = create(:budget_investment, budget: budget, title: "Show me what you got")
+      budget_investment2 = create(:budget_investment, budget: budget, title: "Get Schwifty")
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Support budget investments"
-      expect(page).to have_content(@budget.name)
-      within "#budget_#{@budget.id}" do
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
         click_link "Support budget investments"
       end
 
@@ -119,23 +119,23 @@ feature "Budget Investments" do
         expect(page).to have_css(".budget-investment", count: 1)
         expect(page).to have_content(budget_investment1.title)
         expect(page).not_to have_content(budget_investment2.title)
-        expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment1)}']",
+        expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment1)}']",
                                  text: budget_investment1.title)
       end
     end
 
     scenario "by heading" do
-      budget_investment1 = create(:budget_investment, budget: @budget, title: "Hey ho",
+      budget_investment1 = create(:budget_investment, budget: budget, title: "Hey ho",
                                                       heading: create(:budget_heading, name: "District 9"))
-      budget_investment2 = create(:budget_investment, budget: @budget, title: "Let's go",
+      budget_investment2 = create(:budget_investment, budget: budget, title: "Let's go",
                                                       heading: create(:budget_heading, name: "Area 52"))
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Support budget investments"
-      expect(page).to have_content(@budget.name)
-      within "#budget_#{@budget.id}" do
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
         click_link "Support budget investments"
       end
 
@@ -146,22 +146,22 @@ feature "Budget Investments" do
         expect(page).to have_css(".budget-investment", count: 1)
         expect(page).not_to have_content(budget_investment1.title)
         expect(page).to have_content(budget_investment2.title)
-        expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment2)}']",
+        expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment2)}']",
                                  text: budget_investment2.title)
       end
     end
   end
 
   scenario "Listing" do
-    budget_investment1 = create(:budget_investment, budget: @budget, title: "Show me what you got")
-    budget_investment2 = create(:budget_investment, budget: @budget, title: "Get Schwifty")
+    budget_investment1 = create(:budget_investment, budget: budget, title: "Show me what you got")
+    budget_investment2 = create(:budget_investment, budget: budget, title: "Get Schwifty")
 
     user = create(:user, :level_two)
     login_managed_user(user)
 
     click_link "Support budget investments"
-    expect(page).to have_content(@budget.name)
-    within "#budget_#{@budget.id}" do
+    expect(page).to have_content(budget.name)
+    within "#budget_#{budget.id}" do
       click_link "Support budget investments"
     end
 
@@ -174,9 +174,9 @@ feature "Budget Investments" do
 
     within("#budget-investments") do
       expect(page).to have_css(".budget-investment", count: 2)
-      expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment1)}']",
+      expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment1)}']",
                                text: budget_investment1.title)
-      expect(page).to have_css("a[href='#{management_budget_investment_path(@budget, budget_investment2)}']",
+      expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment2)}']",
                                text: budget_investment2.title)
     end
   end
@@ -239,14 +239,14 @@ feature "Budget Investments" do
   context "Supporting" do
 
     scenario "Supporting budget investments on behalf of someone in index view", :js do
-      budget_investment = create(:budget_investment, budget: @budget, heading: @heading)
+      budget_investment = create(:budget_investment, budget: budget, heading: heading)
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Support budget investments"
-      expect(page).to have_content(@budget.name)
-      within "#budget_#{@budget.id}" do
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
         click_link "Support budget investments"
       end
       expect(page).to have_content(budget_investment.title)
@@ -261,14 +261,14 @@ feature "Budget Investments" do
 
     # This test passes ok locally but fails on the last two lines in Travis
     xscenario "Supporting budget investments on behalf of someone in show view", :js do
-      budget_investment = create(:budget_investment, budget: @budget)
+      budget_investment = create(:budget_investment, budget: budget)
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Support budget investments"
-      expect(page).to have_content(@budget.name)
-      within "#budget_#{@budget.id}" do
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
         click_link "Support budget investments"
       end
 
@@ -282,7 +282,7 @@ feature "Budget Investments" do
     end
 
     scenario "Should not allow unverified users to vote proposals" do
-      budget_investment = create(:budget_investment, budget: @budget)
+      create(:budget_investment, budget: budget)
 
       user = create(:user)
       login_managed_user(user)
@@ -296,12 +296,12 @@ feature "Budget Investments" do
   context "Printing" do
 
     scenario "Printing budget investments" do
-      16.times { create(:budget_investment, budget: @budget, heading: @heading) }
+      16.times { create(:budget_investment, budget: budget, heading: heading) }
 
       click_link "Print budget investments"
 
-      expect(page).to have_content(@budget.name)
-      within "#budget_#{@budget.id}" do
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
         click_link "Print budget investments"
       end
 
@@ -310,20 +310,20 @@ feature "Budget Investments" do
     end
 
     scenario "Filtering budget investments by heading to be printed", :js do
-      district_9 = create(:budget_heading, group: @group, name: "District Nine")
-      another_heading = create(:budget_heading, group: @group)
-      low_investment = create(:budget_investment, budget: @budget, title: "Nuke district 9", heading: district_9, cached_votes_up: 1)
-      mid_investment = create(:budget_investment, budget: @budget, title: "Change district 9", heading: district_9, cached_votes_up: 10)
-      top_investment = create(:budget_investment, budget: @budget, title: "Destroy district 9", heading: district_9, cached_votes_up: 100)
-      unvoted_investment = create(:budget_investment, budget: @budget, heading: another_heading, title: "Add new districts to the city")
+      district_9 = create(:budget_heading, group: group, name: "District Nine")
+      another_heading = create(:budget_heading, group: group)
+      low_investment = create(:budget_investment, budget: budget, title: "Nuke district 9", heading: district_9, cached_votes_up: 1)
+      mid_investment = create(:budget_investment, budget: budget, title: "Change district 9", heading: district_9, cached_votes_up: 10)
+      top_investment = create(:budget_investment, budget: budget, title: "Destroy district 9", heading: district_9, cached_votes_up: 100)
+      unvoted_investment = create(:budget_investment, budget: budget, heading: another_heading, title: "Add new districts to the city")
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Print budget investments"
 
-      expect(page).to have_content(@budget.name)
-      within "#budget_#{@budget.id}" do
+      expect(page).to have_content(budget.name)
+      within "#budget_#{budget.id}" do
         click_link "Print budget investments"
       end
 

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "Budget Investments" do
 
   let(:manager) { create(:manager) }
-  let(:budget)  { create(:budget, phase: "selecting", name: "2033") }
+  let(:budget)  { create(:budget, phase: "selecting", name: "2033", slug: "budget_slug") }
   let(:group)   { create(:budget_group, budget: budget, name: "Whole city") }
   let(:heading) { create(:budget_heading, group: group, name: "Health") }
 
@@ -20,7 +20,6 @@ feature "Budget Investments" do
 
   context "Load" do
 
-    let(:budget)     { create(:budget, slug: "budget_slug") }
     let(:investment) { create(:budget_investment, budget: budget) }
     let(:user)       { create(:user, :level_two) }
 

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -118,8 +118,9 @@ feature "Budget Investments" do
         expect(page).to have_css(".budget-investment", count: 1)
         expect(page).to have_content(budget_investment1.title)
         expect(page).not_to have_content(budget_investment2.title)
-        expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment1)}']",
-                                 text: budget_investment1.title)
+
+        investment1_path = management_budget_investment_path(budget, budget_investment1)
+        expect(page).to have_link(budget_investment1.title, href: investment1_path)
       end
     end
 
@@ -145,8 +146,9 @@ feature "Budget Investments" do
         expect(page).to have_css(".budget-investment", count: 1)
         expect(page).not_to have_content(budget_investment1.title)
         expect(page).to have_content(budget_investment2.title)
-        expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment2)}']",
-                                 text: budget_investment2.title)
+
+        investment2_path = management_budget_investment_path(budget, budget_investment2)
+        expect(page).to have_link(budget_investment2.title, href: investment2_path)
       end
     end
   end
@@ -173,10 +175,12 @@ feature "Budget Investments" do
 
     within("#budget-investments") do
       expect(page).to have_css(".budget-investment", count: 2)
-      expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment1)}']",
-                               text: budget_investment1.title)
-      expect(page).to have_css("a[href='#{management_budget_investment_path(budget, budget_investment2)}']",
-                               text: budget_investment2.title)
+
+      investment1_path = management_budget_investment_path(budget, budget_investment1)
+      expect(page).to have_link(budget_investment1.title, href: investment1_path)
+
+      investment2_path = management_budget_investment_path(budget, budget_investment2)
+      expect(page).to have_link(budget_investment2.title, href: investment2_path)
     end
   end
 
@@ -305,16 +309,31 @@ feature "Budget Investments" do
       end
 
       expect(page).to have_css(".budget-investment", count: 15)
-      expect(page).to have_css("a[href='javascript:window.print();']", text: "Print")
+      expect(page).to have_link("Print", href: "javascript:window.print();")
     end
 
     scenario "Filtering budget investments by heading to be printed", :js do
       district_9 = create(:budget_heading, group: group, name: "District Nine")
       another_heading = create(:budget_heading, group: group)
-      low_investment = create(:budget_investment, budget: budget, title: "Nuke district 9", heading: district_9, cached_votes_up: 1)
-      mid_investment = create(:budget_investment, budget: budget, title: "Change district 9", heading: district_9, cached_votes_up: 10)
-      top_investment = create(:budget_investment, budget: budget, title: "Destroy district 9", heading: district_9, cached_votes_up: 100)
-      unvoted_investment = create(:budget_investment, budget: budget, heading: another_heading, title: "Add new districts to the city")
+      low_investment = create(:budget_investment,
+                              budget: budget,
+                              title: "Nuke district 9",
+                              heading: district_9,
+                              cached_votes_up: 1)
+      mid_investment = create(:budget_investment,
+                              budget: budget,
+                              title: "Change district 9",
+                              heading: district_9,
+                              cached_votes_up: 10)
+      top_investment = create(:budget_investment,
+                              budget: budget,
+                              title: "Destroy district 9",
+                              heading: district_9,
+                              cached_votes_up: 100)
+      unvoted_investment = create(:budget_investment,
+                                  budget: budget,
+                                  heading: another_heading,
+                                  title: "Add new districts to the city")
 
       user = create(:user, :level_two)
       login_managed_user(user)

--- a/spec/features/management/budget_investments_spec.rb
+++ b/spec/features/management/budget_investments_spec.rb
@@ -312,6 +312,23 @@ feature "Budget Investments" do
       expect(page).to have_link("Print", href: "javascript:window.print();")
     end
 
+    scenario "Printing voted budget investments in balloting phase" do
+      budget.update(phase: "balloting")
+
+      voted_investment = create(:budget_investment, :selected, heading: heading)
+      ballot = create(:budget_ballot, user: create(:user, :level_two), budget: budget)
+      ballot.investments << voted_investment
+
+      click_link "Print budget investments"
+
+      within "#budget_#{budget.id}" do
+        click_link "Print budget investments"
+      end
+
+      expect(page).to have_content voted_investment.title
+      expect(page).to have_link("Print", href: "javascript:window.print();")
+    end
+
     scenario "Filtering budget investments by heading to be printed", :js do
       district_9 = create(:budget_heading, group: group, name: "District Nine")
       another_heading = create(:budget_heading, group: group)

--- a/spec/support/common_actions/users.rb
+++ b/spec/support/common_actions/users.rb
@@ -44,8 +44,7 @@ module Users
     visit new_officing_residence_path
   end
 
-  def login_as_manager
-    manager = create(:manager)
+  def login_as_manager(manager = create(:manager))
     login_as(manager.user)
     visit management_sign_in_path
   end


### PR DESCRIPTION
## Objectives
When visiting `/management/budgets/:id/investments/print`

If budget is in balloting phase and there are voted investments, it was not possible to print budgets investments because the ballot was never being loaded in the controller and therefore an error was raised when rendering the view.
```
Failure/Error: <% if ballot.has_investment?(investment) %>

  ActionView::Template::Error:
    undefined method `has_investment?' for nil:NilClass
      app/views/budgets/investments/_ballot.html.erb:3
      app/views/budgets/investments/_investment.html.erb:88
      app/views/custom/management/budgets/investments/print.html.erb:26
```

## Does this PR need a Backport to CONSUL?

Yes 😄 