### PR TITLE
Move poll ballot factories to main files

### DIFF
--- a/spec/factories/custom.rb
+++ b/spec/factories/custom.rb
@@ -4,17 +4,6 @@ FactoryBot.define do
     poll
   end
 
-  factory :poll_ballot_sheet, class: "Poll::BallotSheet" do
-    association :poll
-    association :officer_assignment, factory: :poll_officer_assignment
-    data "1234;9876;5678\n1000;2000;3000;9999"
-  end
-
-  factory :poll_ballot, class: "Poll::Ballot" do
-    association :ballot_sheet, factory: :poll_ballot_sheet
-    data "1,2,3"
-  end
-
   factory :volunteer_poll do
     sequence(:email)      { |n| "volunteer#{n}@consul.dev" }
     sequence(:first_name) { |n| "volunteer#{n} first name" }

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -153,6 +153,17 @@ FactoryBot.define do
     end
   end
 
+  factory :poll_ballot_sheet, class: "Poll::BallotSheet" do
+    association :poll
+    association :officer_assignment, factory: :poll_officer_assignment
+    data "1234;9876;5678\n1000;2000;3000;9999"
+  end
+
+  factory :poll_ballot, class: "Poll::Ballot" do
+    association :ballot_sheet, factory: :poll_ballot_sheet
+    data "1,2,3"
+  end
+
   factory :officing_residence, class: "Officing::Residence" do
     user
     association :officer, factory: :poll_officer


### PR DESCRIPTION
## References

* Pull request consul#2857
* Pull request consul#2858

## Objectives

* Move code which used to be custom and is now present in CONSUL to the main folder files.
* Reduce differences between CONSUL's and Madrid's codebases.

## Does this PR need a Backport to CONSUL?

No, the code is already there.