### PR TITLE
Fix obsolete reference to proposal question

### DIFF
--- a/app/views/admin/poll/questions/_successful_proposals.html.erb
+++ b/app/views/admin/poll/questions/_successful_proposals.html.erb
@@ -12,7 +12,6 @@
           <%= link_to proposal.title, proposal_path(proposal) %>
           <p>
             <%= proposal.summary %><br>
-            <strong><%= proposal.question %></strong>
           </p>
         </td>
         <td>

--- a/spec/features/admin/poll/questions_spec.rb
+++ b/spec/features/admin/poll/questions_spec.rb
@@ -117,6 +117,10 @@ feature "Admin poll questions" do
     click_button "Save"
 
     expect(page).to have_content(proposal.title)
+
+    visit admin_questions_path
+
+    expect(page).to have_content(proposal.title)
   end
 
   scenario "Update" do


### PR DESCRIPTION
## References

* Pull request #1913

## Objectives

Fix a crash visting the admin questions index when there are questions from successful proposals.

## Does this PR need a Backport to CONSUL?

Yes, backport when backporting #1913