### PR TITLE
Hide polls created by users on admin poll booth assigments

### DIFF
--- a/app/controllers/admin/poll/polls_controller.rb
+++ b/app/controllers/admin/poll/polls_controller.rb
@@ -56,7 +56,7 @@ class Admin::Poll::PollsController < Admin::Poll::BaseController
   end
 
   def booth_assignments
-    @polls = Poll.current
+    @polls = Poll.current.created_by_admin
   end
 
   def destroy

--- a/spec/features/admin/poll/booth_assigments_spec.rb
+++ b/spec/features/admin/poll/booth_assigments_spec.rb
@@ -31,6 +31,16 @@ describe "Admin booths assignments" do
       expect(page).to have_content(second_booth.name)
     end
 
+    scenario "Index do not show polls created by users from proposals dashboard" do
+      create(:poll, name: "Poll created by admin")
+      create(:poll, name: "Poll from user's proposal", related_type: "Proposal")
+
+      visit booth_assignments_admin_polls_path
+
+      expect(page).to have_content "Poll created by admin"
+      expect(page).not_to have_content "Poll from user's proposal"
+    end
+
     scenario "Assign booth to poll", :js do
       visit admin_poll_path(poll)
       within("#poll-resources") do


### PR DESCRIPTION
## Objectives

Hide polls created by users on admin poll booth assigments `/admin/polls/booth_assignments`.

## Does this PR need a Backport to CONSUL?

Yes, backport to CONSUL.