### PR TITLE
Move search form to sidebar

### DIFF
--- a/app/assets/javascripts/advanced_search.js.coffee
+++ b/app/assets/javascripts/advanced_search.js.coffee
@@ -1,26 +1,52 @@
 App.AdvancedSearch =
 
   advanced_search_terms: ->
-    $("#js-advanced-search").data("advanced-search-terms")
+    $("#js-advanced-search-list").data("advanced-search-terms")
+
+  advanced_search_sidebar_terms: ->
+    $("#js-advanced-search-sidebar").data("advanced-search-terms")
 
   toggle_form: (event) ->
     event.preventDefault()
-    $("#js-advanced-search").slideToggle()
+    $("#js-advanced-search-list").slideToggle()
+
+  toggle_form_sidebar: (event) ->
+    event.preventDefault()
+    $("#js-advanced-search-sidebar").slideToggle()
 
   toggle_date_options: ->
-    if $("#js-advanced-search-date-min").val() == "custom"
-      $("#js-custom-date").show()
-      $( ".js-calendar" ).datepicker( "option", "disabled", false )
+    if $("#js-advanced-search-date-min-list").val() == "custom"
+      $("#js-custom-date-list").show()
+      $( ".js-calendar-list" ).datepicker( "option", "disabled", false )
     else
-      $("#js-custom-date").hide()
-      $( ".js-calendar" ).datepicker( "option", "disabled", true )
+      $("#js-custom-date-list").hide()
+      $( ".js-calendar-list" ).datepicker( "option", "disabled", true )
+
+  toggle_date_options_sidebar: ->
+    if $("#js-advanced-search-date-min-sidebar").val() == "custom"
+      $("#js-custom-date-sidebar").show()
+      $( ".js-calendar-sidebar" ).datepicker( "option", "disabled", false )
+    else
+      $("#js-custom-date-sidebar").hide()
+      $( ".js-calendar-sidebar" ).datepicker( "option", "disabled", true )
 
   init_calendar: ->
     locale = $("#js-locale").data("current-locale")
     if locale == "en"
       locale = ""
 
-    $(".js-calendar").datepicker
+    $(".js-calendar-list").datepicker
+      regional: locale
+      maxDate: "+0d"
+    $(".js-calendar-full").datepicker
+      regional: locale
+
+  init_calendar_sidebar: ->
+    locale = $("#js-locale").data("current-locale")
+    if locale == "en"
+      locale = ""
+
+    $(".js-calendar-sidebar").datepicker
       regional: locale
       maxDate: "+0d"
     $(".js-calendar-full").datepicker
@@ -28,15 +54,28 @@ App.AdvancedSearch =
 
   initialize: ->
     App.AdvancedSearch.init_calendar()
+    App.AdvancedSearch.init_calendar_sidebar()
 
     if App.AdvancedSearch.advanced_search_terms()
-      $("#js-advanced-search").show()
+      $("#js-advanced-search-list").show()
       App.AdvancedSearch.toggle_date_options()
 
-    $("#js-advanced-search-title").on
+    if App.AdvancedSearch.advanced_search_sidebar_terms()
+      $("#js-advanced-search-sidebar").show()
+      App.AdvancedSearch.toggle_date_options_sidebar()
+
+    $("#js-advanced-search-title-list").on
       click: (event) ->
         App.AdvancedSearch.toggle_form(event)
 
-    $("#js-advanced-search-date-min").on
+    $("#js-advanced-search-title-sidebar").on
+      click: (event) ->
+        App.AdvancedSearch.toggle_form_sidebar(event)
+
+    $("#js-advanced-search-date-min-list").on
       change: ->
         App.AdvancedSearch.toggle_date_options()
+
+    $("#js-advanced-search-date-min-sidebar").on
+      change: ->
+        App.AdvancedSearch.toggle_date_options_sidebar()

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -899,6 +899,7 @@ footer {
 }
 
 .sidebar-map {
+  margin-top: $line-height;
 
   .map {
     z-index: 0;

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -796,8 +796,15 @@ header {
   }
 }
 
-.search-form-header [type=text] {
-  max-width: none;
+.search-form {
+
+  label {
+    width: 100%;
+  }
+
+  .input-group {
+    margin-bottom: 0;
+  }
 }
 
 // 03. Footer
@@ -1383,20 +1390,6 @@ form {
 
 // 09. Search
 // ----------
-
-.advanced-search {
-  float: left;
-  margin: $line-height 0;
-  position: inherit;
-
-  @include breakpoint(medium) {
-    float: right;
-    margin-bottom: 0;
-    margin-top: $line-height / 4;
-    position: absolute;
-    right: 0;
-  }
-}
 
 .advanced-search-form {
 

--- a/app/views/budgets/investments/_sidebar.html.erb
+++ b/app/views/budgets/investments/_sidebar.html.erb
@@ -15,6 +15,12 @@
   <% end %>
 <% end %>
 
+<%= render "shared/search_form", search_path: budget_investments_path(budget_id: @budget.id, page: 1),
+                                 i18n_namespace: "budgets.investments.index.search_form",
+                                 id: "search_form" %>
+
+<%= render "shared/advanced_search", search_path: budget_investments_url(@budget), position: "sidebar" %>
+
 <% if @heading && can?(:show, @ballot) %>
   <p class="callout">
     <%= t("budgets.investments.index.sidebar.voted_info",

--- a/app/views/budgets/investments/index.html.erb
+++ b/app/views/budgets/investments/index.html.erb
@@ -55,7 +55,9 @@
         </div>
       <% end %>
 
-      <%= render("shared/advanced_search", search_path: budget_investments_url(@budget)) %>
+      <div class="show-for-small-only">
+        <%= render "shared/advanced_search", search_path: budget_investments_url(@budget), position: "list" %>
+      </div>
 
       <% if unfeasible_or_unselected_filter %>
         <ul class="no-bullet submenu">

--- a/app/views/custom/budgets/investments/index.html.erb
+++ b/app/views/custom/budgets/investments/index.html.erb
@@ -60,7 +60,9 @@
         </div>
       <% end %>
 
-      <%= render("shared/advanced_search", search_path: budget_investments_url(@budget)) %>
+      <div class="show-for-small-only">
+        <%= render "shared/advanced_search", search_path: budget_investments_url(@budget), position: "list" %>
+      </div>
 
       <% if unfeasible_or_unselected_filter %>
         <ul class="no-bullet submenu">

--- a/app/views/custom/debates/index.html.erb
+++ b/app/views/custom/debates/index.html.erb
@@ -65,7 +65,9 @@
         </div>
       </div>
 
-      <%= render "shared/advanced_search", search_path: debates_path(page: 1) %>
+      <div class="show-for-small-only">
+        <%= render "shared/advanced_search", search_path: debates_path(page: 1), position: "list" %>
+      </div>
 
       <%= render "shared/order_links", i18n_namespace: "debates.index" %>
 
@@ -114,6 +116,10 @@
 
       <aside class="margin-bottom">
         <%= link_to t("debates.index.start_debate"), new_debate_path, class: "button expanded" %>
+        <%= render "shared/search_form", search_path: debates_path(page: 1),
+                                         i18n_namespace: "debates.index.search_form",
+                                         id: "search_form" %>
+        <%= render "shared/advanced_search", search_path: debates_path(page: 1), position: "sidebar" %>
         <%= render "shared/tag_cloud", taggable: "debate" %>
         <%= render "popular" %>
       </aside>

--- a/app/views/custom/proposals/index.html.erb
+++ b/app/views/custom/proposals/index.html.erb
@@ -87,8 +87,9 @@
       <% end %>
 
       <% unless params[:retired].present? || params[:selected].present? %>
-        <%= render "shared/advanced_search",
-                   search_path: path_to_search_proposals  %>
+        <div class="show-for-small-only">
+          <%= render "shared/advanced_search", search_path: path_to_search_proposals, position: "list" %>
+        </div>
       <% end %>
 
       <% unless params[:selected].present? %>
@@ -151,6 +152,13 @@
           <%= link_to t("proposals.index.start_proposal"),
                       new_proposal_guide,
                       class: "button expanded" %>
+        <% end %>
+
+        <%= render "shared/search_form", search_path: current_path_with_query_params(page: 1),
+                                         i18n_namespace: "proposals.index.search_form",
+                                         id: "search_form" %>
+        <% unless params[:retired].present? || params[:selected].present? %>
+          <%= render "shared/advanced_search", search_path: path_to_search_proposals, position: "sidebar" %>
         <% end %>
 
         <div class="sidebar-divider"></div>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -58,7 +58,9 @@
         </div>
       </div>
 
-      <%= render "shared/advanced_search", search_path: debates_path(page: 1) %>
+      <div class="show-for-small-only">
+        <%= render "shared/advanced_search", search_path: debates_path(page: 1), position: "list" %>
+      </div>
 
       <%= render "shared/order_links", i18n_namespace: "debates.index" %>
 
@@ -104,6 +106,10 @@
 
       <aside class="margin-bottom">
         <%= link_to t("debates.index.start_debate"), new_debate_path, class: "button expanded" %>
+        <%= render "shared/search_form", search_path: debates_path(page: 1),
+                                         i18n_namespace: "debates.index.search_form",
+                                         id: "search_form" %>
+        <%= render "shared/advanced_search", search_path: debates_path(page: 1), position: "sidebar" %>
         <%= render "shared/tag_cloud", taggable: "debate" %>
       </aside>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -50,7 +50,7 @@
         <div class="hide-for-small-only">
           <%= render "shared/subnavigation" %>
         </div>
-        <div class="small-12 medium-3 column">
+        <div class="search-form show-for-small-only small-12 column margin-bottom">
           <%= yield :header_addon %>
         </div>
       </div>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -59,7 +59,7 @@
       <% end %>
 
       <% if show_featured_proposals? %>
-        <div id="featured-proposals" class="row featured-proposals">
+        <div id="featured-proposals" class="row featured-proposals margin-bottom">
           <div class="small-12 column">
             <h2>
               <%= t("proposals.index.featured_proposals") %>
@@ -78,8 +78,9 @@
       </div>
 
       <% unless params[:retired].present? || params[:selected].present? %>
-        <%= render "shared/advanced_search",
-                   search_path: path_to_search_proposals  %>
+        <div class="show-for-small-only">
+          <%= render "shared/advanced_search", search_path: path_to_search_proposals, position: "list" %>
+        </div>
       <% end %>
 
       <% unless params[:selected].present? %>
@@ -124,6 +125,13 @@
         <%= link_to t("proposals.index.start_proposal"),
                     new_proposal_path,
                     class: "button expanded" %>
+
+        <%= render "shared/search_form", search_path: current_path_with_query_params(page: 1),
+                                         i18n_namespace: "proposals.index.search_form",
+                                         id: "search_form" %>
+        <% unless params[:retired].present? || params[:selected].present? %>
+          <%= render "shared/advanced_search", search_path: path_to_search_proposals, position: "sidebar" %>
+        <% end %>
 
         <div class="sidebar-divider"></div>
         <h2 class="sidebar-title"><%= t("proposals.index.selected_proposals") %></h2>

--- a/app/views/shared/_advanced_search.html.erb
+++ b/app/views/shared/_advanced_search.html.erb
@@ -1,12 +1,12 @@
-<div class="relative">
-  <%= link_to t("shared.advanced_search.title"), "#advanced_search_form",
-              id: "js-advanced-search-title",
-              class: "advanced-search small" %>
+<div>
+  <%= link_to t("shared.advanced_search.title"), "#advanced_search_form_#{position}",
+              id: "js-advanced-search-title-#{position}",
+              class: "small" %>
 </div>
 
 <div class="row advanced-search-form">
-  <%= form_tag search_path, id: "advanced_search_form", method: :get do %>
-    <div id="js-advanced-search"
+  <%= form_tag search_path, id: "advanced_search_form_#{position}", method: :get do %>
+    <div id="js-advanced-search-<%= position %>"
          data-advanced-search-terms="<%= @advanced_search_terms.present? %>"
          style="display: none">
 
@@ -29,10 +29,10 @@
           <label for="js-advanced-search-date-min"><%= t("shared.advanced_search.date") %></label>
           <%= select_tag("advanced_search[date_min]", date_range_options,
                         include_blank: t("shared.advanced_search.date_range_blank"),
-                        id: "js-advanced-search-date-min") %>
+                        id: "js-advanced-search-date-min-#{position}") %>
         </div>
 
-        <div id="js-custom-date" class="small-12 large-8 column" style="display: none">
+        <div id="js-custom-date-<%= position %>" class="small-12 large-8 column" style="display: none">
           <div class="row">
             <div class="small-12 large-6 column">
               <label for="advanced_search_date_min">
@@ -40,7 +40,7 @@
               </label>
               <%= text_field_tag "advanced_search[date_min]",
                                   params[:advanced_search].try(:[], :date_min),
-                                  class: "js-calendar" %>
+                                  class: "js-calendar-#{position}" %>
             </div>
             <div class="small-12 large-6 column">
               <label for="advanced_search_date_max">
@@ -48,7 +48,7 @@
               </label>
               <%= text_field_tag "advanced_search[date_max]",
                                   params[:advanced_search].try(:[], :date_max),
-                                  class: "js-calendar" %>
+                                  class: "js-calendar-#{position}" %>
             </div>
           </div>
         </div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,4 +1,8 @@
-<div id="search_form" class="search-form-header">
+<div class="hide-for-small-only">
+  <div class="sidebar-divider"></div>
+  <h2 class="sidebar-title"><%= t("shared.search") %></h2>
+</div>
+
 <div id="<%= local_assigns[:id] %>" class="search-form">
   <h1 class="show-for-sr"><%= t("shared.outline.searcher") %></h1>
   <%= form_tag search_path, method: :get do %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,4 +1,5 @@
 <div id="search_form" class="search-form-header">
+<div id="<%= local_assigns[:id] %>" class="search-form">
   <h1 class="show-for-sr"><%= t("shared.outline.searcher") %></h1>
   <%= form_tag search_path, method: :get do %>
     <div class="input-group">

--- a/app/views/shared/_subnavigation.html.erb
+++ b/app/views/shared/_subnavigation.html.erb
@@ -1,4 +1,4 @@
-<div class="small-12 medium-9 column">
+<div class="small-12 column">
   <ul>
     <%= raw content_block("subnavigation_left", I18n.locale) %>
 

--- a/app/views/shared/_tag_cloud.html.erb
+++ b/app/views/shared/_tag_cloud.html.erb
@@ -1,7 +1,7 @@
+<div class="sidebar-divider"></div>
+<h2 class="sidebar-title"><%= t("shared.tags_cloud.tags") %></h2>
+<br>
 <div id="tag-cloud">
-  <div class="sidebar-divider"></div>
-  <h2 class="sidebar-title"><%= t("shared.tags_cloud.tags") %></h2>
-  <br>
   <ul class="no-bullet tag-cloud">
     <% @tag_cloud.tags.each do |tag| %>
       <li class="inline-block">

--- a/spec/features/budgets/investments_spec.rb
+++ b/spec/features/budgets/investments_spec.rb
@@ -183,7 +183,7 @@ describe "Budget Investments" do
 
       visit budget_investments_path(budget, heading_id: heading.id)
 
-      within(".expanded #search_form") do
+      within("#search_form") do
         fill_in "search", with: "Schwifty"
         click_button "Search"
       end
@@ -350,9 +350,11 @@ describe "Budget Investments" do
 
             visit budget_investments_path(budget)
 
-            click_link "Advanced search"
-            select "Last 24 hours", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 investments")
 
@@ -370,9 +372,11 @@ describe "Budget Investments" do
 
             visit budget_investments_path(budget)
 
-            click_link "Advanced search"
-            select "Last week", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last week", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 investments")
 
@@ -390,9 +394,11 @@ describe "Budget Investments" do
 
             visit budget_investments_path(budget)
 
-            click_link "Advanced search"
-            select "Last month", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last month", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 investments")
 
@@ -410,9 +416,11 @@ describe "Budget Investments" do
 
             visit budget_investments_path(budget)
 
-            click_link "Advanced search"
-            select "Last year", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last year", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 investments")
 
@@ -432,11 +440,13 @@ describe "Budget Investments" do
 
           visit budget_investments_path(budget)
 
-          click_link "Advanced search"
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 7.days.ago
-          fill_in "advanced_search_date_max", with: 1.day.ago
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 7.days.ago
+            fill_in "advanced_search_date_max", with: 1.day.ago
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 2 investments")
 
@@ -454,11 +464,13 @@ describe "Budget Investments" do
 
           visit budget_investments_path(budget)
 
-          click_link "Advanced search"
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 4000.years.ago
-          fill_in "advanced_search_date_max", with: "wrong date"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 4000.years.ago
+            fill_in "advanced_search_date_max", with: "wrong date"
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 3 investments")
 
@@ -479,10 +491,12 @@ describe "Budget Investments" do
 
           visit budget_investments_path(budget)
 
-          click_link "Advanced search"
-          fill_in "Write the text", with: "Schwifty"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
+          within("aside") do
+            click_link "Advanced search"
+            fill_in "Write the text", with: "Schwifty"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+          end
 
           click_button "Filter"
 
@@ -495,17 +509,19 @@ describe "Budget Investments" do
 
         scenario "Maintain advanced search criteria", :js do
           visit budget_investments_path(budget)
-          click_link "Advanced search"
 
-          fill_in "Write the text", with: "Schwifty"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
+          within("aside") do
+            click_link "Advanced search"
+            fill_in "Write the text", with: "Schwifty"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+          end
 
           click_button "Filter"
 
           expect(page).to have_content("investments cannot be found")
 
-          within "#js-advanced-search" do
+          within "#js-advanced-search-sidebar" do
             expect(page).to have_selector("input[name='search'][value='Schwifty']")
             expect(page).to have_select("advanced_search[official_level]", selected: Setting["official_level_1_name"])
             expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
@@ -514,16 +530,18 @@ describe "Budget Investments" do
 
         scenario "Maintain custom date search criteria", :js do
           visit budget_investments_path(budget)
-          click_link "Advanced search"
 
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
-          fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
+            fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
+            click_button "Filter"
+          end
 
           expect(page).to have_content("investments cannot be found")
 
-          within "#js-advanced-search" do
+          within "#js-advanced-search-sidebar" do
             expect(page).to have_select("advanced_search[date_min]", selected: "Customized")
             expect(page).to have_selector("input[name='advanced_search[date_min]'][value*='#{7.days.ago.strftime('%d/%m/%Y')}']")
             expect(page).to have_selector("input[name='advanced_search[date_max]'][value*='#{1.day.ago.strftime('%d/%m/%Y')}']")

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -630,7 +630,7 @@ describe "Debates" do
 
         visit debates_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: "Schwifty"
           click_button "Search"
         end
@@ -647,7 +647,7 @@ describe "Debates" do
       scenario "Maintain search criteria" do
         visit debates_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: "Schwifty"
           click_button "Search"
         end
@@ -666,9 +666,11 @@ describe "Debates" do
 
         visit debates_path
 
-        click_link "Advanced search"
-        fill_in "Write the text", with: "Schwifty"
-        click_button "Filter"
+        within("aside") do
+          click_link "Advanced search"
+          fill_in "Write the text", with: "Schwifty"
+          click_button "Filter"
+        end
 
         expect(page).to have_content("There are 2 debates")
 
@@ -691,9 +693,11 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 2 debates")
 
@@ -714,9 +718,11 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          select Setting["official_level_2_name"], from: "advanced_search_official_level"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select Setting["official_level_2_name"], from: "advanced_search_official_level"
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 2 debates")
 
@@ -737,9 +743,11 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          select Setting["official_level_3_name"], from: "advanced_search_official_level"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select Setting["official_level_3_name"], from: "advanced_search_official_level"
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 2 debates")
 
@@ -760,9 +768,11 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          select Setting["official_level_4_name"], from: "advanced_search_official_level"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select Setting["official_level_4_name"], from: "advanced_search_official_level"
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 2 debates")
 
@@ -809,9 +819,11 @@ describe "Debates" do
 
             visit debates_path
 
-            click_link "Advanced search"
-            select "Last 24 hours", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             within("#debates") do
               expect(page).to have_css(".debate", count: 2)
@@ -829,9 +841,11 @@ describe "Debates" do
 
             visit debates_path
 
-            click_link "Advanced search"
-            select "Last week", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last week", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             within("#debates") do
               expect(page).to have_css(".debate", count: 2)
@@ -849,9 +863,11 @@ describe "Debates" do
 
             visit debates_path
 
-            click_link "Advanced search"
-            select "Last month", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last month", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             within("#debates") do
               expect(page).to have_css(".debate", count: 2)
@@ -869,9 +885,11 @@ describe "Debates" do
 
             visit debates_path
 
-            click_link "Advanced search"
-            select "Last year", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last year", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             within("#debates") do
               expect(page).to have_css(".debate", count: 2)
@@ -891,11 +909,13 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 7.days.ago
-          fill_in "advanced_search_date_max", with: 1.day.ago
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 7.days.ago
+            fill_in "advanced_search_date_max", with: 1.day.ago
+            click_button "Filter"
+          end
 
           within("#debates") do
             expect(page).to have_css(".debate", count: 2)
@@ -913,11 +933,13 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: "9"
-          fill_in "advanced_search_date_max", with: "444444444"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: "9"
+            fill_in "advanced_search_date_max", with: "444444444"
+            click_button "Filter"
+          end
 
           within("#debates") do
             expect(page).to have_css(".debate", count: 3)
@@ -938,10 +960,12 @@ describe "Debates" do
 
           visit debates_path
 
-          click_link "Advanced search"
-          fill_in "Write the text", with: "Schwifty"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
+          within("aside") do
+            click_link "Advanced search"
+            fill_in "Write the text", with: "Schwifty"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+          end
 
           click_button "Filter"
 
@@ -953,15 +977,16 @@ describe "Debates" do
 
         scenario "Maintain advanced search criteria", :js do
           visit debates_path
-          click_link "Advanced search"
 
-          fill_in "Write the text", with: "Schwifty"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
+          within("aside") do
+            click_link "Advanced search"
+            fill_in "Write the text", with: "Schwifty"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+            click_button "Filter"
+          end
 
-          click_button "Filter"
-
-          within "#js-advanced-search" do
+          within "#js-advanced-search-sidebar" do
             expect(page).to have_selector("input[name='search'][value='Schwifty']")
             expect(page).to have_select("advanced_search[official_level]", selected: Setting["official_level_1_name"])
             expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
@@ -970,14 +995,16 @@ describe "Debates" do
 
         scenario "Maintain custom date search criteria", :js do
           visit debates_path
-          click_link "Advanced search"
 
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
-          fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
+            fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
+            click_button "Filter"
+          end
 
-          within "#js-advanced-search" do
+          within "#js-advanced-search-sidebar" do
             expect(page).to have_select("advanced_search[date_min]", selected: "Customized")
             expect(page).to have_selector("input[name='advanced_search[date_min]'][value*='#{7.days.ago.strftime("%d/%m/%Y")}']")
             expect(page).to have_selector("input[name='advanced_search[date_max]'][value*='#{1.day.ago.strftime("%d/%m/%Y")}']")
@@ -1012,8 +1039,12 @@ describe "Debates" do
       debate4 = create(:debate, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
 
       visit debates_path
-      fill_in "search", with: "Show you got"
-      click_button "Search"
+
+      within("#search_form") do
+        fill_in "search", with: "Show you got"
+        click_button "Search"
+      end
+
       click_link "newest"
       expect(page).to have_selector("a.is-active", text: "newest")
 
@@ -1040,8 +1071,12 @@ describe "Debates" do
       create(:follow, followable: proposal1, user: user)
 
       visit debates_path
-      fill_in "search", with: "Show you got"
-      click_button "Search"
+
+      within("#search_form") do
+        fill_in "search", with: "Show you got"
+        click_button "Search"
+      end
+
       click_link "recommendations"
       expect(page).to have_selector("a.is-active", text: "recommendations")
 
@@ -1061,7 +1096,7 @@ describe "Debates" do
       debate = create(:debate, title: "Abcdefghi")
 
       visit debates_path
-      within(".expanded #search_form") do
+      within("#search_form") do
         fill_in "search", with: debate.title
         click_button "Search"
       end

--- a/spec/features/human_rights_spec.rb
+++ b/spec/features/human_rights_spec.rb
@@ -46,7 +46,7 @@ describe "Human Rights" do
 
         visit human_rights_proposals_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: "Schwifty"
           click_button "Search"
         end
@@ -68,7 +68,7 @@ describe "Human Rights" do
 
         visit human_rights_proposals_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: "educación"
           click_button "Search"
         end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -1147,7 +1147,7 @@ describe "Proposals" do
 
         visit proposals_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: "Schwifty"
           click_button "Search"
         end
@@ -1167,7 +1167,7 @@ describe "Proposals" do
 
         visit proposals_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: proposal1.code
           click_button "Search"
         end
@@ -1183,7 +1183,7 @@ describe "Proposals" do
       scenario "Maintain search criteria" do
         visit proposals_path
 
-        within(".expanded #search_form") do
+        within("#search_form") do
           fill_in "search", with: "Schwifty"
           click_button "Search"
         end
@@ -1346,9 +1346,11 @@ describe "Proposals" do
 
             visit proposals_path
 
-            click_link "Advanced search"
-            select "Last 24 hours", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 citizen proposals")
 
@@ -1366,9 +1368,11 @@ describe "Proposals" do
 
             visit proposals_path
 
-            click_link "Advanced search"
-            select "Last week", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last week", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 citizen proposals")
 
@@ -1386,9 +1390,11 @@ describe "Proposals" do
 
             visit proposals_path
 
-            click_link "Advanced search"
-            select "Last month", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last month", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 citizen proposals")
 
@@ -1406,9 +1412,11 @@ describe "Proposals" do
 
             visit proposals_path
 
-            click_link "Advanced search"
-            select "Last year", from: "js-advanced-search-date-min"
-            click_button "Filter"
+            within("aside") do
+              click_link "Advanced search"
+              select "Last year", from: "js-advanced-search-date-min-sidebar"
+              click_button "Filter"
+            end
 
             expect(page).to have_content("There are 2 citizen proposals")
 
@@ -1428,11 +1436,13 @@ describe "Proposals" do
 
           visit proposals_path
 
-          click_link "Advanced search"
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 7.days.ago
-          fill_in "advanced_search_date_max", with: 1.day.ago
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 7.days.ago
+            fill_in "advanced_search_date_max", with: 1.day.ago
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 2 citizen proposals")
 
@@ -1450,11 +1460,13 @@ describe "Proposals" do
 
           visit proposals_path
 
-          click_link "Advanced search"
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 4000.years.ago
-          fill_in "advanced_search_date_max", with: "wrong date"
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 4000.years.ago
+            fill_in "advanced_search_date_max", with: "wrong date"
+            click_button "Filter"
+          end
 
           expect(page).to have_content("There are 3 citizen proposals")
 
@@ -1475,10 +1487,12 @@ describe "Proposals" do
 
           visit proposals_path
 
-          click_link "Advanced search"
-          fill_in "Write the text", with: "Schwifty"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
+          within("aside") do
+            click_link "Advanced search"
+            fill_in "Write the text", with: "Schwifty"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+          end
 
           click_button "Filter"
 
@@ -1491,17 +1505,19 @@ describe "Proposals" do
 
         scenario "Maintain advanced search criteria", :js do
           visit proposals_path
-          click_link "Advanced search"
 
-          fill_in "Write the text", with: "Schwifty"
-          select Setting["official_level_1_name"], from: "advanced_search_official_level"
-          select "Last 24 hours", from: "js-advanced-search-date-min"
+          within("aside") do
+            click_link "Advanced search"
+            fill_in "Write the text", with: "Schwifty"
+            select Setting["official_level_1_name"], from: "advanced_search_official_level"
+            select "Last 24 hours", from: "js-advanced-search-date-min-sidebar"
+          end
 
           click_button "Filter"
 
           expect(page).to have_content("citizen proposals cannot be found")
 
-          within "#js-advanced-search" do
+          within "#js-advanced-search-sidebar" do
             expect(page).to have_selector("input[name='search'][value='Schwifty']")
             expect(page).to have_select("advanced_search[official_level]", selected: Setting["official_level_1_name"])
             expect(page).to have_select("advanced_search[date_min]", selected: "Last 24 hours")
@@ -1510,16 +1526,18 @@ describe "Proposals" do
 
         scenario "Maintain custom date search criteria", :js do
           visit proposals_path
-          click_link "Advanced search"
 
-          select "Customized", from: "js-advanced-search-date-min"
-          fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
-          fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
-          click_button "Filter"
+          within("aside") do
+            click_link "Advanced search"
+            select "Customized", from: "js-advanced-search-date-min-sidebar"
+            fill_in "advanced_search_date_min", with: 7.days.ago.strftime("%d/%m/%Y")
+            fill_in "advanced_search_date_max", with: 1.day.ago.strftime("%d/%m/%Y")
+            click_button "Filter"
+          end
 
           expect(page).to have_content("citizen proposals cannot be found")
 
-          within "#js-advanced-search" do
+          within "#js-advanced-search-sidebar" do
             expect(page).to have_select("advanced_search[date_min]", selected: "Customized")
             expect(page).to have_selector("input[name='advanced_search[date_min]'][value*='#{7.days.ago.strftime("%d/%m/%Y")}']")
             expect(page).to have_selector("input[name='advanced_search[date_max]'][value*='#{1.day.ago.strftime("%d/%m/%Y")}']")
@@ -1582,8 +1600,12 @@ describe "Proposals" do
       create(:follow, followable: proposal5, user: user)
 
       visit proposals_path
-      fill_in "search", with: "Show you got"
-      click_button "Search"
+
+      within("#search_form") do
+        fill_in "search", with: "Show you got"
+        click_button "Search"
+      end
+
       click_link "recommendations"
       expect(page).to have_selector("a.is-active", text: "recommendations")
 
@@ -1603,7 +1625,7 @@ describe "Proposals" do
       proposal = create(:proposal, title: "Abcdefghi")
 
       visit proposals_path
-      within(".expanded #search_form") do
+      within("#search_form") do
         fill_in "search", with: proposal.title
         click_button "Search"
       end


### PR DESCRIPTION
## References

Issue https://github.com/consul/consul/issues/2607.

## Objectives

Move search form from header to sidebar on:
- Debates
- Proposals
- Participatory budgets

## Visual Changes

![search_sidebar](https://user-images.githubusercontent.com/631897/58695963-e7df1280-8396-11e9-8b8c-7a817605cb39.gif)

![search_mobile](https://user-images.githubusercontent.com/631897/58758879-703dee80-8522-11e9-8416-89674dd0b0c6.png)

## Does this PR need a Backport to CONSUL?

Yes, backport to CONSUL.