### PR TITLE
Dashboard UI improvements

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -589,7 +589,6 @@
 
     p {
       font-size: rem-calc(18);
-      max-width: 60%;
       margin: 0 auto;
     }
 
@@ -655,7 +654,7 @@
     font-size: rem-calc(19);
     margin-top: rem-calc(50);
     padding-left: rem-calc(40);
-    width: 50%;
+    width: 75%;
   }
 }
 
@@ -740,9 +739,9 @@
 
   .poster-footer {
     display: block;
-    margin-left: 15cm;
+    margin-left: 10cm;
     margin-top: 2cm;
-    max-width: 55%;
+    max-width: 75%;
     padding-left: 4cm;
   }
 }

--- a/app/controllers/admin/dashboard/actions_controller.rb
+++ b/app/controllers/admin/dashboard/actions_controller.rb
@@ -24,7 +24,9 @@ class Admin::Dashboard::ActionsController < Admin::Dashboard::BaseController
     end
   end
 
-  def edit; end
+  def edit
+    dashboard_action
+  end
 
   def update
     if dashboard_action.update(dashboard_action_params)

--- a/app/helpers/admin/proposal_dashboard_actions_helper.rb
+++ b/app/helpers/admin/proposal_dashboard_actions_helper.rb
@@ -7,4 +7,8 @@ module Admin::ProposalDashboardActionsHelper
   def default_actions
     %w[polls email poster]
   end
+
+  def css_for_resource(action)
+    "hide" if action == "proposed_action"
+  end
 end

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -48,7 +48,7 @@ module ProposalsDashboardHelper
     controller_name == "dashboard" && action_name == "new_request" && dashboard_action&.id == id
   end
 
-  def resoure_availability_label(resource)
+  def resource_availability_label(resource)
     label = []
 
     label << t("dashboard.resource.required_days",

--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -16,9 +16,10 @@
     <%= f.check_box :active, label: ::Dashboard::Action.human_attribute_name(:active) %>
   </div>
 
-  <div id="request_to_administrators" class="small-12 column margin-bottom hide"
-                                      data-toggler=".hide">
-    <%= f.check_box :request_to_administrators, label: ::Dashboard::Action.human_attribute_name(:request_to_administrators) %>
+  <div id="request_to_administrators"
+       class="small-12 column margin-bottom <%= css_for_resource(@dashboard_action.action_type) %>"
+       data-toggler=".hide">
+    <%= f.check_box :request_to_administrators %>
   </div>
 
 </div>

--- a/app/views/communities/_poll.html.erb
+++ b/app/views/communities/_poll.html.erb
@@ -1,6 +1,6 @@
 <div class="community-poll">
   <h4>
-    <%= link_to poll.title, poll %>
+    <%= link_to poll.title, proposal_poll_path(@community.proposal, poll) %>
   </h4>
 
   <p class="topic-info">

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -46,7 +46,9 @@
         <div class="sidebar-divider"></div>
         <h2><%= t("communities.show.surveys") %></h2>
         <%= link_to t("communities.show.complete_survey"),
-                    @community.proposal.polls.current.first, class: "button expanded hollow" %>
+                    proposal_poll_path(@community.proposal,
+                                       @community.proposal.polls.current.first),
+                    class: "button expanded hollow" %>
       <% end %>
     </aside>
   </div>

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -58,8 +58,6 @@
 
       <% unless preview %>
         <aside class="small-12 medium-3 column">
-          <!-- Hides temporally dashboard button -->
-          <% if false %>
           <% if can?(:dashboard, @proposal) %>
             <div class="sidebar-divider"></div>
             <h2><%= t("proposals.show.author") %></h2>
@@ -71,7 +69,6 @@
                 <%= t("proposals.show.dashboard_proposal_link") %>
               <% end %>
             </div>
-          <% end %>
           <% end %>
 
           <div class="sidebar-divider"></div>

--- a/app/views/dashboard/_goal.html.erb
+++ b/app/views/dashboard/_goal.html.erb
@@ -9,7 +9,7 @@
 
   <div class="goal-resource">
     <strong><%= goal.title %></strong>
-    <span class="help-text"><%= t("dashboard.goal.unlocked_resource") %></span>
+    <span class="help-text"><%= t("dashboard.goal.locked_resource") %></span>
   </div>
 
   <% if goal.day_offset.positive? %>

--- a/app/views/dashboard/_resource.html.erb
+++ b/app/views/dashboard/_resource.html.erb
@@ -23,7 +23,7 @@
                     class: "button expanded" %>
       <% else %>
         <strong>
-          <%== resoure_availability_label(resource) %>
+          <%== resource_availability_label(resource) %>
         </strong>
       <% end %>
     </div>

--- a/app/views/proposals/created.html.erb
+++ b/app/views/proposals/created.html.erb
@@ -6,13 +6,10 @@
       <p><%= t("proposals.created.motivation") %></p>
       <p><%= t("proposals.created.motivation_2_html") %></p>
 
-      <!-- Hides temporally dashboard button -->
-      <% if false %>
       <% if can?(:dashboard, @proposal) %>
         <%= link_to t("proposals.created.dashboard"),
                     progress_proposal_dashboard_path(@proposal),
                     class: "button" %>
-      <% end %>
       <% end %>
 
       <% if can?(:publish, @proposal) %>

--- a/app/views/proposals/share.html.erb
+++ b/app/views/proposals/share.html.erb
@@ -28,8 +28,6 @@
           mobile: @proposal.title
         } %>
 
-        <!-- Hides temporally dashboard button -->
-        <% if false %>
         <% if can?(:dashboard, @proposal) %>
           <div class="callout light margin">
             <p class="text-center">
@@ -40,7 +38,6 @@
                           progress_proposal_dashboard_path(@proposal), class: "button expanded" %>
             </div>
           </div>
-        <% end %>
         <% end %>
 
         <%= render "custom/proposals/kit_decide" %>

--- a/app/views/users/_proposal.html.erb
+++ b/app/views/users/_proposal.html.erb
@@ -18,12 +18,11 @@
 
   <% if proposal.retired? %>
     <td class="help-text"><%= t("users.proposals.retired_help_text") %></td>
-  <!-- Hides temporally dashboard button -->
-  <%# elsif can?(:dashboard, proposal) %>
-    <!-- <td>
-        <%#= link_to t("proposals.show.dashboard_proposal_link"),
-                    progress_proposal_dashboard_path(proposal), class: "button hollow expanded" %>
-    </td> -->
+  <% elsif can?(:dashboard, proposal) %>
+    <td>
+      <%= link_to t("proposals.show.dashboard_proposal_link"),
+                  progress_proposal_dashboard_path(proposal), class: "button hollow expanded" %>
+    </td>
   <% else %>
     <td class="text-center">
       <%= link_to t("users.proposals.see"), proposal, class: "button hollow" %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -521,7 +521,7 @@ en:
       days:
         one: "%{count} day"
         other: "%{count} days"
-      unlocked_resource: Resource unlocked
+      locked_resource: Resource locked
       ideal_time: Ideal time
     community:
       access_community: Access the community

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -521,7 +521,7 @@ es:
       days:
         one: "%{count} día"
         other: "%{count} días"
-      unlocked_resource: Recurso desbloqueado
+      locked_resource: Recurso bloqueado
       ideal_time: Tiempo ideal
     community:
       access_community: Acceder a la comunidad

--- a/lib/tasks/proposal_actions.rake
+++ b/lib/tasks/proposal_actions.rake
@@ -411,21 +411,19 @@ namespace :proposal_actions do
     goal_votes = Setting["votes_for_proposal_success"].to_f
     cached_votes_up = 0
 
-    tags = Faker::Lorem.words(25)
     author = User.all.sample
-    description = "<p>#{Faker::Lorem.paragraphs.join('</p><p>')}</p>"
+    description = "<p>This is an example of a successful proposal with an ideal progress.</p>"
     proposal = Proposal.create!(author: author,
-                                title: Faker::Lorem.sentence(3).truncate(60),
-                                summary: Faker::Lorem.sentence(3),
-                                responsible_name: Faker::Name.name,
+                                title: "Successful proposal",
+                                summary: "Example of a successful proposal",
+                                responsible_name: "User Name",
                                 description: description,
                                 created_at: Time.now - expected_supports.length.days,
-                                tag_list: tags.sample(3).join(","),
+                                tag_list: "Example",
                                 geozone: Geozone.all.sample,
                                 skip_map: "1",
                                 terms_of_service: "1",
                                 published_at: Time.now - expected_supports.length.days)
-
 
     expected_supports.each_with_index do |supports, day_offset|
       supports = (supports * goal_votes / votes_count).ceil


### PR DESCRIPTION
## References

Add proposal's dashboard  https://github.com/AyuntamientoMadrid/consul/pull/1945.

## Objectives

- Change i18n to resources on next goal: this resources always are locked when are shown on next goal section.
- Dont use faker gem on simulate successful proposal rake.
- Fix typo.
- Always show dashboard buttons.
- Use proposal_poll_path on communities poll links.
- Fix styles of dashboard poster.
- Fix request_to_administrators checkbox on admin dashboard actions.

## Does this PR need a Backport to CONSUL?

Yes,  backport to CONSUL. 🙏 😌 