### PR TITLE
Add message on dashboard request to archived proposals

### DIFF
--- a/app/views/dashboard/_form.html.erb
+++ b/app/views/dashboard/_form.html.erb
@@ -4,7 +4,11 @@
   </div>
 <% end %>
 
-<% unless proposal.archived? %>
+<% if proposal.archived? %>
+  <div class="callout primary">
+    <p><%= t("dashboard.create_request.archived") %></p>
+  </div>
+<% else %>
   <% if dashboard_action.request_to_administrators && !dashboard_action.requested_for?(proposal) %>
     <%= form_for @dashboard_executed_action,
                  url: create_request_proposal_dashboard_action_url(proposal,

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -474,6 +474,7 @@ en:
       request: Request
     create_request:
       success: The request has been successfully sent. We will contact you as soon as possible to inform you about it.
+      archived: This proposal is archived and can not request resources.
     progress:
       title: Graphic
       group_by_month: Monthly

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -474,6 +474,7 @@ es:
       request: Solicitar
     create_request:
       success: La petición ha sido correctamente enviada. Te contactaremos lo antes posible para informarte al respecto.
+      archived: Esta propuesta está archivada y no puede solicitar recursos.
     progress:
       title: Gráfico
       group_by_month: Mensual

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -333,6 +333,7 @@ feature "Proposal's dashboard" do
     end
 
     expect(page).not_to have_button("Request")
+    expect(page).to have_content("This proposal is archived and can not request resources.")
   end
 
   scenario "Dashboard has a link to dashboard community", js: true do


### PR DESCRIPTION
## Objectives

Add message on dashboard request to archived proposals. Show this message instead of "Request" button.

## Visual Changes

![archived](https://user-images.githubusercontent.com/631897/56888512-6ed95c00-6a74-11e9-877b-7fb4fd7773b5.png)

## Does this PR need a Backport to CONSUL?

Yes, backport to CONSUL.
