### PR TITLE
Allow lines to be 110 characters long by Rubocop

### DIFF
--- a/.rubocop_basic.yml
+++ b/.rubocop_basic.yml
@@ -36,7 +36,7 @@ Lint/UselessAssignment:
   Enabled: true
 
 Metrics/LineLength:
-  Max: 100
+  Max: 110
 
 RSpec/NotToNot:
   Enabled: true


### PR DESCRIPTION
## Objectives

Update Rubocop rule to allow lines up to 110 characters long.

## Does this PR need a Backport to CONSUL?

Yes 😄 