### PR TITLE
Load custom locales after everything is loaded

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ module Consul
       "nl"    => "en"
     }
 
-    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**[^custom]*", "*.{rb,yml}")]
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "custom", "**", "*.{rb,yml}")]
 
     config.after_initialize do

--- a/spec/customization_engine_spec.rb
+++ b/spec/customization_engine_spec.rb
@@ -3,38 +3,72 @@ require "rails_helper"
 # This module tests functionality related with custom application files
 # TODO test models, controllers, etc...
 
-describe "Customization Engine" do
-
-  let(:test_key)      { I18n.t("account.show.change_credentials_link") }
+describe "Check Custom Locales" do
   let!(:default_path) { I18n.load_path }
-
-  before do
-    reset_load_path_and_reload(default_path)
-  end
 
   after do
     reset_load_path_and_reload(default_path)
   end
 
-  it "loads custom and override original locales" do
-    increase_load_path_and_reload(Dir[Rails.root.join("spec", "support",
-                                                      "locales", "custom", "*.{rb,yml}")])
-    expect(test_key).to eq "Overriden string with custom locales"
+  describe "Customization Engine" do
+    let(:test_key)      { I18n.t("account.show.change_credentials_link") }
+
+    before do
+      reset_load_path_and_reload(default_path)
+    end
+
+    it "loads custom and override original locales" do
+      increase_load_path_and_reload(Dir[Rails.root.join("spec", "support",
+                                                        "locales", "custom", "*.{rb,yml}")])
+      expect(test_key).to eq "Overriden string with custom locales"
+    end
+
+    it "does not override original locales" do
+      increase_load_path_and_reload(Dir[Rails.root.join("spec", "support",
+                                                        "locales", "*.{rb,yml}")])
+      expect(test_key).to eq "Not overriden string with custom locales"
+    end
+
+    def increase_load_path_and_reload(path)
+      I18n.load_path += path
+      I18n.reload!
+    end
   end
 
-  it "does not override original locales" do
-    increase_load_path_and_reload(Dir[Rails.root.join("spec", "support",
-                                                      "locales", "*.{rb,yml}")])
-    expect(test_key).to eq "Not overriden string with custom locales"
+  describe "I18n config load_path" do
+
+    let(:test_key)      { I18n.t("management.document_verifications.not_in_census") }
+
+    it "loads custom and override original locales" do
+      i18n_load_path_correctly
+
+      expect(test_key).to eq "This document is not registered in Madrid Census."
+    end
+
+    it "load original locales" do
+      i18n_load_path_wrongly
+
+      expect(test_key).to eq "This document is not registered in Madrid."
+    end
+
+    def i18n_load_path_correctly
+      I18n.load_path = Dir[Rails.root.join("config", "locales", "**[^custom]*", "*.{rb,yml}")]
+      I18n.load_path += Dir[Rails.root.join("config", "locales", "custom", "**", "*.{rb,yml}")]
+
+      I18n.reload!
+    end
+
+    def i18n_load_path_wrongly
+      I18n.load_path = Dir[Rails.root.join("config", "locales", "custom", "**", "*.{rb,yml}")]
+      I18n.load_path += Dir[Rails.root.join("config", "locales", "**[^custom]*", "*.{rb,yml}")]
+
+      I18n.reload!
+    end
+
   end
 
   def reset_load_path_and_reload(path)
     I18n.load_path = path
-    I18n.reload!
-  end
-
-  def increase_load_path_and_reload(path)
-    I18n.load_path += path
     I18n.reload!
   end
 


### PR DESCRIPTION
## References
Related PR: [Load custom locales after everything is loaded #3663](https://github.com/consul/consul/pull/3663) 

## Objectives
Fix specs related with custom locales.

## Notes
The line:

```
config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
```

Was adding every locale under the `config/locales` folder, including the
ones inside `config/locales/custom/`. The files were loaded in the same
order as listed using `ls -f`.

So if the custom locales were loaded before the folder
`config/locales/#{I18n.locale}`, the default locales would override the
custom ones, and we want the custom locales to override the default
ones so CONSUL is easier to customize.