### PR TITLE
Fix investment order spec

### DIFF
--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -59,7 +59,7 @@ class Budget
 
     scope :sort_by_id, -> { order("id DESC") }
     scope :sort_by_title, -> { order("title ASC") }
-    scope :sort_by_supports, -> { order("cached_votes_up + physical_votes DESC") }
+    scope :sort_by_supports, -> { order("cached_votes_up + physical_votes DESC").order(id: :desc) }
 
     scope :valuation_open,              -> { where(valuation_finished: false) }
     scope :without_admin,               -> { valuation_open.where(administrator_id: nil) }


### PR DESCRIPTION
## References

**PR**: https://github.com/AyuntamientoMadrid/consul/pull/1991

## Objectives

Bringing back a secondary investment order by `id`, for the cases when two investments have the same number of votes, to [fix the build](https://travis-ci.org/AyuntamientoMadrid/consul/jobs/528819257#L1262).

## Does this PR need a Backport to CONSUL?
Maybe. Depends on whether we also backport the [initial PR that introduced this issue](https://github.com/AyuntamientoMadrid/consul/pull/1991/files#diff-8e806f1abf6a06e54748ebcb2ce63d3aL156).
