### PR TITLE
Don't destroy budgets with an associated poll

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -48,6 +48,8 @@ class Admin::BudgetsController < Admin::BaseController
   def destroy
     if @budget.investments.any?
       redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice")
+    elsif @budget.poll.present?
+      redirect_to admin_budgets_path, alert: t("admin.budgets.destroy.unable_notice_polls")
     else
       @budget.destroy
       redirect_to admin_budgets_path, notice: t("admin.budgets.destroy.success_notice")

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -105,6 +105,7 @@ en:
       destroy:
         success_notice: Budget deleted successfully
         unable_notice: You cannot destroy a budget that has associated investments
+        unable_notice_polls: You cannot destroy a budget that has an associated poll
       new:
         title: New participatory budget
       winners:

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -104,7 +104,7 @@ en:
         blank_dates: Dates are blank
       destroy:
         success_notice: Budget deleted successfully
-        unable_notice: You cannot destroy a Budget that has associated investments
+        unable_notice: You cannot destroy a budget that has associated investments
       new:
         title: New participatory budget
       winners:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -105,6 +105,7 @@ es:
       destroy:
         success_notice: Presupuesto eliminado correctamente
         unable_notice: No se puede eliminar un presupuesto con proyectos asociados
+        unable_notice_polls: No se puede eliminar un presupuesto con una votación asociada
       new:
         title: Nuevo presupuesto ciudadano
       winners:

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -175,7 +175,7 @@ describe "Admin budgets" do
       click_link "Edit budget"
       click_link "Delete budget"
 
-      expect(page).to have_content("You cannot destroy a Budget that has associated investments")
+      expect(page).to have_content("You cannot destroy a budget that has associated investments")
       expect(page).to have_content("There is 1 budget")
     end
   end

--- a/spec/features/admin/budgets_spec.rb
+++ b/spec/features/admin/budgets_spec.rb
@@ -178,6 +178,16 @@ describe "Admin budgets" do
       expect(page).to have_content("You cannot destroy a budget that has associated investments")
       expect(page).to have_content("There is 1 budget")
     end
+
+    scenario "Try to destroy a budget with polls" do
+      create(:poll, budget: budget)
+
+      visit edit_admin_budget_path(budget)
+      click_link "Delete budget"
+
+      expect(page).to have_content("You cannot destroy a budget that has an associated poll")
+      expect(page).to have_content("There is 1 budget")
+    end
   end
 
   context "Edit" do


### PR DESCRIPTION
## Objectives

Fix an exception happening when trying to delete a budget which has a poll associated. 

## Does this PR need a Backport to CONSUL?

Yes.