### PR TITLE
Increase poll stats performance

### DIFF
--- a/app/models/poll/stats.rb
+++ b/app/models/poll/stats.rb
@@ -104,11 +104,11 @@ class Poll::Stats
   private
 
     def participant_ids
-      voters.pluck(:user_id)
+      voters
     end
 
     def voters
-      @voters ||= poll.voters
+      @voters ||= poll.voters.select(:user_id)
     end
 
     def recounts


### PR DESCRIPTION
## References

* Pull request #1951

## Objectives

Use SQL's `select` instead of Ruby's  `pluck` to calculate unique voters faster.

## Notes

* With this change, performance increases dramatically when there are thousands of records. For a poll with 200000 voters, calculating stats used to take more than 7 minutes on our preproduction server, and now it takes less than 2 minutes.

## Does this PR need a Backport to CONSUL?

Yes, backport alongside everything related to stats.