### PR TITLE
Sort investments by cached votes plus physical votes

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -153,7 +153,7 @@ class Budget
         direction = params[:direction] == "desc" ? "desc" : "asc"
         order("#{allowed_sort_option} #{direction}")
       else
-        order(cached_votes_up: :desc).order(id: :desc)
+        sort_by_supports
       end
     end
 

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -1,6 +1,6 @@
 class Budget
   class Investment < ApplicationRecord
-    SORTING_OPTIONS = {id: "id", title: "title", supports: "cached_votes_up"}.freeze
+    SORTING_OPTIONS = {id: "id", title: "title", supports: "cached_votes_up + physical_votes"}.freeze
 
     include Rails.application.routes.url_helpers
     include Measurable
@@ -59,7 +59,7 @@ class Budget
 
     scope :sort_by_id, -> { order("id DESC") }
     scope :sort_by_title, -> { order("title ASC") }
-    scope :sort_by_supports, -> { order("cached_votes_up DESC") }
+    scope :sort_by_supports, -> { order("cached_votes_up + physical_votes DESC") }
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
     scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1082,6 +1082,16 @@ describe Budget::Investment do
 
   describe ".order_filter" do
 
+    it "sorts investments by supports when no order given" do
+      most_voted = create(:budget_investment, cached_votes_up: 1, physical_votes: 10)
+      some_votes = create(:budget_investment, cached_votes_up: 3, physical_votes: 3)
+      least_voted = create(:budget_investment, cached_votes_up: 4, physical_votes: 1)
+
+      expect(described_class.order_filter({}).first).to eq most_voted
+      expect(described_class.order_filter({}).second).to eq some_votes
+      expect(described_class.order_filter({}).third).to eq least_voted
+    end
+
     it "sorts investments by supports" do
       most_voted = create(:budget_investment, cached_votes_up: 1, physical_votes: 10)
       some_votes = create(:budget_investment, cached_votes_up: 3, physical_votes: 3)

--- a/spec/models/budget/investment_spec.rb
+++ b/spec/models/budget/investment_spec.rb
@@ -1044,6 +1044,54 @@ describe Budget::Investment do
         expect(described_class.sort_by_confidence_score.fourth).to eq least_voted
       end
     end
+
+    describe "#sort_by_supports" do
+
+      it "sorts by cached votes" do
+        most_voted = create(:budget_investment, cached_votes_up: 10)
+        some_votes = create(:budget_investment, cached_votes_up: 5)
+        least_voted = create(:budget_investment, cached_votes_up: 2)
+
+        expect(described_class.sort_by_supports.first).to eq most_voted
+        expect(described_class.sort_by_supports.second).to eq some_votes
+        expect(described_class.sort_by_supports.third).to eq least_voted
+      end
+
+      it "sorts by physical votes" do
+        most_voted = create(:budget_investment, physical_votes: 10)
+        some_votes = create(:budget_investment, physical_votes: 5)
+        least_voted = create(:budget_investment, physical_votes: 2)
+
+        expect(described_class.sort_by_supports.first).to eq most_voted
+        expect(described_class.sort_by_supports.second).to eq some_votes
+        expect(described_class.sort_by_supports.third).to eq least_voted
+      end
+
+      it "sorts by cached votes plus physical votes" do
+        most_voted = create(:budget_investment, cached_votes_up: 1, physical_votes: 10)
+        some_votes = create(:budget_investment, cached_votes_up: 3, physical_votes: 3)
+        least_voted = create(:budget_investment, cached_votes_up: 4, physical_votes: 1)
+
+        expect(described_class.sort_by_supports.first).to eq most_voted
+        expect(described_class.sort_by_supports.second).to eq some_votes
+        expect(described_class.sort_by_supports.third).to eq least_voted
+      end
+
+    end
+  end
+
+  describe ".order_filter" do
+
+    it "sorts investments by supports" do
+      most_voted = create(:budget_investment, cached_votes_up: 1, physical_votes: 10)
+      some_votes = create(:budget_investment, cached_votes_up: 3, physical_votes: 3)
+      least_voted = create(:budget_investment, cached_votes_up: 4, physical_votes: 1)
+
+      expect(described_class.order_filter(sort_by: "supports", direction: "desc").first).to eq most_voted
+      expect(described_class.order_filter(sort_by: "supports", direction: "desc").second).to eq some_votes
+      expect(described_class.order_filter(sort_by: "supports", direction: "desc").third).to eq least_voted
+    end
+
   end
 
   describe "responsible_name" do


### PR DESCRIPTION
## Context

The admin interface was displaying investments in an incorrect order because it did not take into account physical votes when ordering by supports.

## Objectives

Take into account physical votes when ordering investments in the admin interface.

## Does this PR need a Backport to CONSUL?

Maybe, `physical_votes` is a deprecated attribute but it could still be in use in CONSUL.