### PR TITLE
Add new settings automatically on every deployment

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -131,5 +131,11 @@ class Setting < ApplicationRecord
     def reset_defaults
       defaults.each { |name, value| self[name] = value }
     end
+
+    def add_new_settings
+      defaults.each do |name, value|
+        self[name] = value unless find_by(key: name)
+      end
+    end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,6 +47,7 @@ namespace :deploy do
   #before :starting, "rvm1:install:ruby" # install Ruby and create gemset
   #before :starting, "install_bundler_gem" # install bundler gem
 
+  after "deploy:migrate", "add_new_settings"
   after :publishing, "deploy:restart"
   after :published, "delayed_job:restart"
   after :published, "refresh_sitemap"
@@ -65,6 +66,16 @@ task :refresh_sitemap do
     within release_path do
       with rails_env: fetch(:rails_env) do
         execute :rake, "sitemap:refresh:no_ping"
+      end
+    end
+  end
+end
+
+task :add_new_settings do
+  on roles(:app) do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rake, "settings:add_new_settings"
       end
     end
   end

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -53,4 +53,9 @@ namespace :settings do
     Setting["feature.captcha"] = nil
     Setting["captcha.max_failed_login_attempts"] = 5
   end
+
+  desc "Add new settings"
+  task add_new_settings: :environment do
+    Setting.add_new_settings
+  end
 end

--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -48,12 +48,6 @@ namespace :settings do
     Setting.rename_key from: "feature.homepage.widgets.feeds.processes", to: "homepage.widgets.feeds.processes"
   end
 
-  desc "Add the reCAPTCHA settings"
-  task add_recaptcha_settings: :environment do
-    Setting["feature.captcha"] = nil
-    Setting["captcha.max_failed_login_attempts"] = 5
-  end
-
   desc "Add new settings"
   task add_new_settings: :environment do
     Setting.add_new_settings

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -117,4 +117,60 @@ describe Setting do
       expect(Setting.all).to eq all_settings
     end
   end
+
+  describe ".add_new_settings" do
+    context "default settings with strings" do
+      before do
+        allow(Setting).to receive(:defaults).and_return({ stub: "stub" })
+      end
+
+      it "creates the setting if it doesn't exist" do
+        expect(Setting.where(key: :stub)).to be_empty
+
+        Setting.add_new_settings
+
+        expect(Setting.where(key: :stub)).not_to be_empty
+        expect(Setting.find_by(key: :stub).value).to eq "stub"
+      end
+
+      it "doesn't modify custom values" do
+        Setting["stub"] = "custom"
+
+        Setting.add_new_settings
+
+        expect(Setting.find_by(key: :stub).value).to eq "custom"
+      end
+
+      it "doesn't modify custom nil values" do
+        Setting["stub"] = nil
+
+        Setting.add_new_settings
+
+        expect(Setting.find_by(key: :stub).value).to be_nil
+      end
+    end
+
+    context "nil default settings" do
+      before do
+        allow(Setting).to receive(:defaults).and_return({ stub: nil })
+      end
+
+      it "creates the setting if it doesn't exist" do
+        expect(Setting.where(key: :stub)).to be_empty
+
+        Setting.add_new_settings
+
+        expect(Setting.where(key: :stub)).not_to be_empty
+        expect(Setting.find_by(key: :stub).value).to be_nil
+      end
+
+      it "doesn't modify custom values" do
+        Setting["stub"] = "custom"
+
+        Setting.add_new_settings
+
+        expect(Setting.find_by(key: :stub).value).to eq "custom"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## References

* Continues PR #1746

## Objectives

* Remove the need to manually run rake tasks when we add a new setting

## Does this PR need a Backport to CONSUL?

Yes.
