### PR TITLE
Generate navigation links for polls without a slug

### DIFF
--- a/app/helpers/polls_helper.rb
+++ b/app/helpers/polls_helper.rb
@@ -51,11 +51,11 @@ module PollsHelper
 
   def link_to_poll(text, poll)
     if poll.results_enabled?
-      link_to text, results_poll_path(id: poll.slug)
+      link_to text, results_poll_path(id: poll.slug || poll.id)
     elsif poll.stats_enabled?
-      link_to text, stats_poll_path(id: poll.slug)
+      link_to text, stats_poll_path(id: poll.slug || poll.id)
     else
-      link_to text, poll
+      link_to text, poll_path(id: poll.slug || poll.id)
     end
   end
 

--- a/app/views/polls/_poll_subnav.html.erb
+++ b/app/views/polls/_poll_subnav.html.erb
@@ -8,7 +8,7 @@
               <h2><%= t("polls.show.results_menu") %></h2>
             </li>
           <% else %>
-            <li><%= link_to t("polls.show.results_menu"), results_poll_path(id: @poll.slug) %></li>
+            <li><%= link_to t("polls.show.results_menu"), results_poll_path(id: @poll.slug || @poll.id) %></li>
           <% end %>
         <% end %>
 
@@ -18,7 +18,7 @@
               <h2><%= t("polls.show.stats_menu") %></h2>
             </li>
           <% else %>
-            <li><%= link_to t("polls.show.stats_menu"), stats_poll_path(id: @poll.slug) %></li>
+            <li><%= link_to t("polls.show.stats_menu"), stats_poll_path(id: @poll.slug || @poll.id) %></li>
           <% end %>
         <% end %>
 
@@ -27,7 +27,7 @@
             <h2><%= t("polls.show.info_menu") %></h2>
           </li>
         <% else %>
-          <li><%= link_to t("polls.show.info_menu"), poll_path(id: @poll.slug) %></li>
+          <li><%= link_to t("polls.show.info_menu"), poll_path(id: @poll.slug || @poll.id) %></li>
         <% end %>
       </ul>
     </div>

--- a/spec/features/polls/polls_spec.rb
+++ b/spec/features/polls/polls_spec.rb
@@ -594,5 +594,20 @@ describe "Polls" do
       expect(page).not_to have_content("Poll results")
       expect(page).not_to have_content("Participation statistics")
     end
+
+    scenario "Generates navigation links for polls without a slug" do
+      poll = create(:poll, :expired, results_enabled: true, stats_enabled: true)
+      poll.update_column(:slug, nil)
+
+      visit poll_path(poll)
+
+      expect(page).to have_link "Participation statistics"
+      expect(page).to have_link "Poll results"
+
+      click_link "Poll results"
+
+      expect(page).to have_link "Information"
+    end
+
   end
 end


### PR DESCRIPTION
## References

* Commits 5ca528d2 and e461c8d0

## Objectives

* Correctly generate links for polls without slugs
* Correctly use the slug in the link to a poll with no results nor stats

## Does this PR need a Backport to CONSUL?

No, the code is already there.