### PR TITLE
Add Arabic, Bosnian, Croatian, Czech, Danish, Greek, and Turkish to locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,12 +20,18 @@ module Consul
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :es
     available_locales = [
+      "ar",
+      "bs",
+      "cs",
+      "da",
       "de",
+      "el",
       "en",
       "es",
       "fr",
       "gl",
       "he",
+      "hr",
       "id",
       "it",
       "nl",
@@ -36,6 +42,7 @@ module Consul
       "sq",
       "so",
       "sv",
+      "tr",
       "val",
       "zh-CN",
       "zh-TW"]

--- a/config/locales/bs-BA/i18n.yml
+++ b/config/locales/bs-BA/i18n.yml
@@ -1,4 +1,4 @@
 bs:
   i18n:
     language:
-      name: "Engleski"
+      name: "Bosanski"

--- a/config/locales/da-DK/i18n.yml
+++ b/config/locales/da-DK/i18n.yml
@@ -1,4 +1,4 @@
 da:
   i18n:
     language:
-      name: "Engelsk"
+      name: "Dansk"

--- a/config/locales/hr-HR/i18n.yml
+++ b/config/locales/hr-HR/i18n.yml
@@ -1,4 +1,4 @@
 hr:
   i18n:
     language:
-      name: "Engleski"
+      name: "Hrvatski"

--- a/config/locales/it/i18n.yml
+++ b/config/locales/it/i18n.yml
@@ -1,4 +1,4 @@
 it:
   i18n:
     language:
-      name: "Inglese"
+      name: "Italiano"


### PR DESCRIPTION
## References

**PR:** https://github.com/consul/consul/pull/3571/

## Objectives

- Add Arabic, Bosnian, Croatian, Czech, Danish, Greek, and Turkish as available locales.
- Update locale names for Italian, Polish and Albanian.

## Does this PR need a Backport to CONSUL?

No, this PR comes from upstream.

## Notes

This PR contains a commit from a [Prerequisite PR](https://github.com/AyuntamientoMadrid/consul/pull/2030) 