### PR TITLE
Show reCAPTCHA after consecutive failed attempts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'paperclip', '~> 5.2.1'
 gem 'paranoia', '~> 2.4.1'
 gem 'pg', '~> 0.21.0'
 gem 'pg_search', '~> 2.0.1'
+gem "recaptcha", "~> 4.14"
 gem 'redcarpet', '~> 3.4.0'
 gem 'responders', '~> 2.4.0'
 gem 'rinku', '~> 2.0.2', require: 'rails_rinku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,8 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (12.3.2)
+    recaptcha (4.14.0)
+      json
     recipient_interceptor (0.2.0)
       mail
     redcarpet (3.4.0)
@@ -589,6 +591,7 @@ DEPENDENCIES
   rails (= 5.0.7.2)
   rails-assets-leaflet!
   rails-assets-markdown-it (~> 8.2.1)!
+  recaptcha (~> 4.14)
   recipient_interceptor (~> 0.2.0)
   redcarpet (~> 3.4.0)
   responders (~> 2.4.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -86,6 +86,7 @@
 //= require globalize
 //= require send_admin_notification_alert
 //= require settings
+//= require login_form
 
 var initialize_modules = function() {
   App.Answers.initialize();
@@ -135,6 +136,7 @@ var initialize_modules = function() {
   App.Globalize.initialize();
   App.SendAdminNotificationAlert.initialize();
   App.Settings.initialize();
+  App.LoginForm.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/login_form.js.coffee
+++ b/app/assets/javascripts/login_form.js.coffee
@@ -1,0 +1,20 @@
+App.LoginForm =
+
+  initialize: ->
+
+    registrationForm = $("form#new_user[action='/users/sign_in']")
+    loginInput = $("input#user_login")
+    recaptcha = $(".recaptcha")
+
+    showRecaptchaFor = (login) ->
+      request = $.get "/users/sessions/show_recaptcha?login=#{login}"
+      request.done (response) ->
+        if response.recaptcha
+          recaptcha.show()
+        else
+          recaptcha.hide()
+
+    if registrationForm.length > 0 and recaptcha.length > 0
+      loginInput.on "focusout", ->
+        login = loginInput.val()
+        showRecaptchaFor(login) if login != ""

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1063,6 +1063,16 @@ form {
   }
 }
 
+.recaptcha {
+  padding-bottom: 10px;
+  text-align: center;
+  display: none;
+}
+
+.g-recaptcha {
+  display: inline-block;
+}
+
 // 07. Callout
 // -----------
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable, :confirmable, :recoverable, :rememberable,
          :trackable, :validatable, :omniauthable, :password_expirable, :secure_validatable,
-         authentication_keys: [:login]
+         :lockable, authentication_keys: [:login]
 
   acts_as_voter
   acts_as_paranoid column: :hidden_at
@@ -381,6 +381,10 @@ class User < ApplicationRecord
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
+  end
+
+  def exceeded_failed_login_attempts?
+    failed_attempts >= Setting["captcha.max_failed_login_attempts"].to_i
   end
 
   private

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,6 +28,12 @@
       </div>
     <% end -%>
 
+    <% if Setting["feature.captcha"] %>
+      <div class="recaptcha">
+        <%= recaptcha_tags %>
+      </div>
+    <% end %>
+
     <div class="small-12 medium-6 small-centered">
       <%= f.submit(t("devise_views.sessions.new.submit"), class: "button expanded") %>
     </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -122,6 +122,7 @@ ignore_missing:
   - "tracking.events.category.*"
   - "tracking.user_data.*"
   - "tracking.events.name.*"
+  - "recaptcha.errors.verification_failed"
 
 ## Consider these keys used:
 ignore_unused:

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -165,7 +165,7 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [:email]
@@ -175,11 +175,11 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :none
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = Float::INFINITY
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,4 @@
+Recaptcha.configure do |config|
+  config.site_key   = Rails.application.secrets.recaptcha_site_key
+  config.secret_key = Rails.application.secrets.recaptcha_secret_key
+end

--- a/config/locales/en/devise.yml
+++ b/config/locales/en/devise.yml
@@ -64,3 +64,7 @@ en:
         one: "1 error prevented this %{resource} from being saved. Please check the marked fields to know how to correct them:"
         other: "%{count} errors prevented this %{resource} from being saved. Please check the marked fields to know how to correct them:"
       equal_to_current_password: "must be different than the current password."
+  recaptcha:
+    errors:
+      verification_failed: "reCAPTCHA human verification is missing. please try again."
+      recaptcha_unreachable: "Was not possible to verify reCAPTCHA, maybe due to an Internet issue. Please try again."

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -117,6 +117,8 @@ en:
       public_stats_description: "Display public stats in the Administration panel"
       help_page: "Help page"
       help_page_description: 'Displays a Help menu that contains a page with an info section about each enabled feature. Also custom pages and menus can be created in the "Custom pages" and  "Custom content blocks" sections'
+      captcha: "reCAPTCHA"
+      captcha_description: "Enables a human verification system after a number of failed login attempts. Normally used to prevent brute force attacks"
     map:
       latitude: "Latitude"
       latitude_description: "Latitude to show the map position"
@@ -140,3 +142,6 @@ en:
       per_page_code_head_description: "This code will appear inside the <head> label. Useful for entering custom scripts, analytics..."
       per_page_code_body: "Code to be included on every page (<body>)"
       per_page_code_body_description: "This code will appear inside the <body> label. Useful for entering custom scripts, analytics..."
+    captcha:
+      max_failed_login_attempts: "Number of allowed failed login attempts"
+      max_failed_login_attempts_description: "After this number of failed attempts a reCAPTCHA will show in the login form if the feature is enabled"

--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -63,3 +63,7 @@ es:
         one: "1 error impidió que este %{resource} fuera guardado. Por favor revisa los campos marcados para saber cómo corregirlos:"
         other: "%{count} errores impidieron que este %{resource} fuera guardado. Por favor revisa los campos marcados para saber cómo corregirlos:"
       equal_to_current_password: "debe ser diferente a la contraseña actual"
+  recaptcha:
+    errors:
+      verification_failed: "No se ha realizado la verificación humana reCAPTCHA. Por favor inténtalo de nuevo."
+      recaptcha_unreachable: "No ha sido posible verificar reCAPTCHA, possiblemente por un error en la conexión a Internet. Por favor inténtalo de nuevo."

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -116,6 +116,8 @@ es:
       public_stats_description: "Muestra las estadísticas públicas en el panel de Administración"
       help_page: "Página de ayuda"
       help_page_description: 'Muestra un menú Ayuda que contiene una página con una sección de información sobre cada funcionalidad habilitada. También se pueden crear páginas y menús personalizados en las secciones "Personalizar páginas" y "Personalizar bloques"'
+      captcha: "reCAPTCHA"
+      captcha_description: "Habilita un sistema de verificación humana después de un número de intentos de autentificación fallidos. Frecuentemente usado para prevenir ataques de fuerza bruta"
     map:
       latitude: "Latitud"
       latitude_description: "Latitud para mostrar la posición del mapa"
@@ -139,3 +141,6 @@ es:
       per_page_code_head_description: "Esté código aparecerá dentro de la etiqueta <head>. Útil para introducir scripts personalizados, analitycs..."
       per_page_code_body: "Código a incluir en cada página (<body>)"
       per_page_code_body_description: "Esté código aparecerá dentro de la etiqueta <body>. Útil para introducir scripts personalizados, analitycs..."
+    captcha:
+      max_failed_login_attempts: "Número de intentos de autentificación fallidos permitidos"
+      max_failed_login_attempts_description: "Después de ese número de intentos fallidos se mostrará un reCAPTCHA en el formulario de acceso si la funcionalidad está activada"

--- a/config/routes/devise.rb
+++ b/config/routes/devise.rb
@@ -13,6 +13,7 @@ devise_scope :user do
   delete "users/registrations", to: "users/registrations#delete"
   get :finish_signup, to: "users/registrations#finish_signup"
   patch :do_finish_signup, to: "users/registrations#do_finish_signup"
+  get "users/sessions/show_recaptcha", to: "users/sessions#show_recaptcha"
 end
 
 devise_for :organizations, class_name: "User",

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -56,6 +56,8 @@ preproduction:
   facebook_secret: ""
   google_oauth2_key: ""
   google_oauth2_secret: ""
+  recaptcha_site_key: ""
+  recaptcha_secret_key: ""
   <<: *maps
   <<: *apis
 
@@ -73,5 +75,7 @@ production:
   facebook_secret: ""
   google_oauth2_key: ""
   google_oauth2_secret: ""
+  recaptcha_site_key: ""
+  recaptcha_secret_key: ""
   <<: *maps
   <<: *apis

--- a/db/dev_seeds/settings.rb
+++ b/db/dev_seeds/settings.rb
@@ -49,6 +49,7 @@ section "Creating Settings" do
   Setting.create(key: "feature.public_stats", value: "true")
   Setting.create(key: "feature.guides", value: true)
   Setting.create(key: "feature.help_page", value: "true")
+  Setting.create(key: "feature.captcha", value: nil)
 
   Setting.create(key: "html.per_page_code_head", value: "")
   Setting.create(key: "html.per_page_code_body", value: "")
@@ -107,4 +108,6 @@ section "Creating Settings" do
   Setting.create(key: "proposals.email_description", value: nil)
 
   Setting.create(key: "dashboard.emails", value: nil)
+
+  Setting.create(key: "captcha.max_failed_login_attempts", value: 5)
 end

--- a/db/migrate/20190507102732_add_failed_attempts_to_users.rb
+++ b/db/migrate/20190507102732_add_failed_attempts_to_users.rb
@@ -1,0 +1,6 @@
+class AddFailedAttemptsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190411090023) do
+ActiveRecord::Schema.define(version: 20190507102732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1546,6 +1546,8 @@ ActiveRecord::Schema.define(version: 20190411090023) do
     t.boolean  "recommended_proposals",                     default: true
     t.string   "newsletter_token"
     t.datetime "newsletter_token_used_at"
+    t.integer  "failed_attempts",                           default: 0,                     null: false
+    t.datetime "locked_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["geozone_id"], name: "index_users_on_geozone_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,6 +92,7 @@ Setting["feature.allow_images"] = true
 Setting["feature.allow_attached_documents"] = true
 Setting["feature.guides"] = true
 Setting["feature.help_page"] = true
+Setting["feature.captcha"] = nil
 
 # Proposal notifications
 Setting["proposal_notification_minimum_interval_in_days"] = 3
@@ -136,6 +137,9 @@ Setting["proposals.poster_description"] = nil
 
 # Dashboard
 Setting["dashboard.emails"] = nil
+
+# Recaptcha
+Setting["captcha.max_failed_login_attempts"] = 5
 
 # Default custom pages
 load Rails.root.join("db", "pages.rb")

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -48,4 +48,9 @@ namespace :settings do
     Setting.rename_key from: "feature.homepage.widgets.feeds.processes", to: "homepage.widgets.feeds.processes"
   end
 
+  desc "Add the reCAPTCHA settings"
+  task add_recaptcha_settings: :environment do
+    Setting["feature.captcha"] = nil
+    Setting["captcha.max_failed_login_attempts"] = 5
+  end
 end

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -106,6 +106,104 @@ feature "Users" do
 
         expect(page).to have_link "My activity", href: user_path(u2)
       end
+
+      scenario "counts failed attempts" do
+        user = create(:user, email: "manuela@consul.dev", password: "judgementday")
+        expect(user.failed_attempts).to be 0
+
+        visit user_session_path
+        fill_in "user_login",    with: "manuela@consul.dev"
+        fill_in "user_password", with: "wrong_password"
+        click_button "Enter"
+
+        expect(page).to have_content "Invalid Email or username or password."
+        expect(user.reload.failed_attempts).to be 1
+      end
+
+      scenario "resets failed attempts after successful login" do
+        user = create(:user, email: "manuela@consul.dev", password: "judgementday", failed_attempts: 3)
+
+        visit user_session_path
+        fill_in "user_login",    with: "manuela@consul.dev"
+        fill_in "user_password", with: "judgementday"
+        click_button "Enter"
+
+        expect(page).to have_content "You have been signed in successfully."
+        expect(user.reload.failed_attempts).to be 0
+      end
+
+      scenario "never shows recaptcha by default" do
+        create(:user, email: "manuela@consul.dev", password: "judgementday", failed_attempts: 1000)
+
+        visit user_session_path
+        fill_in "user_login",    with: "manuela@consul.dev"
+        fill_in "user_password", with: "judgementday"
+
+        expect(page).not_to have_css ".recaptcha"
+      end
+
+      context "with recaptcha" do
+
+        before do
+          Setting["feature.captcha"] = true
+        end
+
+        scenario "shows recaptcha only after consecutive failed attempts", :js do
+          create(:user, email: "manuela@consul.dev", password: "judgementday", failed_attempts: 4)
+
+          visit new_user_session_path
+
+          fill_in "user_login",    with: "manuela@consul.dev"
+          fill_in "user_password", with: "wrong_password"
+
+          expect(page).not_to have_css ".recaptcha"
+
+          click_button "Enter"
+          expect(page).to have_content "Invalid Email or username or password."
+
+          fill_in "user_login",    with: "manuela@consul.dev"
+          fill_in "user_password", with: "wrong_password"
+
+          expect(page).to have_css ".recaptcha"
+        end
+
+        scenario "unchecked recaptcha with correct login details", :js do
+          allow_any_instance_of(Users::SessionsController).to receive(:verify_recaptcha).and_return false
+          create(:user, email: "manuela@consul.dev", password: "judgementday", failed_attempts: 5)
+
+          visit new_user_session_path
+
+          fill_in "user_login",    with: "manuela@consul.dev"
+          fill_in "user_password", with: "judgementday"
+
+          click_button "Enter"
+          expect(page).to have_content "reCAPTCHA human verification is missing. please try again."
+        end
+
+        scenario "checked recaptcha with incorrect login details", :js do
+          create(:user, email: "manuela@consul.dev", password: "judgementday", failed_attempts: 5)
+
+          visit new_user_session_path
+
+          fill_in "user_login",    with: "manuela@consul.dev"
+          fill_in "user_password", with: "wrong_password"
+
+          click_button "Enter"
+          expect(page).to have_content "Invalid Email or username or password."
+        end
+
+        scenario "checked recaptcha with correct login details", :js do
+          create(:user, email: "manuela@consul.dev", password: "judgementday", failed_attempts: 5)
+
+          visit new_user_session_path
+
+          fill_in "user_login",    with: "manuela@consul.dev"
+          fill_in "user_password", with: "judgementday"
+
+          click_button "Enter"
+          expect(page).to have_content "You have been signed in successfully."
+        end
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -738,4 +738,19 @@ describe User do
     end
   end
 
+  describe "#exceeded_failed_login_attempts?" do
+
+    before { Setting["captcha.max_failed_login_attempts"] = 5 }
+
+    it "returns true if the failed login attempts reached the setting max value" do
+      user = create(:user, failed_attempts: 5)
+      expect(user.exceeded_failed_login_attempts?).to be true
+    end
+
+    it "returns false if the failed login attempts didn't reach the setting max value" do
+      user = create(:user, failed_attempts: 4)
+      expect(user.exceeded_failed_login_attempts?).to be false
+    end
+  end
+
 end


### PR DESCRIPTION
## Objectives

After a certain number of failed login attempts, a reCAPTCHA will show in the login form to prevent brute force attacks.
This feature is disabled by default, but it can be enabled/disabled from the admin panel -> Settings section -> Features (check gif below)
The number of failed login attempts is set to 5 by default, but it also can be changed from the admin panel -> Settings section -> Configuration settings (check gif below)

## Visual Changes

### SETTINGS
![recaptcha_settings](https://user-images.githubusercontent.com/942995/57378388-f7f34000-71a4-11e9-951c-b4e3fe88f5f4.gif)

### RECAPTCHA
![recaptcha](https://user-images.githubusercontent.com/942995/57378371-edd14180-71a4-11e9-85ef-a76f932de54b.gif)

## Does this PR need a Backport to CONSUL?
❓(unknown)  

## Notes

- If you would like to enable this feature you must get your reCAPTCHA keys from [Google reCAPTCHA admin panel](https://www.google.com/recaptcha/admin) and you need to update your file `config/secrets.yml` accordingly. You must add the keys `recaptcha_site_key` and `recaptcha_secret_key`. You can see an example under the file `config/secrets.yml.example` of this repository.

⚠️ Release notes

- Even if you don't want to enable the feature you need to execute the rake task in order to create the default settings values in the DB. To do that, please execute `bin/rake settings:add_recaptcha_settings RAILS_ENV=production` in your production server.