### PR TITLE
Remove deprecated attributes from Poll::Question::Answer

### DIFF
--- a/db/migrate/20190221163117_remove_deprecated_translatable_fields_from_poll_question_answers.rb
+++ b/db/migrate/20190221163117_remove_deprecated_translatable_fields_from_poll_question_answers.rb
@@ -1,0 +1,6 @@
+class RemoveDeprecatedTranslatableFieldsFromPollQuestionAnswers < ActiveRecord::Migration[4.2]
+  def change
+    remove_column :poll_question_answers, :title, :string
+    remove_column :poll_question_answers, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1065,8 +1065,6 @@ ActiveRecord::Schema.define(version: 20190411090023) do
   end
 
   create_table "poll_question_answers", force: :cascade do |t|
-    t.string  "title"
-    t.text    "description"
     t.integer "question_id"
     t.integer "given_order", default: 1
     t.boolean "most_voted",  default: false


### PR DESCRIPTION
## References

* This commit was missing from pull request #1985

## Objectives

* Remove obsolete columns which might still accidentally be used by active record scopes
* Fix incompatibilities between Globalize and Rails 5

## Does this PR need a Backport to CONSUL?

Yes, backport when backporting #1985