### PR TITLE
Remove Rspec deprecation warning

### DIFF
--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -7,7 +7,7 @@ describe Users::ConfirmationsController do
 
   describe "GET show" do
     it "returns a 404 code with a wrong token" do
-      expect { get :show, token: "non_existent" }.to raise_error ActiveRecord::RecordNotFound
+      expect { get :show, params: { token: "non_existent" } }.to raise_error ActiveRecord::RecordNotFound
     end
   end
 end


### PR DESCRIPTION
## Objectives

Remove this deprecation warning appearing when running the test suite.

```
DEPRECATION WARNING: Using positional arguments in functional tests
has been deprecated, in favor of keyword arguments, and will be
removed in Rails 5.1.

Deprecated style:
get :show, { id: 1 }, nil, { notice: "Flash message" }

New keyword style:
get :show, params: { id: 1 }, flash: { notice: "Flash message" }

```
## Does this PR need a Backport to CONSUL?

Yes 😄 