### PR TITLE
Allow users to delete dashboard polls

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -65,15 +65,6 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
     else
       @poll.destroy
 
-      @poll.questions.each do |question|
-
-        question.answers.each do |answer|
-          answer.destroy
-        end
-
-        question.destroy
-      end
-
       redirect_to admin_polls_path, notice: t("admin.polls.destroy.success_notice")
     end
   end

--- a/app/controllers/dashboard/polls_controller.rb
+++ b/app/controllers/dashboard/polls_controller.rb
@@ -35,6 +35,16 @@ class Dashboard::PollsController < Dashboard::BaseController
     end
   end
 
+  def destroy
+    if ::Poll::Voter.where(poll: poll).any?
+      redirect_to proposal_dashboard_polls_path(proposal), alert: t("dashboard.polls.poll.unable_notice")
+    else
+      poll.destroy
+
+      redirect_to proposal_dashboard_polls_path(proposal), notice: t("dashboard.polls.poll.success_notice")
+    end
+  end
+
   private
 
     def poll

--- a/app/controllers/dashboard/polls_controller.rb
+++ b/app/controllers/dashboard/polls_controller.rb
@@ -1,20 +1,16 @@
 class Dashboard::PollsController < Dashboard::BaseController
   helper_method :poll
+  before_action :authorize_manage_polls
 
   def index
-    authorize! :manage_polls, proposal
-
     @polls = Poll.for(proposal)
   end
 
   def new
-    authorize! :manage_polls, proposal
     @poll = Poll.new
   end
 
   def create
-    authorize! :manage_polls, proposal
-
     @poll = Poll.new(poll_params.merge(author: current_user, related: proposal))
     if @poll.save
       redirect_to proposal_dashboard_polls_path(proposal), notice: t("flash.actions.create.poll")
@@ -24,12 +20,9 @@ class Dashboard::PollsController < Dashboard::BaseController
   end
 
   def edit
-    authorize! :manage_polls, proposal
   end
 
   def update
-    authorize! :manage_polls, proposal
-
     respond_to do |format|
       if poll.update(poll_params)
         format.html { redirect_to proposal_dashboard_polls_path(proposal),
@@ -69,5 +62,9 @@ class Dashboard::PollsController < Dashboard::BaseController
 
     def documents_attributes
       [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy]
+    end
+
+    def authorize_manage_polls
+      authorize! :manage_polls, proposal
     end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -25,7 +25,7 @@ class Poll < ApplicationRecord
   has_many :voters
   has_many :officer_assignments, through: :booth_assignments
   has_many :officers, through: :officer_assignments
-  has_many :questions, inverse_of: :poll
+  has_many :questions, inverse_of: :poll, dependent: :destroy
   has_many :comments, as: :commentable
   has_many :ballot_sheets
 

--- a/app/models/poll/question.rb
+++ b/app/models/poll/question.rb
@@ -13,7 +13,7 @@ class Poll::Question < ApplicationRecord
 
   has_many :comments, as: :commentable
   has_many :answers, class_name: "Poll::Answer"
-  has_many :question_answers, -> { order "given_order asc" }, class_name: "Poll::Question::Answer"
+  has_many :question_answers, -> { order "given_order asc" }, class_name: "Poll::Question::Answer", dependent: :destroy
   has_many :partial_results
   belongs_to :proposal
 

--- a/app/views/dashboard/polls/_form.html.erb
+++ b/app/views/dashboard/polls/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [proposal, :dashboard, poll] do |f| %>
   <div class="row expanded">
     <div class="small-12 medium-6 column">
-      <%= f.text_field :name %>
+      <%= f.text_field :name, label: t("dashboard.polls.form.name") %>
     </div>
   </div>
 

--- a/app/views/dashboard/polls/_poll.html.erb
+++ b/app/views/dashboard/polls/_poll.html.erb
@@ -1,8 +1,8 @@
 <div id="<%= dom_id(poll) %>" class="small-12 medium-6 large-4 column end">
   <div class="poll-card" data-equalizer-watch="poll-cards">
     <h4>
-      <%= link_to poll.title, 
-                  proposal_poll_path(proposal, poll), 
+      <%= link_to poll.title,
+                  proposal_poll_path(proposal, poll),
                   target: "_blank" %>
     </h4>
     <span class="small">
@@ -19,7 +19,7 @@
                     edit_proposal_dashboard_poll_path(proposal, poll), class: "button hollow" %>
       <% else %>
         <%= link_to t("dashboard.polls.poll.view_results"),
-                    results_proposal_poll_path(proposal, poll), 
+                    results_proposal_poll_path(proposal, poll),
                     class: "button", target: "_blank" %>
       <% end %>
     </div>
@@ -31,5 +31,11 @@
         class: "js-submit-on-change" %>
     <% end %>
     <p class="help-text"><%= t("dashboard.polls.poll.show_results_help") %></p>
+
+    <%= link_to t("dashboard.polls.poll.delete"),
+                proposal_dashboard_poll_path(proposal, poll),
+                method: :delete,
+                "data-confirm": t("dashboard.polls.poll.alert_notice"),
+                class: "delete" %>
   </div>
 </div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -558,6 +558,10 @@ en:
         edit_poll: Edit survey
         show_results: Show results
         show_results_help: If you check this box the results will be public and all users will be able to see them
+        delete: Delete survey
+        alert_notice: This action will remove the survey and all its associated questions.
+        success_notice: Survey deleted successfully
+        unable_notice: You cannot destroy a survey that has responses
       form:
         name: Survey title
         add_question: Add question

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -559,6 +559,7 @@ en:
         show_results: Show results
         show_results_help: If you check this box the results will be public and all users will be able to see them
       form:
+        name: Survey title
         add_question: Add question
       question_fields:
         remove_question: Remove question

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -559,6 +559,7 @@ es:
         show_results: Mostrar resultados
         show_results_help: Si marcas esta casilla los resultados serán públicos y todos los usuarios podrán verlos
       form:
+        name: Título de la encuesta
         add_question: Añadir pregunta
       question_fields:
         remove_question: Borrar pregunta

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -558,6 +558,10 @@ es:
         edit_poll: Editar encuesta
         show_results: Mostrar resultados
         show_results_help: Si marcas esta casilla los resultados serán públicos y todos los usuarios podrán verlos
+        delete: Eliminar encuesta
+        alert_notice: Esta acción eliminará la encuesta y todas sus preguntas asociadas.
+        success_notice: Encuesta eliminada correctamente
+        unable_notice: No se pueden eliminar encuestas con respuestas
       form:
         name: Título de la encuesta
         add_question: Añadir pregunta

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -11,7 +11,7 @@ resources :proposals do
     resources :achievements, only: [:index], controller: "dashboard/achievements"
     resources :successful_supports, only: [:index], controller: "dashboard/successful_supports"
     resources :supports, only: [:index], controller: "dashboard/supports"
-    resources :polls, except: [:show, :destroy], controller: "dashboard/polls"
+    resources :polls, except: [:show], controller: "dashboard/polls"
     resources :mailing, only: [:index, :new, :create], controller: "dashboard/mailing"
     resources :poster, only: [:index, :new], controller: "dashboard/poster"
     resources :actions, only: [], controller: "dashboard/actions" do

--- a/spec/features/admin/poll/polls_spec.rb
+++ b/spec/features/admin/poll/polls_spec.rb
@@ -139,6 +139,9 @@ describe "Admin polls" do
 
       expect(page).to     have_content("Poll deleted successfully")
       expect(page).not_to have_content(poll.name)
+
+      expect(Poll::Question.count).to eq(0)
+      expect(Poll::Question::Answer.count). to eq(0)
     end
 
     scenario "Can't destroy poll with votes", :js  do

--- a/spec/features/dashboard/polls_spec.rb
+++ b/spec/features/dashboard/polls_spec.rb
@@ -153,6 +153,34 @@ describe "Polls" do
     end
   end
 
+  scenario "Can destroy poll without responses", :js do
+    poll = create(:poll, related: proposal)
+
+    visit proposal_dashboard_polls_path(proposal)
+
+    within("#poll_#{poll.id}") do
+      accept_confirm { click_link "Delete survey" }
+    end
+
+    expect(page).to have_content("Survey deleted successfully")
+    expect(page).not_to have_content(poll.name)
+  end
+
+  scenario "Can't destroy poll with responses", :js  do
+    poll = create(:poll, related: proposal)
+    create(:poll_question, poll: poll)
+    create(:poll_voter, poll: poll)
+
+    visit proposal_dashboard_polls_path(proposal)
+
+    within("#poll_#{poll.id}") do
+      accept_confirm { click_link "Delete survey" }
+    end
+
+    expect(page).to have_content("You cannot destroy a survey that has responses")
+    expect(page).to have_content(poll.name)
+  end
+
   scenario "View results not available for upcoming polls" do
     poll = create(:poll, related: proposal, starts_at: 1.week.from_now)
 


### PR DESCRIPTION
## References

Include the changes made on https://github.com/consul/consul/pull/3476/.

## Objectives
- Replace "Name" label on dashboard polls form to "Survey title"
- Allow users delete dashboard polls (if doesn't have responses)

## Visual Changes

![1_survey_label](https://user-images.githubusercontent.com/631897/58491120-b7b52b00-816e-11e9-9c7e-af33a0e799e4.png)
![2_delete_survey](https://user-images.githubusercontent.com/631897/58491121-b7b52b00-816e-11e9-89c8-b621aa7fce58.png)
![3_alert_message](https://user-images.githubusercontent.com/631897/58491122-b7b52b00-816e-11e9-8035-b4fcbd95bab4.png)
![4_success](https://user-images.githubusercontent.com/631897/58491123-b84dc180-816e-11e9-8987-c233c28f90f8.png)
![5_alert](https://user-images.githubusercontent.com/631897/58491124-b84dc180-816e-11e9-9331-cd2c4a753696.png)

## Does this PR need a Backport to CONSUL?

Yes, backport to CONSUL (the first commit its already on CONSUL).