### PR TITLE
Show name and email for deleted poll officer's user account

### DIFF
--- a/app/models/poll/officer.rb
+++ b/app/models/poll/officer.rb
@@ -7,7 +7,13 @@ class Poll
 
     validates :user_id, presence: true, uniqueness: true
 
-    delegate :name, :email, to: :user
+    def name
+      user&.name || I18n.t("shared.author_info.author_deleted")
+    end
+
+    def email
+      user&.email || I18n.t("shared.author_info.email_deleted")
+    end
 
     def voting_days_assigned_polls
       officer_assignments.voting_days.includes(booth_assignment: :poll).

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -723,6 +723,7 @@ en:
       to: 'To'
     author_info:
       author_deleted: User deleted
+      email_deleted: Email deleted
     back: Go back
     check: Select
     check_all: All

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -723,6 +723,7 @@ es:
       to: 'Hasta'
     author_info:
       author_deleted: Usuario eliminado
+      email_deleted: Email eliminado
     back: Volver
     check: Seleccionar
     check_all: Todos

--- a/spec/models/poll/officer_spec.rb
+++ b/spec/models/poll/officer_spec.rb
@@ -2,6 +2,34 @@ require "rails_helper"
 
 describe Poll::Officer do
 
+  describe "#name" do
+    let(:officer) { create(:poll_officer) }
+
+    it "returns user name if user is not deleted" do
+      expect(officer.name).to eq officer.user.name
+    end
+
+    it "returns 'User deleted' if user is deleted" do
+      officer.user.destroy
+
+      expect(officer.reload.name).to eq "User deleted"
+    end
+  end
+
+  describe "#email" do
+    let(:officer) { create(:poll_officer) }
+
+    it "returns user email if user is not deleted" do
+      expect(officer.email).to eq officer.user.email
+    end
+
+    it "returns 'Email deleted' if user is deleted" do
+      officer.user.destroy
+
+      expect(officer.reload.email).to eq "Email deleted"
+    end
+  end
+
   describe "#voting_days_assigned_polls" do
     it "returns all polls with this officer assigned during voting days" do
       officer = create(:poll_officer)


### PR DESCRIPTION
## Objectives

Avoid to raise an exception `Module::DelegationError` when trying to show the name and/or email of a poll officer whose user account has been deleted.
We'll show a message "User deleted" and "Email deleted" instead.

## Does this PR need a Backport to CONSUL?

Yes