### PR TITLE
Executions tab management

### DIFF
--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -23,7 +23,7 @@ module Abilities
       can [:read, :print, :json_data], Budget::Investment
       can(:read_results, Budget) { |budget| budget.results_enabled? && budget.finished? }
       can(:read_stats, Budget) { |budget| budget.stats_enabled? && budget.valuating_or_later? }
-      can :read_executions, Budget, phase: "finished"
+      can(:read_executions, Budget) { |budget| budget.executions_enabled? && budget.finished? }
       can :new, DirectMessage
       can [:read, :debate, :draft_publication, :allegations, :result_publication,
            :proposals, :milestones], Legislation::Process, published: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,5 +1,5 @@
 class Report < ApplicationRecord
-  KINDS = %i[results stats advanced_stats]
+  KINDS = %i[results stats advanced_stats executions]
 
   belongs_to :process, polymorphic: true
 end

--- a/app/views/admin/shared/_show_results_fields.html.erb
+++ b/app/views/admin/shared/_show_results_fields.html.erb
@@ -3,5 +3,6 @@
   <%= form.check_box :results_enabled %>
   <%= form.check_box :stats_enabled %>
   <%= form.check_box :advanced_stats_enabled %>
+  <%= form.check_box :executions_enabled if form.object_name == "budget" %>
   <p class="small"><%= t("admin.shared.results_and_stats_reminder") %></p>
 </fieldset>

--- a/app/views/budgets/_finished.html.erb
+++ b/app/views/budgets/_finished.html.erb
@@ -20,10 +20,11 @@
                                 budget_results_path(budget),
                                 class: "button" %>
                   <% end %>
-
-                  <%= link_to t("budgets.index.milestones"),
-                              budget_executions_path(budget),
-                              class: "button" %>
+                  <% if can?(:read_executions, budget) %>
+                    <%= link_to t("budgets.index.milestones"),
+                                budget_executions_path(budget),
+                                class: "button" %>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -3,6 +3,7 @@ en:
     results_enabled: "Show results"
     stats_enabled: "Show stats"
     advanced_stats_enabled: "Show advanced stats"
+    executions_enabled: "Show Executions"
   activerecord:
     models:
       activity:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -3,6 +3,7 @@ es:
     results_enabled: "Mostrar resultados"
     stats_enabled: "Mostrar estadísticas"
     advanced_stats_enabled: "Mostrar estadísticas avanzadas"
+    executions_enabled: "Mostrar seguimiento"
   activerecord:
     models:
       activity:

--- a/db/migrate/20190722133302_add_executions_to_reports.rb
+++ b/db/migrate/20190722133302_add_executions_to_reports.rb
@@ -1,0 +1,5 @@
+class AddExecutionsToReports < ActiveRecord::Migration[5.0]
+  def change
+    add_column :reports, :executions, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190531173316) do
+ActiveRecord::Schema.define(version: 20190722133302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1324,6 +1324,7 @@ ActiveRecord::Schema.define(version: 20190531173316) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.boolean  "advanced_stats"
+    t.boolean  "executions",     default: true
     t.index ["process_type", "process_id"], name: "index_reports_on_process_type_and_process_id", using: :btree
   end
 

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -292,6 +292,8 @@ describe "Executions" do
 
     visit budgets_path
 
+    expect(page).not_to have_link "Milestones"
+
     visit budget_stats_path(budget)
 
     expect(page).not_to have_link "Milestones"

--- a/spec/features/budgets/executions_spec.rb
+++ b/spec/features/budgets/executions_spec.rb
@@ -286,4 +286,14 @@ describe "Executions" do
     end
 
   end
+
+  scenario "No links to budget executions with executions disabled" do
+    budget.update(executions_enabled: false)
+
+    visit budgets_path
+
+    visit budget_stats_path(budget)
+
+    expect(page).not_to have_link "Milestones"
+  end
 end

--- a/spec/lib/migrations/reports_spec.rb
+++ b/spec/lib/migrations/reports_spec.rb
@@ -31,13 +31,14 @@ describe Migrations::Reports do
     end
 
     it "ignores budgets with existing reports" do
-      create(:budget, results_enabled: false, stats_enabled: false, advanced_stats_enabled: false)
+      create(:budget, results_enabled: false, stats_enabled: false, advanced_stats_enabled: false, executions_enabled: false)
 
       Migrations::Reports.new.migrate
 
       expect(Budget.last.results_enabled).to be false
       expect(Budget.last.stats_enabled).to be false
       expect(Budget.last.advanced_stats_enabled).to be false
+      expect(Budget.last.executions_enabled).to be false
     end
 
     it "enables results and stats for every budget" do
@@ -48,6 +49,7 @@ describe Migrations::Reports do
       expect(Budget.last.results_enabled).to be true
       expect(Budget.last.stats_enabled).to be true
       expect(Budget.last.advanced_stats_enabled).to be true
+      expect(Budget.last.executions_enabled).to be true
     end
   end
 end

--- a/spec/models/abilities/everyone_spec.rb
+++ b/spec/models/abilities/everyone_spec.rb
@@ -107,4 +107,24 @@ describe Abilities::Everyone do
       it { should_not be_able_to(:read_stats, budget) }
     end
   end
+
+  context "when accessing budget executions" do
+    context "budget is not finished" do
+      let(:budget) { create(:budget, phase: "reviewing_ballots", executions_enabled: true) }
+
+      it { should_not be_able_to(:read_executions, budget) }
+    end
+
+    context "budget is finished" do
+      let(:budget) { create(:budget, :finished) }
+
+      it { should be_able_to(:read_executions, budget) }
+    end
+
+    context "executions disabled" do
+      let(:budget) { create(:budget, :finished, executions_enabled: false) }
+
+      it { should_not be_able_to(:read_executions, budget) }
+    end
+  end
 end

--- a/spec/models/concerns/reportable.rb
+++ b/spec/models/concerns/reportable.rb
@@ -72,4 +72,40 @@ shared_examples "reportable" do
       expect(reportable.read_attribute(:stats_enabled)).to be false
     end
   end
+
+  describe "#executions_enabled" do
+    it "can write and read the attribute" do
+      reportable.executions_enabled = true
+
+      expect(reportable.executions_enabled?).to be true
+      expect(reportable.executions_enabled).to be true
+
+      reportable.executions_enabled = false
+
+      expect(reportable.executions_enabled?).to be false
+      expect(reportable.executions_enabled).to be false
+    end
+
+    it "can save the value to the database" do
+      reportable.update(executions_enabled: true)
+      saved_reportable = described_class.last
+
+      expect(saved_reportable.executions_enabled?).to be true
+      expect(saved_reportable.executions_enabled).to be true
+
+      reportable.update(executions_enabled: false)
+      saved_reportable = described_class.last
+
+      expect(saved_reportable.executions_enabled?).to be false
+      expect(saved_reportable.executions_enabled).to be false
+    end
+
+    it "uses the `has_one` relation instead of the original column" do
+      skip "there's no original column" unless reportable.has_attribute?(:executions_enabled)
+
+      reportable.update(executions_enabled: true)
+
+      expect(reportable.read_attribute(:executions_enabled)).to be false
+    end
+  end
 end


### PR DESCRIPTION
## Objectives
An administrator can manage to show or hide information related to the tracking of participatory budgets (executions) from Backend (budget#edit).
Related content that we will display or hide:
  - Executions tab on Budget#show Results/Stats page ()
  - Finished participatory budgets section on Budget#index

## Visual Changes
- Backend(budget#edit)
![Captura de pantalla 2019-07-23 a las 9 44 04](https://user-images.githubusercontent.com/16189/61692726-73897580-ad2e-11e9-987a-0b6d052c4651.png)
- Budget#show
![Captura de pantalla 2019-07-23 a las 9 46 26](https://user-images.githubusercontent.com/16189/61692867-c5320000-ad2e-11e9-8eaa-a434d8a084e6.png)
- Budget#index
![Captura de pantalla 2019-07-23 a las 9 45 11](https://user-images.githubusercontent.com/16189/61692878-cbc07780-ad2e-11e9-8a51-a7e4d7721cd7.png)

## Does this PR need a Backport to CONSUL?
Yes

