### PR TITLE
Avoid error when accessing final voting stats before the balloting phase

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -78,6 +78,8 @@ class Admin::StatsController < Admin::BaseController
   def budget_balloting
     @budget = Budget.find(params[:budget_id])
 
+    authorize! :read_admin_stats, @budget, message: t("admin.stats.budgets.no_data_before_balloting_phase")
+
     budget_stats = Stat.hash("budget_#{@budget.id}_balloting_stats")
     @user_count = budget_stats["stats"]["user_count"]
     @vote_count = budget_stats["stats"]["vote_count"]

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -68,6 +68,8 @@ module Abilities
       can :create, Budget::ValuatorAssignment
       can [:read_results], Budget, phase: "reviewing_ballots"
 
+      can(:read_admin_stats, Budget) { |budget| budget.balloting_or_later? }
+
       can [:search, :edit, :update, :create, :index, :destroy], Banner
 
       can [:index, :create, :edit, :update, :destroy], Geozone

--- a/app/views/admin/stats/budgets.html.erb
+++ b/app/views/admin/stats/budgets.html.erb
@@ -9,8 +9,15 @@
         <strong><%= budget.name %></strong>
       </td>
       <td>
-        <%= link_to t("admin.stats.budgets.supporting_phase"), budget_supporting_admin_stats_path(budget_id: budget.id), class: "button hollow" %>
-        <%= link_to t("admin.stats.budgets.balloting_phase"), budget_balloting_admin_stats_path(budget_id: budget.id), class: "button hollow" %>
+        <%= link_to t("admin.stats.budgets.supporting_phase"),
+                    budget_supporting_admin_stats_path(budget_id: budget.id),
+                    class: "button hollow" %>
+
+        <% if can? :read_admin_stats, budget %>
+          <%= link_to t("admin.stats.budgets.balloting_phase"),
+                      budget_balloting_admin_stats_path(budget_id: budget.id),
+                      class: "button hollow" %>
+        <% end %>
       </td>
     </tr>
   </table>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1405,6 +1405,8 @@ en:
           other: "There is %{count} votes created from verified signatures."
         loading: "There are still signatures that are being verified by the Census, please refresh the page in a few moments"
     stats:
+      budgets:
+        no_data_before_balloting_phase: "There isn't any data to show before the balloting phase."
       show:
         stats_title: Stats
         summary:

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -1404,6 +1404,8 @@ es:
           other: "Hay %{count} votos asociados a las firmas verificadas."
         loading: "Aún hay firmas que se están verificando por el Padrón, por favor refresca la página en unos instantes"
     stats:
+      budgets:
+        no_data_before_balloting_phase: "No hay datos que mostrar hasta que la fase de votación no esté abierta."
       show:
         stats_title: Estadísticas
         summary:

--- a/spec/features/admin/stats_spec.rb
+++ b/spec/features/admin/stats_spec.rb
@@ -205,6 +205,21 @@ describe "Stats" do
         within("#only_district_voters") {expect(page).to have_content 1}
         within("#only_city_voters") {expect(page).to have_content 1}
       end
+
+      scenario "hide final voting link" do
+        visit admin_stats_path
+        click_link "Participatory Budgets"
+
+        within("#budget_#{budget.id}") do
+          expect(page).not_to have_link "Final voting"
+        end
+      end
+
+      scenario "show message when accessing final voting stats" do
+        visit budget_balloting_admin_stats_path(budget_id: budget.id)
+
+        expect(page).to have_content "There isn't any data to show before the balloting phase."
+      end
     end
 
     context "Balloting phase" do


### PR DESCRIPTION
## Objectives

When accessing the URL `/admin/stats/budget_balloting?budget_id=X` for a budget in a phase prior to the balloting phase, the following error was raised due to the stats were not calculated yet. Instead, we'll now show a flash message.

```
NoMethodError:
  undefined method `[]' for nil:NilClass
    ./app/controllers/admin/stats_controller.rb:82
```

## Visual Changes
![Captura de pantalla 2019-06-06 a las 18 15 02](https://user-images.githubusercontent.com/942995/59049247-e1b1d000-8887-11e9-8547-00f59830b94a.png)

![Captura de pantalla 2019-06-06 a las 18 54 16](https://user-images.githubusercontent.com/942995/59051188-88986b00-888c-11e9-9333-50fc3ccf83af.png)

## Does this PR need a Backport to CONSUL?

Yes 😄 
