### PR TITLE
Fix wrong column usage in 2017 poll stats

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -46,14 +46,14 @@ class PollsController < ApplicationController
   def stats_2017
     @totals = Stat.hash("polls_2017_participation")['totals']
 
-    @poll_1 = ::Poll.where("name ILIKE ?", "%Billete único%").first
-    @poll_2 = ::Poll.where("name ILIKE ?", "%Gran Vía%").first
-    @poll_3 = ::Poll.where("name ILIKE ?", "%Territorial de Barajas%").first
-    @poll_4 = ::Poll.where("name ILIKE ?", "%Territorial de San Blas%").first
-    @poll_5 = ::Poll.where("name ILIKE ?", "%Hortaleza%").first
-    @poll_6 = ::Poll.where("name ILIKE ?", "%culturales en Retiro%").first
-    @poll_7 = ::Poll.where("name ILIKE ?", "%Distrito de Salamanca%").first
-    @poll_8 = ::Poll.where("name ILIKE ?", "%Distrito de Vicálvaro%").first
+    @poll_1 = ::Poll.joins(:translations).where("name ILIKE ?", "%Billete único%").first
+    @poll_2 = ::Poll.joins(:translations).where("name ILIKE ?", "%Gran Vía%").first
+    @poll_3 = ::Poll.joins(:translations).where("name ILIKE ?", "%Territorial de Barajas%").first
+    @poll_4 = ::Poll.joins(:translations).where("name ILIKE ?", "%Territorial de San Blas%").first
+    @poll_5 = ::Poll.joins(:translations).where("name ILIKE ?", "%Hortaleza%").first
+    @poll_6 = ::Poll.joins(:translations).where("name ILIKE ?", "%culturales en Retiro%").first
+    @poll_7 = ::Poll.joins(:translations).where("name ILIKE ?", "%Distrito de Salamanca%").first
+    @poll_8 = ::Poll.joins(:translations).where("name ILIKE ?", "%Distrito de Vicálvaro%").first
 
     @poll_stats = Stat.hash("polls_2017_polls")
 


### PR DESCRIPTION
## References

* Pull request #1985

## Objectives

Fix a crash accessing old polls happening because we were using the original (already removed) "name" column in the polls table, instead of using the one in the translations table.

## Does this PR need a Backport to CONSUL?

No, the code is only present in Madrid's fork.