### PR TITLE
Images and documents settings

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -418,6 +418,15 @@ code {
   word-break: break-all;
 }
 
+.content-type {
+  white-space: nowrap;
+  padding-right: $line-height;
+
+  label {
+    margin-left: 0 !important;
+  }
+}
+
 // 02. Sidebar
 // -----------
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -16,6 +16,7 @@ class Admin::SettingsController < Admin::BaseController
     @participation_processes_settings = all_settings["process"]
     @map_configuration_settings = all_settings["map"]
     @proposals_settings = all_settings["proposals"]
+    @uploads_settings = all_settings["uploads"]
   end
 
   def update
@@ -31,10 +32,24 @@ class Admin::SettingsController < Admin::BaseController
     redirect_to admin_settings_path, notice: t("admin.settings.index.map.flash.update")
   end
 
+  def update_content_types
+    setting = Setting.find(params[:id])
+    group = setting.content_type_group
+    mime_type_values = content_type_params.keys.map do |content_type|
+      Setting.mime_types[group][content_type]
+    end
+    setting.update value: mime_type_values.join(" ")
+    redirect_to admin_settings_path, notice: t("admin.settings.flash.updated")
+  end
+
   private
 
     def settings_params
       params.require(:setting).permit(:value)
+    end
+
+    def content_type_params
+      params.permit(:jpg, :png, :gif, :pdf, :doc, :docx, :xls, :xlsx, :csv, :zip)
     end
 
     def hidden_settings

--- a/app/helpers/documentables_helper.rb
+++ b/app/helpers/documentables_helper.rb
@@ -17,15 +17,11 @@ module DocumentablesHelper
   end
 
   def accepted_content_types_extensions(documentable_class)
-    documentable_class.accepted_content_types
-                      .collect{ |content_type| ".#{content_type.split("/").last}" }
-                      .join(",")
+    Setting.accepted_content_types_for("documents").map { |content_type| ".#{content_type}" }.join(",")
   end
 
   def documentable_humanized_accepted_content_types(documentable_class)
-    documentable_class.accepted_content_types
-                      .collect{ |content_type| content_type.split("/").last }
-                      .join(", ")
+    Setting.accepted_content_types_for("documents").join(", ")
   end
 
   def documentables_note(documentable)

--- a/app/helpers/imageables_helper.rb
+++ b/app/helpers/imageables_helper.rb
@@ -9,7 +9,7 @@ module ImageablesHelper
   end
 
   def imageable_max_file_size
-    bytes_to_megabytes(Image::MAX_IMAGE_SIZE)
+    bytes_to_megabytes(Setting["uploads.images.max_size"].to_i.megabytes)
   end
 
   def bytes_to_megabytes(bytes)
@@ -17,19 +17,21 @@ module ImageablesHelper
   end
 
   def imageable_accepted_content_types
-    Image::ACCEPTED_CONTENT_TYPE
+    Setting["uploads.images.content_types"]&.split(" ") || [ "image/jpeg" ]
   end
 
   def imageable_accepted_content_types_extensions
-    Image::ACCEPTED_CONTENT_TYPE
-      .collect{ |content_type| ".#{content_type.split("/").last}" }
-      .join(",")
+    Setting.accepted_content_types_for("images").map do |content_type|
+      if content_type == "jpg"
+        ".jpg,.jpeg"
+      else
+        ".#{content_type}"
+      end
+    end.join(",")
   end
 
   def imageable_humanized_accepted_content_types
-    Image::ACCEPTED_CONTENT_TYPE
-      .collect{ |content_type| content_type.split("/").last }
-      .join(", ")
+    Setting.accepted_content_types_for("images").join(", ")
   end
 
   def imageables_note(_imageable)

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -13,9 +13,6 @@ class Budget
     include Imageable
     include Mappable
     include Documentable
-    documentable max_documents_allowed: 3,
-                 max_file_size: 3.megabytes,
-                 accepted_content_types: [ "application/pdf" ]
 
     acts_as_votable
     acts_as_paranoid column: :hidden_at

--- a/app/models/concerns/documentable.rb
+++ b/app/models/concerns/documentable.rb
@@ -7,16 +7,17 @@ module Documentable
   end
 
   module ClassMethods
-    attr_reader :max_documents_allowed, :max_file_size, :accepted_content_types
-
-    private
-
-    def documentable(options = {})
-      @max_documents_allowed = options[:max_documents_allowed]
-      @max_file_size = options[:max_file_size]
-      @accepted_content_types = options[:accepted_content_types]
+    def max_documents_allowed
+      Setting["uploads.documents.max_amount"].to_i
     end
 
+    def max_file_size
+      Setting["uploads.documents.max_size"].to_i.megabytes
+    end
+
+    def accepted_content_types
+      Setting["uploads.documents.content_types"]&.split(" ") || [ "application/pdf" ]
+    end
   end
 
 end

--- a/app/models/dashboard/action.rb
+++ b/app/models/dashboard/action.rb
@@ -1,13 +1,5 @@
 class Dashboard::Action < ApplicationRecord
   include Documentable
-  documentable max_documents_allowed: 3,
-               max_file_size: 3.megabytes,
-               accepted_content_types: [ "application/pdf",
-                                         "image/jpeg",
-                                         "image/jpg",
-                                         "image/png",
-                                         "application/zip" ]
-
   include Linkable
 
   acts_as_paranoid column: :hidden_at

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,12 +2,11 @@ class Image < ApplicationRecord
   include ImagesHelper
   include ImageablesHelper
 
-  TITLE_LENGTH_RANGE = 4..80
-  MIN_SIZE = 475
-  MAX_IMAGE_SIZE = 1.megabyte
-  ACCEPTED_CONTENT_TYPE = %w(image/jpeg image/jpg).freeze
-
-  has_attached_file :attachment, styles: { large: "x#{MIN_SIZE}", medium: "300x300#", thumb: "140x245#" },
+  has_attached_file :attachment, styles: {
+                                   large: "x#{Setting["uploads.images.min_height"]}",
+                                   medium: "300x300#",
+                                   thumb: "140x245#"
+                                 },
                                  url: "/system/:class/:prefix/:style/:hash.:extension",
                                  hash_data: ":class/:style",
                                  use_timestamp: false,
@@ -23,7 +22,8 @@ class Image < ApplicationRecord
   validate :attachment_presence
   validate :validate_attachment_content_type,         if: -> { attachment.present? }
   validate :validate_attachment_size,                 if: -> { attachment.present? }
-  validates :title, presence: true, length: { in: TITLE_LENGTH_RANGE }
+  validates :title, presence: true
+  validate :validate_title_length
   validates :user_id, presence: true
   validates :imageable_id, presence: true,         if: -> { persisted? }
   validates :imageable_type, presence: true,       if: -> { persisted? }
@@ -71,17 +71,35 @@ class Image < ApplicationRecord
         return true if imageable_class == Widget::Card
 
         dimensions = Paperclip::Geometry.from_file(attachment.queued_for_write[:original].path)
-        errors.add(:attachment, :min_image_width, required_min_width: MIN_SIZE) if dimensions.width < MIN_SIZE
-        errors.add(:attachment, :min_image_height, required_min_height: MIN_SIZE) if dimensions.height < MIN_SIZE
+        min_width = Setting["uploads.images.min_width"].to_i
+        min_height = Setting["uploads.images.min_height"].to_i
+        errors.add(:attachment, :min_image_width, required_min_width: min_width) if dimensions.width < min_width
+        errors.add(:attachment, :min_image_height, required_min_height: min_height) if dimensions.height < min_height
       end
     end
 
     def validate_attachment_size
       if imageable_class &&
-         attachment_file_size > 1.megabytes
+         attachment_file_size > Setting["uploads.images.max_size"].to_i.megabytes
         errors.add(:attachment, I18n.t("images.errors.messages.in_between",
                                      min: "0 Bytes",
                                      max: "#{imageable_max_file_size} MB"))
+      end
+    end
+
+    def validate_title_length
+      if title.present?
+
+        title_min_length = Setting["uploads.images.title.min_length"].to_i
+        title_max_length = Setting["uploads.images.title.max_length"].to_i
+
+        if title.size < title_min_length
+          errors.add(:title, I18n.t("errors.messages.too_short", count: title_min_length))
+        end
+
+        if title.size > title_max_length
+          errors.add(:title, I18n.t("errors.messages.too_long", count: title_max_length))
+        end
       end
     end
 

--- a/app/models/legislation/process.rb
+++ b/app/models/legislation/process.rb
@@ -4,9 +4,6 @@ class Legislation::Process < ApplicationRecord
   include Milestoneable
   include Imageable
   include Documentable
-  documentable max_documents_allowed: 5,
-               max_file_size: 3.megabytes,
-               accepted_content_types: [ "application/pdf" ]
 
   acts_as_paranoid column: :hidden_at
   acts_as_taggable_on :customs

--- a/app/models/legislation/proposal.rb
+++ b/app/models/legislation/proposal.rb
@@ -19,9 +19,6 @@ class Legislation::Proposal < ApplicationRecord
   include Imageable
   include Randomizable
 
-  documentable max_documents_allowed: 3,
-               max_file_size: 3.megabytes,
-               accepted_content_types: [ "application/pdf" ]
   accepts_nested_attributes_for :documents, allow_destroy: true
 
   acts_as_votable

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -1,9 +1,6 @@
 class Milestone < ApplicationRecord
   include Imageable
   include Documentable
-  documentable max_documents_allowed: 3,
-               max_file_size: 3.megabytes,
-               accepted_content_types: [ "application/pdf" ]
 
   translates :title, :description, touch: true
   include Globalizable

--- a/app/models/poll/question/answer.rb
+++ b/app/models/poll/question/answer.rb
@@ -7,9 +7,6 @@ class Poll::Question::Answer < ApplicationRecord
   translates :description, touch: true
   include Globalizable
 
-  documentable max_documents_allowed: 3,
-               max_file_size: 20.megabytes,
-               accepted_content_types: [ "application/pdf" ]
   accepts_nested_attributes_for :documents, allow_destroy: true
 
   belongs_to :question, class_name: "Poll::Question", foreign_key: "question_id"

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -16,9 +16,6 @@ class Proposal < ApplicationRecord
   include Mappable
   include Notifiable
   include Documentable
-  documentable max_documents_allowed: 3,
-               max_file_size: 3.megabytes,
-               accepted_content_types: [ "application/pdf" ]
   include EmbedVideosHelper
   include Relationable
   include Milestoneable

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,7 +8,7 @@ class Setting < ApplicationRecord
   end
 
   def type
-    if %w[feature process proposals map html homepage].include? prefix
+    if %w[feature process proposals map html homepage uploads].include? prefix
       prefix
     else
       "configuration"
@@ -17,6 +17,14 @@ class Setting < ApplicationRecord
 
   def enabled?
     value.present?
+  end
+
+  def content_type?
+    key.split(".").last == "content_types"
+  end
+
+  def content_type_group
+    key.split(".").second
   end
 
   class << self
@@ -42,6 +50,25 @@ class Setting < ApplicationRecord
     def remove(key)
       setting = where(key: key).first
       setting.destroy if setting.present?
+    end
+
+    def mime_types
+      {
+        "images" => {
+          "jpg"  => "image/jpeg",
+          "png"  => "image/png",
+          "gif"  => "image/gif"
+        },
+        "documents" => {
+          "pdf"  => "application/pdf",
+          "doc"  => "application/msword",
+          "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "xls"  => "application/x-ole-storage",
+          "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "csv"  => "text/plain",
+          "zip"  => "application/zip"
+        }
+      }
     end
 
     def defaults

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -3,8 +3,11 @@ class Setting < ApplicationRecord
 
   default_scope { order(id: :asc) }
 
+  def prefix
+    key.split(".").first
+  end
+
   def type
-    prefix = key.split(".").first
     if %w[feature process proposals map html homepage].include? prefix
       prefix
     else

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -52,6 +52,11 @@ class Setting < ApplicationRecord
       setting.destroy if setting.present?
     end
 
+    def accepted_content_types_for(group)
+      mime_content_types = Setting["uploads.#{group}.content_types"]&.split(" ") || []
+      Setting.mime_types[group].select { |_, content_type| mime_content_types.include?(content_type) }.keys
+    end
+
     def mime_types
       {
         "images" => {

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -124,6 +124,16 @@ class Setting < ApplicationRecord
         "transparency_url": "http://transparencia.madrid.es/",
         "twitter_handle": "abriendomadrid",
         "twitter_hashtag": "#decidemadrid",
+        # Images and Documents
+        "uploads.images.title.min_length": 4,
+        "uploads.images.title.max_length": 80,
+        "uploads.images.min_width": 0,
+        "uploads.images.min_height": 475,
+        "uploads.images.max_size": 1,
+        "uploads.images.content_types": "image/jpeg",
+        "uploads.documents.max_amount": 3,
+        "uploads.documents.max_size": 3,
+        "uploads.documents.content_types": "application/pdf",
         "url": "https://decide.madrid.es", # Public-facing URL of the app.
         "verification_offices_url": "http://www.madrid.es/portales/munimadrid/es/Inicio/El-Ayuntamiento/Atencion-al-ciudadano/Oficinas-de-Atencion-al-Ciudadano?vgnextfmt=default&vgnextchannel=5b99cde2e09a4310VgnVCM1000000b205a0aRCRD",
         "votes_for_proposal_success": 53726,

--- a/app/views/admin/settings/_content_types_settings_form.html.erb
+++ b/app/views/admin/settings/_content_types_settings_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_tag admin_update_content_types_path, method: :put, id: "edit_#{dom_id(setting)}" do %>
+  <%= hidden_field_tag "id", setting.id %>
+
+  <div class="small-12 medium-6 large-8 column">
+    <% group = setting.content_type_group %>
+    <% Setting.mime_types[group].each do |content_type, mime_type_value| %>
+      <span class="content-type">
+        <%= check_box_tag content_type,
+            setting.value.split(" ").include?(mime_type_value),
+            setting.value.split(" ").include?(mime_type_value) %>
+        <%= label_tag content_type, content_type.upcase %>
+      </span>
+    <% end %>
+  </div>
+
+  <div class="small-12 medium-6 large-4 column">
+    <%= submit_tag t("admin.settings.index.update_setting"), class: "button hollow expanded" %>
+  </div>
+<% end %>

--- a/app/views/admin/settings/_featured_settings_form.html.erb
+++ b/app/views/admin/settings/_featured_settings_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_for(feature, url: admin_setting_path(feature), html: { id: "edit_#{dom_id(feature)}"}) do |f| %>
+  <%= f.hidden_field :value, id: dom_id(feature), value: (feature.enabled? ? "" : "active") %>
+  <%= f.submit(t("admin.settings.index.features.#{feature.enabled? ? "disable" : "enable"}"),
+               class: "button expanded #{feature.enabled? ? "hollow alert" : "success"}",
+               data: {confirm: t("admin.actions.confirm")}) %>
+<% end %>

--- a/app/views/admin/settings/_featured_settings_table.html.erb
+++ b/app/views/admin/settings/_featured_settings_table.html.erb
@@ -32,13 +32,7 @@
         </td>
 
         <td class="text-right">
-          <%= form_for(feature, url: admin_setting_path(feature), html: { id: "edit_#{dom_id(feature)}"}) do |f| %>
-
-            <%= f.hidden_field :value, id: dom_id(feature), value: (feature.enabled? ? "" : "active") %>
-            <%= f.submit(t("admin.settings.index.features.#{feature.enabled? ? "disable" : "enable"}"),
-                        class: "button expanded #{feature.enabled? ? "hollow alert" : "success"}",
-                        data: {confirm: t("admin.actions.confirm")}) %>
-          <% end %>
+          <%= render "admin/settings/featured_settings_form", feature: feature %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/settings/_filter_subnav.html.erb
+++ b/app/views/admin/settings/_filter_subnav.html.erb
@@ -29,6 +29,12 @@
     <% end %>
   </li>
 
+  <li class="tabs-title" id="images-and-documents-tab">
+    <%= link_to "#tab-images-and-documents" do %>
+      <%= t("admin.settings.index.images_and_documents") %>
+    <% end %>
+  </li>
+
   <li class="tabs-title" id="proposals-tab">
     <%= link_to "#tab-proposals" do %>
       <%= t("admin.settings.index.dashboard.title") %>

--- a/app/views/admin/settings/_images_and_documents_tab.html.erb
+++ b/app/views/admin/settings/_images_and_documents_tab.html.erb
@@ -1,0 +1,3 @@
+<h2><%= t("admin.settings.index.images_and_documents") %></h2>
+
+<%= render "settings_table", settings: @uploads_settings %>

--- a/app/views/admin/settings/_settings_form.html.erb
+++ b/app/views/admin/settings/_settings_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
+  <div class="small-12 medium-6 large-8 column">
+    <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
+  </div>
+  <div class="small-12 medium-6 large-4 column">
+    <%= f.submit(t("admin.settings.index.update_setting"), class: "button hollow expanded") %>
+  </div>
+<% end %>

--- a/app/views/admin/settings/_settings_table.html.erb
+++ b/app/views/admin/settings/_settings_table.html.erb
@@ -16,7 +16,11 @@
           </span>
         </td>
         <td class="small-6">
-          <%= render "admin/settings/settings_form", setting: setting %>
+          <% if setting.content_type? %>
+            <%= render "admin/settings/content_types_settings_form", setting: setting %>
+          <% else %>
+            <%= render "admin/settings/settings_form", setting: setting %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/settings/_settings_table.html.erb
+++ b/app/views/admin/settings/_settings_table.html.erb
@@ -16,14 +16,7 @@
           </span>
         </td>
         <td class="small-6">
-          <%= form_for(setting, url: admin_setting_path(setting), html: { id: "edit_#{dom_id(setting)}"}) do |f| %>
-            <div class="small-12 medium-6 large-8 column">
-              <%= f.text_area :value, label: false, id: dom_id(setting), lines: 1 %>
-            </div>
-            <div class="small-12 medium-6 large-4 column">
-              <%= f.submit(t("admin.settings.index.update_setting"), class: "button hollow expanded") %>
-            </div>
-          <% end %>
+          <%= render "admin/settings/settings_form", setting: setting %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -18,6 +18,10 @@
     <%= render "map_configuration_tab" %>
   </div>
 
+  <div class="tabs-panel" id="tab-images-and-documents">
+    <%= render "images_and_documents_tab" %>
+  </div>
+
   <div class="tabs-panel" id="tab-proposals">
     <%= render "proposals_dashboard" %>
   </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -115,6 +115,8 @@ ignore_missing:
   - "activerecord.errors.models.direct_message.*"
   - "errors.messages.blank"
   - "errors.messages.taken"
+  - "errors.messages.too_short"
+  - "errors.messages.too_long"
   - "devise.failure.invalid"
   - "devise.registrations.destroyed"
   - "devise.password_expired.*"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1282,6 +1282,7 @@ en:
         title: Configuration settings
         update_setting: Update
         participation_processes: "Participation processes"
+        images_and_documents: "Images and documents"
         feature_flags: Features
         features:
           enabled: "Feature enabled"

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -145,3 +145,25 @@ en:
     captcha:
       max_failed_login_attempts: "Number of allowed failed login attempts"
       max_failed_login_attempts_description: "After this number of failed attempts a reCAPTCHA will show in the login form if the feature is enabled"
+    uploads:
+      images:
+        min_width: "Image minimum width"
+        min_width_description: "Minimum width allowed for an uploaded image (in pixels)"
+        min_height: "Image minimum height"
+        min_height_description: "Minimum height allowed for an uploaded image (in pixels)"
+        max_size: "Image maximum size"
+        max_size_description: "Maximum size allowed for an uploaded image (in Megabytes/MB)"
+        content_types: "Accepted content types for images"
+        content_types_description: "Select all the content types allowed for uploaded images"
+        title:
+          min_length: "Image title minimum length"
+          min_length_description: "Title provided by the user when uploading an image (used as alt HTML attribute)"
+          max_length: "Image title maximum length"
+          max_length_description: "Title provided by the user when uploading an image (used as alt HTML attribute)"
+      documents:
+        max_amount: "Maximum number of documents"
+        max_amount_description: "Maximum number of documents that can be attached to a proposal, investment..."
+        max_size: "Document maximum size"
+        max_size_description: "Maximum size allowed for an uploaded document (in Megabytes/MB)"
+        content_types: "Accepted content types for documents"
+        content_types_description: "Select all the content types allowed for uploaded documents"

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1281,6 +1281,7 @@ es:
         title: Configuración global
         update_setting: Actualizar
         participation_processes: "Procesos de participación"
+        images_and_documents: "Imágenes y documentos"
         feature_flags: Funcionalidades
         features:
           enabled: "Funcionalidad activada"

--- a/config/locales/es/settings.yml
+++ b/config/locales/es/settings.yml
@@ -144,3 +144,25 @@ es:
     captcha:
       max_failed_login_attempts: "Número de intentos de autentificación fallidos permitidos"
       max_failed_login_attempts_description: "Después de ese número de intentos fallidos se mostrará un reCAPTCHA en el formulario de acceso si la funcionalidad está activada"
+    uploads:
+      images:
+        min_width: "Ancho mínimo de imagen"
+        min_width_description: "Ancho mínimo permitido al subir una imagen (en pixeles)"
+        min_height: "Alto mínimo de imagen"
+        min_height_description: "Alto mínimo permitido al subir una imagen (en pixeles)"
+        max_size: "Tamaño máximo de imagen"
+        max_size_description: "Tamaño máximo permitido al subir una imagen (en Megabytes/MB)"
+        content_types: "Tipos de imagenes permitidos"
+        content_types_description: "Selecciona todos los tipos permitidos para las imágenes subidas"
+        title:
+          min_length: "Longitud mínima del título de la imagen"
+          min_length_description: "El título es proporcionado por el usuario cuando se sube una imagen (usado como atributo HTML alt)"
+          max_length: "Longitud máxima del título de la imagen"
+          max_length_description: "El título es proporcionado por el usuario cuando se sube una imagen (usado como atributo HTML alt)"
+      documents:
+        max_amount: "Número máximo de documentos"
+        max_amount_description: "Número máximo de documentos que se pueden añadir a una propuesta, proyecto de gasto..."
+        max_size: "Tamaño máximo de documento"
+        max_size_description: "Tamaño máximo permitido al subir un documento (en Megabytes/MB)"
+        content_types: "Tipos de documentos permitidos"
+        content_types_description: "Selecciona todos los tipos permitidos para los documentos subidos"

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -96,6 +96,7 @@ namespace :admin do
 
   resources :settings, only: [:index, :update]
   put :update_map, to: "settings#update_map"
+  put :update_content_types, to: "settings#update_content_types"
 
   resources :moderators, only: [:index, :create, :destroy] do
     get :search, on: :collection

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -98,6 +98,40 @@ describe "Admin settings" do
 
   end
 
+  describe "Update content types" do
+
+    scenario "stores the correct mime types" do
+      setting = Setting.create(key: "upload.images.content_types", value: "image/png")
+      admin = create(:administrator).user
+      login_as(admin)
+      visit admin_settings_path
+      find("#images-and-documents-tab").click
+
+      within "#edit_setting_#{setting.id}" do
+        expect(find("#png")).to be_checked
+        expect(find("#jpg")).not_to be_checked
+        expect(find("#gif")).not_to be_checked
+
+        check "gif"
+
+        click_button "Update"
+      end
+
+      expect(page).to have_content "Value updated"
+      expect(Setting["upload.images.content_types"]).to include "image/png"
+      expect(Setting["upload.images.content_types"]).to include "image/gif"
+
+      visit admin_settings_path(anchor: "tab-images-and-documents")
+
+      within "#edit_setting_#{setting.id}" do
+        expect(find("#png")).to be_checked
+        expect(find("#gif")).to be_checked
+        expect(find("#jpg")).not_to be_checked
+      end
+    end
+
+  end
+
   describe "Skip verification" do
 
     scenario "deactivate skip verification", :js do

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -148,6 +148,24 @@ describe Setting do
     end
   end
 
+  describe ".accepted_content_types_for" do
+    it "returns the formats accepted according to the setting value" do
+      Setting["uploads.images.content_types"] =    "image/jpeg image/gif"
+      Setting["uploads.documents.content_types"] = "application/pdf application/msword"
+
+      expect(Setting.accepted_content_types_for("images")).to    eq ["jpg", "gif"]
+      expect(Setting.accepted_content_types_for("documents")).to eq ["pdf", "doc"]
+    end
+
+    it "returns empty array if setting does't exist" do
+      Setting.remove("uploads.images.content_types")
+      Setting.remove("uploads.documents.content_types")
+
+      expect(Setting.accepted_content_types_for("images")).to    be_empty
+      expect(Setting.accepted_content_types_for("documents")).to be_empty
+    end
+  end
+
   describe ".add_new_settings" do
     context "default settings with strings" do
       before do

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -80,6 +80,26 @@ describe Setting do
     end
   end
 
+  describe "#content_type?" do
+    it "returns true if the last part of the key is content_types" do
+      expect(Setting.create(key: "key_name.content_types").content_type?).to be true
+    end
+
+    it "returns false if the last part of the key is not content_types" do
+      expect(Setting.create(key: "key_name.whatever").content_type?).to be false
+    end
+  end
+
+  describe "#content_type_group" do
+    it "returns the group for content_types settings" do
+      images =    Setting.create(key: "update.images.content_types")
+      documents = Setting.create(key: "update.documents.content_types")
+
+      expect(images.content_type_group).to    eq "images"
+      expect(documents.content_type_group).to eq "documents"
+    end
+  end
+
   describe ".rename_key" do
     it "renames the setting keeping the original value and deletes the old setting" do
       Setting["old_key"] = "old_value"

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -17,6 +17,16 @@ describe Setting do
     expect(described_class.where(key: "official_level_1_name", value: "Stormtrooper")).to exist
   end
 
+  describe "#prefix" do
+    it "returns the prefix of its key" do
+      expect(Setting.create(key: "prefix.key_name").prefix).to eq "prefix"
+    end
+
+    it "returns the whole key for a non prefixed key" do
+      expect(Setting.create(key: "key_name").prefix).to eq "key_name"
+    end
+  end
+
   describe "#type" do
     it "returns the key prefix for 'process' settings" do
       process_setting = Setting.create(key: "process.whatever")

--- a/spec/shared/models/image_validations.rb
+++ b/spec/shared/models/image_validations.rb
@@ -41,7 +41,8 @@ shared_examples "image validations" do |imageable_factory|
   end
 
   it "is not valid for attachments larger than imageable max_file_size definition" do
-    allow(image).to receive(:attachment_file_size).and_return(Image::MAX_IMAGE_SIZE + 1.byte)
+    larger_size = Setting["uploads.images.max_size"].to_i.megabytes + 1.byte
+    allow(image).to receive(:attachment_file_size).and_return(larger_size)
 
     expect(image).not_to be_valid
     expect(image.errors[:attachment]).to include "must be in between 0 Bytes and 1 MB"


### PR DESCRIPTION
## References

Issue https://github.com/consul/consul/issues/2934

## Objectives

Modify images and documents attributes easily from the admin panel 🎉  

## Visual Changes

![images_and_documents_settings](https://user-images.githubusercontent.com/942995/58037335-806eca80-7b2d-11e9-8cb5-88a39b495aa1.png)


## Does this PR need a Backport to CONSUL?

Yes 😄 