### PR TITLE
Update recent model and migration files

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -65,7 +65,6 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     end
 
     def poll_params
-      image_attributes = [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
       attributes = [:name, :starts_at, :ends_at, :geozone_restricted, :results_enabled,
                     :stats_enabled, :budget_id, geozone_ids: [],
                     image_attributes: image_attributes]

--- a/app/models/stats_version.rb
+++ b/app/models/stats_version.rb
@@ -1,4 +1,4 @@
-class StatsVersion < ActiveRecord::Base
+class StatsVersion < ApplicationRecord
   validates :process, presence: true
 
   belongs_to :process, polymorphic: true

--- a/db/migrate/20190311215516_destroy_spending_proposals.rb
+++ b/db/migrate/20190311215516_destroy_spending_proposals.rb
@@ -1,4 +1,4 @@
-class DestroySpendingProposals < ActiveRecord::Migration
+class DestroySpendingProposals < ActiveRecord::Migration[4.2]
   def change
     drop_table :spending_proposals
   end

--- a/db/migrate/20190311220350_destroy_spending_proposal_ballots.rb
+++ b/db/migrate/20190311220350_destroy_spending_proposal_ballots.rb
@@ -1,4 +1,4 @@
-class DestroySpendingProposalBallots < ActiveRecord::Migration
+class DestroySpendingProposalBallots < ActiveRecord::Migration[4.2]
   def change
     drop_table :ballot_lines
     drop_table :ballots

--- a/db/migrate/20190311220600_destroy_spending_proposal_delegation.rb
+++ b/db/migrate/20190311220600_destroy_spending_proposal_delegation.rb
@@ -1,4 +1,4 @@
-class DestroySpendingProposalDelegation < ActiveRecord::Migration
+class DestroySpendingProposalDelegation < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :representative_id
     remove_column :users, :accepted_delegation_alert

--- a/db/migrate/20190311220711_destroy_spending_proposal_valuations.rb
+++ b/db/migrate/20190311220711_destroy_spending_proposal_valuations.rb
@@ -1,4 +1,4 @@
-class DestroySpendingProposalValuations < ActiveRecord::Migration
+class DestroySpendingProposalValuations < ActiveRecord::Migration[4.2]
   def change
     drop_table :valuation_assignments
   end

--- a/db/migrate/20190326210351_destroy_spending_proposal_supports.rb
+++ b/db/migrate/20190326210351_destroy_spending_proposal_supports.rb
@@ -1,4 +1,4 @@
-class DestroySpendingProposalSupports < ActiveRecord::Migration
+class DestroySpendingProposalSupports < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :district_wide_spending_proposals_supported_count
     remove_column :users, :city_wide_spending_proposals_supported_count

--- a/db/migrate/20190326211832_destroy_spending_proposal_associations.rb
+++ b/db/migrate/20190326211832_destroy_spending_proposal_associations.rb
@@ -1,4 +1,4 @@
-class DestroySpendingProposalAssociations < ActiveRecord::Migration
+class DestroySpendingProposalAssociations < ActiveRecord::Migration[4.2]
   def change
     remove_column :budget_investments, :original_spending_proposal_id
     remove_column :tags, :spending_proposals_count

--- a/db/migrate/20190408133956_create_stats_versions.rb
+++ b/db/migrate/20190408133956_create_stats_versions.rb
@@ -1,4 +1,4 @@
-class CreateStatsVersions < ActiveRecord::Migration
+class CreateStatsVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :stats_versions do |t|
       t.references :process, polymorphic: true, index: true


### PR DESCRIPTION
## References

* Pull request #1947
* Pull request #1937
* Pull request #1951

## Objectives

Upgrade migration and model files in order to follow Rails 5 inheritance conventions. These migrations and models were created shortly before updating to Rails 5, and so the migrations didn't have the version number and the models inherited from `ActiveRecord::Base` instead of `ApplicationRecord`.

## Does this PR need a Backport to CONSUL?

Yes, backport when backporting the pull requests which generated these migrations.