### PR TITLE
Always use map image from admin site customization images

### DIFF
--- a/app/views/budgets/groups/show.html.erb
+++ b/app/views/budgets/groups/show.html.erb
@@ -49,7 +49,7 @@
   </div>
 
   <div class="medium-5 column show-for-medium text-center">
-    <%= image_tag "map.jpg" %>
+    <%= image_tag(image_path_for("map.jpg")) %>
   </div>
 </div>
 

--- a/app/views/legislation/proposals/_geozones.html.erb
+++ b/app/views/legislation/proposals/_geozones.html.erb
@@ -2,5 +2,5 @@
 <h2 class="sidebar-title"><%= t("shared.tags_cloud.districts") %></h2>
 <br>
 <%= link_to map_proposals_path, id: "map", title: t("shared.tags_cloud.districts_list") do %>
-  <%= image_tag("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
+  <%= image_tag(image_path_for("map.jpg", alt: t("shared.tags_cloud.districts_list")) %>
 <% end %>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -13,7 +13,9 @@
       </div>
 
       <div class="show-for-medium medium-9 column text-center">
-        <%= image_tag("map.jpg", usemap: "#html_map", alt: "Mapa de distritos de Madrid") %>
+        <%= image_tag(image_path_for("map.jpg"),
+                      usemap: "#html_map",
+                      alt: "Mapa de distritos de Madrid") %>
       </div>
 
       <map name="html_map" id="html_map">

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -13,9 +13,7 @@
       </div>
 
       <div class="show-for-medium medium-9 column text-center">
-        <%= image_tag(image_path_for("map.jpg"),
-                      usemap: "#html_map",
-                      alt: "Mapa de distritos de Madrid") %>
+        <%= image_tag(image_path_for("map.jpg"), usemap: "#html_map", alt: t("map.alt")) %>
       </div>
 
       <map name="html_map" id="html_map">

--- a/config/locales/custom/en/custom.yml
+++ b/config/locales/custom/en/custom.yml
@@ -348,3 +348,5 @@ en:
     meta:
       title: Change your city with Decide Madrid
       description: Decide Madrid is a website where you can make decisions to make Madrid more yours, better. Make your proposals for the City Hall to carry them out.
+  map:
+    alt: "Map of Madrid districts"

--- a/config/locales/custom/es/custom.yml
+++ b/config/locales/custom/es/custom.yml
@@ -348,3 +348,5 @@ es:
     meta:
       title: Cambia tu ciudad con Decide Madrid
       description: Decide Madrid es una web donde puedes tomar decisiones para hacer Madrid más tuyo, mejor. Presenta tus propuestas para que el Ayuntamiento las lleve a cabo.
+  map:
+    alt: "Mapa de distritos de Madrid"

--- a/spec/features/admin/site_customization/images_spec.rb
+++ b/spec/features/admin/site_customization/images_spec.rb
@@ -39,7 +39,9 @@ describe "Admin custom images" do
     expect(page).to have_css("img[src*='custom_map.jpg']", count: 1)
   end
 
-  scenario "Image is replaced on front view" do
+  scenario "Image is replaced on front views" do
+    budget = create(:budget)
+    group = create(:budget_group, budget: budget)
     visit admin_root_path
 
     within("#side_menu") do
@@ -54,6 +56,18 @@ describe "Admin custom images" do
     visit proposals_path
 
     within("#map") do
+      expect(page).to have_css("img[src*='custom_map.jpg']")
+    end
+
+    visit map_proposals_path
+
+    within(".show-for-medium") do
+      expect(page).to have_css("img[src*='custom_map.jpg']")
+    end
+
+    visit budget_group_path(budget, group)
+
+    within(".show-for-medium") do
       expect(page).to have_css("img[src*='custom_map.jpg']")
     end
   end


### PR DESCRIPTION
## References

Upstream from https://github.com/consul/consul/pull/3472.

## Objectives

Admin users can change map image on `/admin/site_customization/images`.

This custom image is not rendering in all pages with the map. With this PR we always render custom map image from admin site customization images if it's present.

## Does this PR need a Backport to CONSUL?

No, this code it's already on CONSUL.