### PR TITLE
Fix accessing recommendations without signing in 

### DIFF
--- a/app/controllers/budgets/recommendations_controller.rb
+++ b/app/controllers/budgets/recommendations_controller.rb
@@ -41,7 +41,7 @@ module Budgets
     private
 
       def load_user
-        @user = params[:user_id].present? ? User.find(params[:user_id]) : current_user
+        @user = params[:user_id].present? ? User.find(params[:user_id]) : authenticate_user!
       end
 
       def load_budget

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -198,7 +198,7 @@ FactoryBot.define do
   end
 
   factory :budget_recommendation, class: "Budget::Recommendation" do
-    budget
+    budget { investment.budget }
     association :investment, factory: :budget_investment
     user
   end

--- a/spec/features/budgets/recommendation_spec.rb
+++ b/spec/features/budgets/recommendation_spec.rb
@@ -98,9 +98,9 @@ feature "Recommendations" do
     investment2 = create(:budget_investment, heading: heading)
     investment3 = create(:budget_investment, heading: heading)
 
-    recommendation1 = create(:budget_recommendation, user: user1, investment: investment1, budget: heading.budget)
-    recommendation2 = create(:budget_recommendation, user: user1, investment: investment2, budget: heading.budget)
-    recommendation3 = create(:budget_recommendation, user: user2, investment: investment3, budget: heading.budget)
+    recommendation1 = create(:budget_recommendation, user: user1, investment: investment1)
+    recommendation2 = create(:budget_recommendation, user: user1, investment: investment2)
+    recommendation3 = create(:budget_recommendation, user: user2, investment: investment3)
 
     login_as(user2)
     visit user_path(user1)
@@ -119,7 +119,7 @@ feature "Recommendations" do
     user2 = create(:user, :level_two)
 
     investment = create(:budget_investment, :feasible)
-    create(:budget_recommendation, budget_id: investment.budget_id, investment: investment, user: user1)
+    create(:budget_recommendation, investment: investment, user: user1)
     investment.budget.update(phase: "selecting")
 
     login_as(user2)
@@ -143,7 +143,7 @@ feature "Recommendations" do
     investment = create(:budget_investment, :selected)
     budget = investment.budget
     budget.update!(phase: "balloting")
-    create(:budget_recommendation, budget_id: investment.budget_id, investment: investment, user: user1, phase: "balloting")
+    create(:budget_recommendation, investment: investment, user: user1, phase: "balloting")
 
     login_as(user2)
     visit user_path(user1)

--- a/spec/features/budgets/recommendation_spec.rb
+++ b/spec/features/budgets/recommendation_spec.rb
@@ -25,6 +25,30 @@ feature "Recommendations" do
       end.to raise_error ActiveRecord::RecordNotFound
     end
 
+    scenario "without a user id shows recommendations for current user" do
+      create(:budget_recommendation,
+             user: user,
+             investment: create(:budget_investment, budget: budget, description: "More Festivals!")
+      )
+
+      create(:budget_recommendation,
+             user: create(:user),
+             investment: create(:budget_investment, budget: budget, description: "Less Festivals!")
+      )
+
+      login_as(user)
+      visit budget_recommendations_path(budget)
+
+      expect(page).to have_content "More Festivals!"
+      expect(page).not_to have_content "Less Festivals!"
+    end
+
+    scenario "without a user id redirects to sign in if user isn't authenticated" do
+      visit budget_recommendations_path(budget)
+
+      expect(page).to have_current_path new_user_session_path
+      expect(page).to have_content "You must sign in or register to continue"
+    end
   end
 
   scenario "Create by phase" do


### PR DESCRIPTION
## Objectives

Fix an exception taking place when accessing budget recommendations without signing in and without providing a user id.

## Does this PR need a Backport to CONSUL?

No, unless we decide to backport #702
