### PR TITLE
Add related content section on proposal dashboard

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -86,6 +86,17 @@
   margin: $line-height 0;
 }
 
+.dashboard-related-content {
+
+  .related-content {
+    border-top: 0;
+
+    .margin-bottom {
+      margin-bottom: 0;
+    }
+  }
+}
+
 // 02. Actions
 // -----------
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class DashboardController < Dashboard::BaseController
   helper_method :dashboard_action, :active_resources, :course
   before_action :set_done_and_pending_actions, only: [:recommended_actions, :progress]
-  before_action :authorize_dashboard, only: [:show, :progress, :community, :recommended_actions, :messages]
+  before_action :authorize_dashboard, except: :publish
 
   def show
   end
@@ -23,6 +23,10 @@ class DashboardController < Dashboard::BaseController
   end
 
   def messages
+  end
+
+  def related_content
+    @related_contents = Kaminari.paginate_array(proposal.relationed_contents).page(params[:page]).per(5)
   end
 
   private

--- a/app/helpers/proposals_dashboard_helper.rb
+++ b/app/helpers/proposals_dashboard_helper.rb
@@ -11,6 +11,10 @@ module ProposalsDashboardHelper
     controller_name == "dashboard" && action_name == "messages"
   end
 
+  def related_content_menu_active?
+    controller_name == "dashboard" && action_name == "related_content"
+  end
+
   def progress_menu_active?
     is_proposed_action_request? || (controller_name == "dashboard" && action_name == "progress")
   end

--- a/app/views/dashboard/_menu.html.erb
+++ b/app/views/dashboard/_menu.html.erb
@@ -96,4 +96,11 @@
       <strong><%= t("dashboard.menu.messages") %></strong>
     <% end %>
   </li>
+
+  <li class="section-title <%= "is-active" if related_content_menu_active? %>">
+    <span class="icon-comments"></span>
+    <%= link_to related_content_proposal_dashboard_path(proposal) do %>
+      <strong><%= t("dashboard.menu.related_content") %></strong>
+    <% end %>
+  </li>
 </ul>

--- a/app/views/dashboard/related_content.html.erb
+++ b/app/views/dashboard/related_content.html.erb
@@ -1,0 +1,3 @@
+<div class="dashboard-related-content">
+  <%= render "relationable/related_content", relationable: @proposal %>
+</div>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -485,6 +485,7 @@ en:
       poster: Poster
       recommended_actions: Recommended actions
       messages: Message to users
+      related_content: Related content
     form:
       request: Request
     create_request:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -485,6 +485,7 @@ es:
       poster: Póster
       recommended_actions: Acciones recomendadas
       messages: Mensajes a usuarios
+      related_content: Contenido relacionado
     form:
       request: Solicitar
     create_request:

--- a/config/routes/proposal.rb
+++ b/config/routes/proposal.rb
@@ -6,6 +6,7 @@ resources :proposals do
       get :community
       get :recommended_actions
       get :messages
+      get :related_content
     end
 
     resources :resources, only: [:index], controller: "dashboard/resources"

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -389,6 +389,31 @@ describe "Proposal's dashboard" do
                                                             anchor: "tab-notifications"))
   end
 
+  scenario "Dashboard has a related content section" do
+    related_debate = create(:debate)
+    related_proposal = create(:proposal)
+
+    create(:related_content, parent_relationable: proposal,
+                             child_relationable: related_debate, author: build(:user))
+
+    create(:related_content, parent_relationable: proposal,
+                             child_relationable: related_proposal, author: build(:user))
+
+    within("#side_menu") do
+      click_link "Related content"
+    end
+
+    expect(page).to have_button("Add related content")
+
+    within(".dashboard-related-content") do
+      expect(page).to have_content("Related content (2)")
+      expect(page).to have_selector(".related-content-title", text: "Proposal")
+      expect(page).to have_link related_proposal.title
+      expect(page).to have_selector(".related-content-title", text: "Debate")
+      expect(page).to have_link related_debate.title
+    end
+  end
+
   scenario "On recommended actions section display from the fourth proposed actions
             when click see_proposed_actions_link", js: true do
     create_list(:dashboard_action, 4, :proposed_action, :active)


### PR DESCRIPTION
## Objectives

Add related content section on proposal dashboard.

## Visual Changes

![dashboard_related_content](https://user-images.githubusercontent.com/631897/59041847-b922d980-8879-11e9-9c0d-8c325baa85f0.png)

## Does this PR need a Backport to CONSUL?

Yes, backport to CONSUL.