### PR TITLE
Add http_only and secure options to cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_consul_session"
+Rails.application.config.session_store :cookie_store,
+                                       key: "_consul_session",
+                                       httponly: true,
+                                       secure: true


### PR DESCRIPTION
## Objectives

Make cookies more secure by adding the `http_only` and `secure` [options](https://api.rubyonrails.org/v5.2.3/classes/ActionDispatch/Cookies.html)

## Does this PR need a Backport to CONSUL?

Yes, but should probably wait until https is fully integrated in the Installer. As the `secure` cookie option only sends cookies for https servers, which could have some nasty side effects for CONSUL instances running without https.