### PR TITLE
Update texts on check my ballot links

### DIFF
--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -1166,6 +1166,11 @@
       text-decoration: none;
     }
 
+    .confirmed {
+      font-size: rem-calc(24);
+      font-weight: bold;
+    }
+
     .info {
       background: #6a2a72;
 

--- a/app/views/budgets/ballot/_ballot.html.erb
+++ b/app/views/budgets/ballot/_ballot.html.erb
@@ -9,11 +9,10 @@
         <%= t("budgets.ballots.show.voted_html",
             count: @ballot.investments.count) %>
       </h2>
+      <p class="confirmed">
+        <%= t("budgets.ballots.show.voted_info_html") %>
       <p>
-        <small>
-          <%= t("budgets.ballots.show.voted_info_html") %>
-        </small>
-      </p>
+      <p><%= t("budgets.ballots.show.voted_info_2") %></p>
     </div>
   </div>
 </div>

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -72,4 +72,8 @@
       <% end %>
     <% end %>
   </ul>
+
+  <%= link_to t("budgets.investments.header.check_ballot"),
+                budget_ballot_path(@budget),
+                class: "button hollow expanded" %>
 <% end %>

--- a/config/locales/en/budgets.yml
+++ b/config/locales/en/budgets.yml
@@ -10,7 +10,8 @@ en:
         voted_html:
           one: "You have voted <span>one</span> investment."
           other: "You have voted <span>%{count}</span> investments."
-        voted_info_html: "You can change your vote at any time until the close of this phase.<br> No need to spend all the money available."
+        voted_info_html: "Your ballot is confirmed!"
+        voted_info_2: "But you can change your vote at any time until this phase is closed."
         zero: You have not voted any investment project.
       reasons_for_not_balloting:
         not_logged_in: You must %{signin} or %{signup} to continue.
@@ -91,7 +92,7 @@ en:
           voted_info_link: change your vote
           different_heading_assigned_html: "You have active votes in another heading: %{heading_link}"
           change_ballot: "If your change your mind you can remove your votes in %{check_ballot} and start again."
-          check_ballot_link: "check my ballot"
+          check_ballot_link: "check and confirm my ballot"
           zero: You have not voted any investment project in this group.
           verified_only: "To create a new budget investment %{verify}."
           verify_account: "verify your account"
@@ -143,10 +144,10 @@ en:
           zero: No supports
         give_support: Support
       header:
-        check_ballot: Check my ballot
+        check_ballot: Check and confirm my ballot
         different_heading_assigned_html: "You have active votes in another heading: %{heading_link}"
         change_ballot: "If your change your mind you can remove your votes in %{check_ballot} and start again."
-        check_ballot_link: "check my ballot"
+        check_ballot_link: "check and confirm my ballot"
         price: "This heading has a budget of"
     progress_bar:
       assigned: "You have assigned: "

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -10,7 +10,8 @@ es:
         voted_html:
           one: "Has votado <span>un</span> proyecto."
           other: "Has votado <span>%{count}</span> proyectos."
-        voted_info_html: "Puedes cambiar tus votos en cualquier momento hasta el cierre de esta fase.<br> No hace falta que gastes todo el dinero disponible."
+        voted_info_html: "¡Tus votos están confirmados!"
+        voted_info_2: "Pero puedes cambiarlos en cualquier momento hasta el cierre de esta fase."
         zero: Todavía no has votado ningún proyecto de gasto.
       reasons_for_not_balloting:
         not_logged_in: Necesitas %{signin} o %{signup} para continuar.
@@ -91,7 +92,7 @@ es:
           voted_info_link: cambiar tus votos
           different_heading_assigned_html: "Ya apoyaste proyectos de otra sección del presupuesto: %{heading_link}"
           change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
-          check_ballot_link: "revisar mis votos"
+          check_ballot_link: "revisar y confirmar mis votos"
           zero: Todavía no has votado ningún proyecto de gasto en este ámbito del presupuesto.
           verified_only: "Para crear un nuevo proyecto de gasto %{verify}."
           verify_account: "verifica tu cuenta"
@@ -143,10 +144,10 @@ es:
           other: "%{count} apoyos"
         give_support: Apoyar
       header:
-        check_ballot: Revisar mis votos
+        check_ballot: Revisar y confirmar mis votos
         different_heading_assigned_html: "Ya apoyaste proyectos de otra sección del presupuesto: %{heading_link}"
         change_ballot: "Si cambias de opinión puedes borrar tus votos en %{check_ballot} y volver a empezar."
-        check_ballot_link: "revisar mis votos"
+        check_ballot_link: "revisar y confirmar mis votos"
         price: "Esta partida tiene un presupuesto de"
     progress_bar:
       assigned: "Has asignado: "

--- a/spec/features/budgets/ballots_spec.rb
+++ b/spec/features/budgets/ballots_spec.rb
@@ -166,6 +166,7 @@ feature "Ballots" do
         within("#sidebar") do
           expect(page).to have_content investment1.title
           expect(page).to have_content "€10,000"
+          expect(page).to have_link("Check and confirm my ballot")
         end
 
         add_to_ballot(investment2)
@@ -176,6 +177,7 @@ feature "Ballots" do
         within("#sidebar") do
           expect(page).to have_content investment2.title
           expect(page).to have_content "€20,000"
+          expect(page).to have_link("Check and confirm my ballot")
         end
       end
 
@@ -195,6 +197,7 @@ feature "Ballots" do
         within("#sidebar") do
           expect(page).to have_content investment.title
           expect(page).to have_content "€10,000"
+          expect(page).to have_link("Check and confirm my ballot")
         end
 
         within("#budget_investment_#{investment.id}") do
@@ -207,6 +210,7 @@ feature "Ballots" do
         within("#sidebar") do
           expect(page).not_to have_content investment.title
           expect(page).not_to have_content "€10,000"
+          expect(page).to have_link("Check and confirm my ballot")
         end
       end
 
@@ -504,7 +508,9 @@ feature "Ballots" do
     visit budget_investments_path(budget, heading_id: new_york.id)
     add_to_ballot(investment)
 
-    click_link "Check my ballot"
+    within(".budget-heading") do
+      click_link "Check and confirm my ballot"
+    end
 
     expect(page).to have_content("You have voted one investment")
 

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -980,10 +980,12 @@ feature "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      expect(page).not_to have_link("Check my ballot")
+      expect(page).not_to have_link("Check and confirm my ballot")
       expect(page).not_to have_css("#progress_bar")
+
       within("#sidebar") do
         expect(page).not_to have_content("My ballot")
+        expect(page).not_to have_link("Check and confirm my ballot")
       end
     end
 
@@ -1617,7 +1619,8 @@ feature "Budget Investments" do
 
       visit budget_ballot_path(budget)
 
-      expect(page).to have_content "You can change your vote at any time until the close of this phase"
+      expect(page).to have_content "But you can change your vote at any time "\
+                                   "until this phase is closed."
 
       within("#budget_group_#{global_group.id}") do
         expect(page).to have_content sp1.title
@@ -1680,10 +1683,12 @@ feature "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      expect(page).to have_link("Check my ballot")
+      expect(page).to have_link("Check and confirm my ballot")
       expect(page).to have_css("#progress_bar")
+
       within("#sidebar") do
         expect(page).to have_content("My ballot")
+        expect(page).to have_link("Check and confirm my ballot")
       end
     end
 


### PR DESCRIPTION
## References

Upstream from https://github.com/consul/consul/pull/3407

## Objectives

Update texts on check my ballot links to clarify to users that their ballot (votes) are confirmed.

## Visual Changes

<img width="1206" alt="ballot_1" src="https://user-images.githubusercontent.com/631897/54943020-acf0d680-4f30-11e9-8e6e-6907f45dd636.png">

<img width="326" alt="ballot_2" src="https://user-images.githubusercontent.com/631897/54943066-c4c85a80-4f30-11e9-8a3b-d626e14e75da.png">

<img width="1051" alt="ballot_3" src="https://user-images.githubusercontent.com/631897/54943026-b11cf400-4f30-11e9-9288-119c95d935b2.png">