### PR TITLE
Handle AccessDenied in management sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include HasFilters
   include HasOrders
   include Analytics
+  include AccessDeniedHandler
 
   protect_from_forgery with: :exception
 
@@ -17,19 +18,6 @@ class ApplicationController < ActionController::Base
 
   check_authorization unless: :devise_controller?
   self.responder = ApplicationResponder
-
-  rescue_from CanCan::AccessDenied do |exception|
-    respond_to do |format|
-      format.html {
-        if current_user && current_user.officing_voter?
-          redirect_to new_officing_session_path
-        else
-          redirect_to main_app.root_url, alert: exception.message
-        end
-      }
-      format.json { render json: {error: exception.message}, status: :forbidden }
-    end
-  end
 
   layout :set_layout
   respond_to :html

--- a/app/controllers/concerns/access_denied_handler.rb
+++ b/app/controllers/concerns/access_denied_handler.rb
@@ -1,0 +1,21 @@
+module AccessDeniedHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from CanCan::AccessDenied do |exception|
+      respond_to do |format|
+        format.html do
+          if current_user && current_user.officing_voter?
+            redirect_to new_officing_session_path
+          else
+            redirect_to main_app.root_url, alert: exception.message
+          end
+        end
+
+        format.json do
+          render json: { error: exception.message }, status: :forbidden
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/management/sessions_controller.rb
+++ b/app/controllers/management/sessions_controller.rb
@@ -1,6 +1,7 @@
 require "manager_authenticator"
 
 class Management::SessionsController < ActionController::Base
+  include AccessDeniedHandler
 
   def create
     destroy_session

--- a/spec/controllers/management/sessions_controller_spec.rb
+++ b/spec/controllers/management/sessions_controller_spec.rb
@@ -3,11 +3,13 @@ require "rails_helper"
 describe Management::SessionsController do
 
   describe "Sign in" do
+
     it "denies access if wrong manager credentials" do
       allow_any_instance_of(ManagerAuthenticator).to receive(:auth).and_return(false)
-      expect {
-        get :create, params: { login: "nonexistent", clave_usuario: "wrong" }
-      }.to raise_error CanCan::AccessDenied
+      get :create, params: { login: "nonexistent", clave_usuario: "wrong" }
+
+      expect(response).to redirect_to "/"
+      expect(flash[:alert]).to eq "You do not have permission to access this page."
       expect(session[:manager]).to be_nil
     end
 
@@ -42,7 +44,10 @@ describe Management::SessionsController do
 
     it "denies access if user is not admin or manager" do
       sign_in create(:user)
-      expect { get :create}.to raise_error CanCan::AccessDenied
+      get :create
+
+      expect(response).to redirect_to "/"
+      expect(flash[:alert]).to eq "You do not have permission to access this page."
       expect(session[:manager]).to be_nil
     end
   end


### PR DESCRIPTION
## Objectives

Don't generate a 500 Internal Server Error when trying to access the management sign in page without proper authorization.

## Does this PR need a Backport to CONSUL?

Yes.

## Notes

I've chosen to do the same thing we do in the ApplicationController. There are other options to handle this request, like redirecting to the login page or returning a 401 Unauthorized HTTP status.