### PR TITLE
Proposals authors user segment

### DIFF
--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -4,56 +4,56 @@
 
 <% recipients_count = @newsletter.valid_segment_recipient? ? @newsletter.list_of_recipient_emails.count : 0 %>
 
-  <div class="small-12 column callout highlight">
-    <div class="small-12 medium-2 column">
-      <strong><%= t("admin.newsletters.show.sent_at") %></strong><br>
-      <% if @newsletter.draft? %>
-        <%= t("admin.newsletters.index.draft") %>
-      <% else %>
-        <%= l @newsletter.sent_at.to_date %>
-      <% end %>
-    </div>
-    <div class="small-12 medium-6 column">
-      <strong><%= t("admin.newsletters.show.from") %></strong><br>
-      <%= @newsletter.from %>
-    </div>
-    <div class="small-12 medium-4 column">
-      <strong><%= t("admin.newsletters.show.subject") %></strong><br>
-      <%= @newsletter.subject %>
-    </div>
-    <div class="small-12 column">
-      <strong><%= t("admin.newsletters.show.segment_recipient") %></strong><br>
-      <%= segment_name(@newsletter.segment_recipient) %>
-      <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
-    </div>
-
-    <div class="small-12 column">
-      <strong>
-        <%= t("admin.newsletters.show.sent_emails", count: @newsletter.activities.count) %>
-      </strong>
-    </div>
+<div class="small-12 column callout highlight">
+  <div class="small-12 medium-2 column">
+    <strong><%= t("admin.newsletters.show.sent_at") %></strong><br>
+    <% if @newsletter.draft? %>
+      <%= t("admin.newsletters.index.draft") %>
+    <% else %>
+      <%= l @newsletter.sent_at.to_date %>
+    <% end %>
+  </div>
+  <div class="small-12 medium-6 column">
+    <strong><%= t("admin.newsletters.show.from") %></strong><br>
+    <%= @newsletter.from %>
+  </div>
+  <div class="small-12 medium-4 column">
+    <strong><%= t("admin.newsletters.show.subject") %></strong><br>
+    <%= @newsletter.subject %>
+  </div>
+  <div class="small-12 column">
+    <strong><%= t("admin.newsletters.show.segment_recipient") %></strong><br>
+    <%= segment_name(@newsletter.segment_recipient) %>
+    <%= t("admin.newsletters.show.affected_users", n: recipients_count) %>
   </div>
 
   <div class="small-12 column">
-    <strong><%= t("admin.newsletters.show.body") %></strong>
-    <p class="help-text" id="phase-description-help-text">
-      <%= t("admin.newsletters.show.body_help_text") %>
-    </p>
+    <strong>
+      <%= t("admin.newsletters.show.sent_emails", count: @newsletter.activities.count) %>
+    </strong>
   </div>
+</div>
 
-  <div class="newsletter-body-content">
-    <%= render file: "app/views/layouts/_mailer_header.html.erb" %>
+<div class="small-12 column">
+  <strong><%= t("admin.newsletters.show.body") %></strong>
+  <p class="help-text" id="phase-description-help-text">
+    <%= t("admin.newsletters.show.body_help_text") %>
+  </p>
+</div>
 
-    <table cellpadding="0" cellspacing="0" border="0" style="background: #fff; margin: 0 auto; max-width: 700px; width:100%;">
-      <tbody>
-        <tr>
-          <%= render file: "app/views/mailer/newsletter.html.erb" %>
-        </tr>
-      </tbody>
-    </table>
+<div class="newsletter-body-content">
+  <%= render file: "app/views/layouts/_mailer_header.html.erb" %>
 
-    <%= render file: "app/views/layouts/_mailer_footer.html.erb" %>
-  </div>
+  <table cellpadding="0" cellspacing="0" border="0" style="background: #fff; margin: 0 auto; max-width: 700px; width:100%;">
+    <tbody>
+      <tr>
+        <%= render file: "app/views/mailer/newsletter.html.erb" %>
+      </tr>
+    </tbody>
+  </table>
+
+  <%= render file: "app/views/layouts/_mailer_footer.html.erb" %>
+</div>
 
 <% if @newsletter.draft? && @newsletter.valid_segment_recipient? %>
   <%= link_to t("admin.newsletters.show.send"),

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -54,7 +54,6 @@
 
     <%= render file: "app/views/layouts/_mailer_footer.html.erb" %>
   </div>
-</div>
 
 <% if @newsletter.draft? && @newsletter.valid_segment_recipient? %>
   <%= link_to t("admin.newsletters.show.send"),

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -749,6 +749,7 @@ en:
     segment_recipient:
       all_users: All users
       administrators: Administrators
+      all_proposal_authors: Proposal authors (including archived and retired)
       proposal_authors: Proposal authors
       investment_authors: Investment authors in the current budget
       feasible_and_undecided_investment_authors: "Authors of some investment in the current budget that does not comply with: [valuation finished unfesasible]"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -748,6 +748,7 @@ es:
     segment_recipient:
       all_users: Todos los usuarios
       administrators: Administradores
+      all_proposal_authors: Usuarios autores de propuestas (incluyendo archivadas y retiradas)
       proposal_authors: Usuarios autores de propuestas
       investment_authors: Usuarios autores de proyectos de gasto en los actuales presupuestos
       feasible_and_undecided_investment_authors: "Usuarios autores de algún proyecto de gasto en los actuales presupuestos que no cumpla: [evaluación finalizada inviable]"

--- a/lib/user_segments.rb
+++ b/lib/user_segments.rb
@@ -3,6 +3,7 @@ class UserSegments
   def self.segments
     %w(all_users
        administrators
+       all_proposal_authors
        proposal_authors
        investment_authors
        feasible_and_undecided_investment_authors
@@ -18,6 +19,10 @@ class UserSegments
 
   def self.administrators
     all_users.administrators
+  end
+
+  def self.all_proposal_authors
+    author_ids(Proposal.pluck(:author_id).uniq)
   end
 
   def self.proposal_authors

--- a/spec/lib/user_segments_spec.rb
+++ b/spec/lib/user_segments_spec.rb
@@ -27,6 +27,28 @@ describe UserSegments do
     end
   end
 
+  describe "#all_proposal_authors" do
+    it "returns users that have created a proposal even if is archived or retired" do
+      create(:proposal, author: user1)
+      create(:proposal, :archived, author: user2)
+      create(:proposal, retired_at: Time.current, author: user3)
+
+      all_proposal_authors = described_class.all_proposal_authors
+      expect(all_proposal_authors).to include user1
+      expect(all_proposal_authors).to include user2
+      expect(all_proposal_authors).to include user3
+    end
+
+    it "does not return duplicated users" do
+      create(:proposal, author: user1)
+      create(:proposal, :archived, author: user1)
+      create(:proposal, retired_at: Time.current, author: user1)
+
+      all_proposal_authors = described_class.all_proposal_authors
+      expect(all_proposal_authors).to contain_exactly(user1)
+    end
+  end
+
   describe "#proposal_authors" do
     it "returns users that have created a proposal" do
       proposal = create(:proposal, author: user1)


### PR DESCRIPTION
## Objectives

- Add new user segment `all_proposals_authors`:   this segment include all proposals authors even if the proposals are **archived** or **retired**.

- Also fix html on admin newsletters show to prevent send button renders outside of the layout.

## Does this PR need a Backport to CONSUL?

Yes, backport to CONSUL.
