### PR TITLE
Resize Capybara window back to its original size

### DIFF
--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -182,13 +182,14 @@ describe "Proposals" do
   end
 
   context "Show on mobile screens" do
+    let!(:window_size) { Capybara.current_window.size }
 
     before do
-      Capybara.page.driver.browser.manage.window.resize_to(640, 480)
+      Capybara.current_window.resize_to(640, 480)
     end
 
     after do
-      Capybara.page.driver.browser.manage.window.maximize
+      Capybara.current_window.resize_to(*window_size)
     end
 
     scenario "Show support button sticky at bottom", :js do


### PR DESCRIPTION
## References

* Pull request #1745

## Objectives

Use the same window size for Capybara in every test.

## Does this PR need a Backport to CONSUL?

Yes.