### PR TITLE
Simplify custom budget routes usage

### DIFF
--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -80,7 +80,7 @@
 
       <% if @budget.has_winning_investments? %>
         <%= link_to t("budgets.show.see_results"),
-                    custom_budget_results_path(@budget),
+                    budget_results_path(@budget),
                     class: "button hollow margin-left" %>
       <% end %>
       <% if @budget.persisted? %>

--- a/app/views/budgets/executions/show.html.erb
+++ b/app/views/budgets/executions/show.html.erb
@@ -29,13 +29,13 @@
   <div class="small-12 column">
     <ul class="tabs">
       <li class="tabs-title">
-        <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget) %>
+        <%= link_to t("budgets.results.link"), budget_results_path(@budget) %>
       </li>
       <li class="tabs-title">
-        <%= link_to t("stats.budgets.link"), custom_budget_stats_path(@budget) %>
+        <%= link_to t("stats.budgets.link"), budget_stats_path(@budget) %>
       </li>
       <li class="tabs-title is-active">
-        <%= link_to t("budgets.executions.link"), custom_budget_executions_path(@budget), class: 'is-active' %>
+        <%= link_to t("budgets.executions.link"), budget_executions_path(@budget), class: 'is-active' %>
       </li>
     </ul>
   </div>
@@ -56,7 +56,7 @@
   </div>
 
   <div class="small-12 medium-9 large-10 column">
-    <%= form_tag(custom_budget_executions_path(@budget), method: :get) do %>
+    <%= form_tag(budget_executions_path(@budget), method: :get) do %>
       <div class="small-12 medium-3 column">
         <%= label_tag :status, t("budgets.executions.filters.label") %>
         <%= select_tag :status,

--- a/app/views/budgets/results/show.html.erb
+++ b/app/views/budgets/results/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :meta_description do %><%= @budget.description_for_phase('finished') %><% end %>
 <% provide :social_media_meta_tags do %>
 <%= render "shared/social_media_meta_tags",
-            social_url: custom_budget_results_url(@budget),
+            social_url: budget_results_url(@budget),
             social_title: @budget.name,
             social_description: @budget.description_for_phase('finished'),
             twitter_image_url: 'social_budget_2018_results_twitter.png',
@@ -32,13 +32,13 @@
     <ul class="tabs">
       <li class="tabs-title is-active">
         <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-        <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget), class: "is-active" %>
+        <%= link_to t("budgets.results.link"), budget_results_path(@budget), class: "is-active" %>
       </li>
       <li class="tabs-title">
-        <%= link_to t("stats.budgets.link"), custom_budget_stats_path(@budget) %>
+        <%= link_to t("stats.budgets.link"), budget_stats_path(@budget) %>
       </li>
       <li class="tabs-title">
-        <%= link_to t("budgets.executions.link"), custom_budget_executions_path(@budget) %>
+        <%= link_to t("budgets.executions.link"), budget_executions_path(@budget) %>
       </li>
     </ul>
   </div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -43,7 +43,7 @@
 
       <% if @budget.finished? %>
         <%= link_to t("budgets.show.see_results"),
-                  custom_budget_results_path(@budget),
+                  budget_results_path(@budget),
                   class: "button margin-top expanded" %>
       <% end %>
     </div>

--- a/app/views/budgets/stats/show.html.erb
+++ b/app/views/budgets/stats/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% provide :social_media_meta_tags do %>
 <%= render "shared/social_media_meta_tags",
-            social_url: custom_budget_stats_url(@budget),
+            social_url: budget_stats_url(@budget),
             social_title: @budget.name,
             social_description: @budget.description_for_phase('finished'),
             twitter_image_url: 'social_budget_2018_stats_twitter.png',
@@ -28,13 +28,13 @@
       <ul class="tabs">
         <li class="tabs-title">
           <span class="show-for-sr"><%= t("shared.you_are_in") %></span>
-          <%= link_to t("budgets.results.link"), custom_budget_results_path(@budget) %>
+          <%= link_to t("budgets.results.link"), budget_results_path(@budget) %>
         </li>
         <li class="tabs-title is-active">
-          <%= link_to t("stats.budgets.link"), custom_budget_stats_path(@budget), class: "is-active" %>
+          <%= link_to t("stats.budgets.link"), budget_stats_path(@budget), class: "is-active" %>
         </li>
         <li class="tabs-title">
-          <%= link_to t("budgets.executions.link"), custom_budget_executions_path(@budget) %>
+          <%= link_to t("budgets.executions.link"), budget_executions_path(@budget) %>
         </li>
       </ul>
     </div>

--- a/app/views/custom/admin/budget_investments/index.html.erb
+++ b/app/views/custom/admin/budget_investments/index.html.erb
@@ -1,7 +1,7 @@
 <% if @budget.has_winning_investments? %>
   <div class="float-right">
     <%= link_to t("admin.budget_investments.index.see_results"),
-                custom_budget_results_path(@budget),
+                budget_results_path(@budget),
                 class: "button hollow medium", target: "_blank" %>
   </div>
 <% end %>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -64,7 +64,7 @@
 
         <% if current_budget.finished? %>
           <%= link_to t("budgets.show.see_results"),
-                      custom_budget_results_path(current_budget),
+                      budget_results_path(current_budget),
                       class: "button margin-top expanded" %>
         <% end %>
       </div>
@@ -155,12 +155,12 @@
                     <div class="small-12 medium-6 column table" data-equalizer-watch>
                       <div id="budget_<%= budget.id %>_results" class="table-cell align-middle">
                         <%= link_to t("budgets.index.see_results"),
-                                    custom_budget_results_path(budget),
+                                    budget_results_path(budget),
                                     class: "button" %>
                         
                         <% unless budget.name == "Presupuestos Participativos 2018" %>
                           <%= link_to t("budgets.index.milestones"),
-                                      custom_budget_executions_path(budget, status: 1),
+                                      budget_executions_path(budget, status: 1),
                                       class: "button" %>
                         <% end %>
                       </div>

--- a/app/views/custom/pages/help/budgets/_welcome_header_finished.html.erb
+++ b/app/views/custom/pages/help/budgets/_welcome_header_finished.html.erb
@@ -12,7 +12,7 @@
         <div class="row margin-top">
           <div class="small-12 medium-6 column">
             <%= link_to t("budgets.show.see_results"),
-                        custom_budget_results_path(current_budget),
+                        budget_results_path(current_budget),
                         class: "button expanded large city" %>
           </div>
           <div class="small-12 medium-6 column">

--- a/app/views/custom/pages/help/budgets/_welcome_header_reviewing.html.erb
+++ b/app/views/custom/pages/help/budgets/_welcome_header_reviewing.html.erb
@@ -34,7 +34,7 @@
         </div>
         <div class="small-12 medium-3 column">
           <%= link_to "Estadísticas de participación",
-                      custom_budget_stats_path(id: current_budget.to_param),
+                      budget_stats_path(id: current_budget.to_param),
                       class: "button expanded stats" %>
         </div>
         <div class="small-12 medium-3 column">

--- a/config/routes/custom.rb
+++ b/config/routes/custom.rb
@@ -17,9 +17,9 @@ end
 
 ### Budgets
 get 'presupuestos',                         to: 'budgets#index', id: 'help/budgets/welcome',    as: 'budgets_welcome'
-get "presupuestos/:budget_id/estadisticas", to: "budgets/stats#show", as: 'custom_budget_stats'
-get "presupuestos/:budget_id/resultados",   to: "budgets/results#show", as: 'custom_budget_results'
-get 'presupuestos/:budget_id/ejecuciones',  to: 'budgets/executions#show', as: 'custom_budget_executions'
+get "presupuestos/:budget_id/estadisticas", to: "budgets/stats#show", as: "budget_stats"
+get "presupuestos/:budget_id/resultados",   to: "budgets/results#show", as: "budget_results"
+get "presupuestos/:budget_id/ejecuciones",  to: 'budgets/executions#show', as: "budget_executions"
 get "presupuestos/:budget_id/resultados/:heading_id", to: "budgets/results#show", as: 'custom_budget_heading_result'
 
 resources :budgets, only: [:show, :index], path: 'presupuestos' do

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -14,10 +14,10 @@ feature "Executions" do
   scenario "finds budget by id or slug" do
     budget.update(slug: "budget_slug")
 
-    visit custom_budget_executions_path("budget_slug")
+    visit budget_executions_path("budget_slug")
     within(".budgets-stats") { expect(page).to have_content budget.name }
 
-    visit custom_budget_executions_path(budget)
+    visit budget_executions_path(budget)
     within(".budgets-stats") { expect(page).to have_content budget.name }
 
     visit budget_executions_path("budget_slug")
@@ -252,7 +252,7 @@ feature "Executions" do
       city_heading   = create_heading_with_investment_with_milestone(:city_heading, group: group)
       other_heading2 = create_heading_with_investment_with_milestone(group: group)
 
-      visit custom_budget_executions_path(budget)
+      visit budget_executions_path(budget)
 
       expect(page).to have_css(".budget-execution", count: 3)
       expect(city_heading.name).to appear_before(other_heading1.name)
@@ -265,7 +265,7 @@ feature "Executions" do
       a_heading = create_heading_with_investment_with_milestone(group: group, name: "Aaa")
       m_heading = create_heading_with_investment_with_milestone(group: group, name: "Mmm")
 
-      visit custom_budget_executions_path(budget)
+      visit budget_executions_path(budget)
 
       expect(page).to have_css(".budget-execution", count: 3)
       expect(a_heading.name).to appear_before(m_heading.name)
@@ -280,7 +280,7 @@ feature "Executions" do
       unpublished_milestone = create(:milestone, milestoneable: investment1,
                                      status: status, publication_date: Date.tomorrow)
 
-      visit custom_budget_executions_path(budget, status: status.id)
+      visit budget_executions_path(budget, status: status.id)
 
       expect(page).to have_content("No winner investments in this state")
     end

--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -53,13 +53,13 @@ feature "Results" do
   end
 
   scenario "Does not raise error if budget (slug or id) is not found" do
-    visit custom_budget_results_path("wrong budget")
+    visit budget_results_path("wrong budget")
 
     within(".budgets-stats") do
       expect(page).to have_content "Results"
     end
 
-    visit custom_budget_results_path(0)
+    visit budget_results_path(0)
 
     within(".budgets-stats") do
       expect(page).to have_content "Results"
@@ -67,7 +67,7 @@ feature "Results" do
   end
 
   scenario "Loads budget and heading by slug" do
-    visit custom_budget_results_path(budget.slug, heading.slug)
+    visit budget_results_path(budget.slug, heading.slug)
 
     expect(page).to have_selector("a.is-active", text: heading.name)
 
@@ -85,7 +85,7 @@ feature "Results" do
 
     allow_any_instance_of(Budget).to receive(:city_heading).and_return(city_heading)
 
-    visit custom_budget_results_path(budget)
+    visit budget_results_path(budget)
 
     within("#budget-investments-compatible") do
       expect(page).to have_content city_investment.title
@@ -99,7 +99,7 @@ feature "Results" do
 
     allow_any_instance_of(Budget).to receive(:city_heading).and_return(nil)
 
-    visit custom_budget_results_path(budget)
+    visit budget_results_path(budget)
 
     within("#budget-investments-compatible") do
       expect(page).to have_content investment1.title

--- a/spec/routing/custom/routing_spec.rb
+++ b/spec/routing/custom/routing_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+describe "Custom routes" do
+  describe "custom budget stats route" do
+    it "recognizes standard routes" do
+      expect(get: "/budgets/1/stats").to route_to(
+        controller: "budgets/stats", action: "show", budget_id: "1"
+      )
+    end
+
+    it "recognizes custom routes" do
+      expect(get: "/presupuestos/presupuestos-2018/estadisticas").to route_to(
+        controller: "budgets/stats", action: "show", budget_id: "presupuestos-2018"
+      )
+    end
+
+    it "generates custom routes" do
+      budget = create(:budget, slug: "presupuestos-2018")
+
+      expect(budget_stats_path(budget)).to eq "/presupuestos/presupuestos-2018/estadisticas"
+    end
+  end
+
+  describe "custom budget results route" do
+    it "recognizes standard routes" do
+      expect(get: "/budgets/1/results").to route_to(
+        controller: "budgets/results", action: "show", budget_id: "1"
+      )
+    end
+
+    it "recognizes custom routes" do
+      expect(get: "/presupuestos/presupuestos-2018/resultados").to route_to(
+        controller: "budgets/results", action: "show", budget_id: "presupuestos-2018"
+      )
+    end
+
+    it "generates custom routes" do
+      budget = create(:budget, slug: "presupuestos-2018")
+
+      expect(budget_results_path(budget)).to eq "/presupuestos/presupuestos-2018/resultados"
+    end
+  end
+
+  describe "custom budget executions route" do
+    it "recognizes standard routes" do
+      expect(get: "/budgets/1/executions").to route_to(
+        controller: "budgets/executions", action: "show", budget_id: "1"
+      )
+    end
+
+    it "recognizes custom routes" do
+      expect(get: "/presupuestos/presupuestos-2018/ejecuciones").to route_to(
+        controller: "budgets/executions", action: "show", budget_id: "presupuestos-2018"
+      )
+    end
+
+    it "generates custom routes" do
+      budget = create(:budget, slug: "presupuestos-2018")
+
+      expect(budget_executions_path(budget)).to eq "/presupuestos/presupuestos-2018/ejecuciones"
+    end
+  end
+end


### PR DESCRIPTION
## Objectives

Reduce differences between CONSUL and Madrid's repositories by using route helpers like `budget_stats_path` instead of `custom_budget_stats_path`.

## Does this PR need a Backport to CONSUL?

No, it only affects custom code.