### PR TITLE
Stub city heading in specs

### DIFF
--- a/spec/features/budgets/results_spec.rb
+++ b/spec/features/budgets/results_spec.rb
@@ -166,15 +166,20 @@ feature "Results" do
     context "headings" do
 
       scenario "Displays headings ordered by name with city heading first" do
+        allow_any_instance_of(Budget::Heading).to receive(:city_heading?) do |heading|
+          heading.name == "City of New York"
+        end
+
         budget.update(phase: "finished")
 
+        city_group = create(:budget_group, budget: budget)
         district_group = create(:budget_group, budget: budget)
+
         create(:budget_heading, group: district_group, name: "Brooklyn")
         create(:budget_heading, group: district_group, name: "Queens")
         create(:budget_heading, group: district_group, name: "Manhattan")
 
-        city_group = create(:budget_group, budget: budget)
-        city_heading = create(:budget_heading, group: city_group, name: "City of New York")
+        create(:budget_heading, group: city_group, name: "City of New York")
 
         visit budget_results_path(budget)
 

--- a/spec/features/budgets/stats_spec.rb
+++ b/spec/features/budgets/stats_spec.rb
@@ -50,15 +50,20 @@ feature "Stats" do
     context "headings" do
 
       scenario "Displays headings ordered by name with city heading first" do
+        allow_any_instance_of(Budget::Heading).to receive(:city_heading?) do |heading|
+          heading.name == "City of New York"
+        end
+
         budget.update(phase: "finished")
 
+        city_group = create(:budget_group, budget: budget)
         district_group = create(:budget_group, budget: budget)
+
         create(:budget_heading, group: district_group, name: "Brooklyn")
         create(:budget_heading, group: district_group, name: "Queens")
         create(:budget_heading, group: district_group, name: "Manhattan")
 
-        city_group = create(:budget_group, budget: budget)
-        city_heading = create(:budget_heading, group: city_group, name: "City of New York")
+        create(:budget_heading, group: city_group, name: "City of New York")
 
         visit budget_stats_path(budget)
 


### PR DESCRIPTION
## References

* Commit 597542ad
* Commit 1a3dd780
* [Travis build 11450, job 7](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/524019245)

## Objectives

Stub the `city_heading?` method in tests which are testing for city heading, so these tests don't return results order alphabetically and so they don't fail sometimes depending on the ID of the created budget groups.

## Does this PR need a Backport to CONSUL?

No, there's no "city heading" code there.