### PR TITLE
Add related proposal markers to proposal map

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/app/assets/javascripts/legislation_annotatable.js.coffee
+++ b/app/assets/javascripts/legislation_annotatable.js.coffee
@@ -165,7 +165,7 @@ App.LegislationAnnotatable =
 
       checkExist = setInterval((->
         if $("span[data-annotation-id='#{last_annotation.id}']").length
-          for annotation in annotations
+          annotations.forEach (annotation) ->
             ann_weight = App.LegislationAnnotatable.propotionalWeight(annotation.weight, max_weight)
             el = $("span[data-annotation-id='#{annotation.id}']")
             el.addClass("weight-#{ann_weight}")

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -98,10 +98,10 @@ App.Map =
       map.on    "click",   moveOrPlaceMarker
 
     if addMarkerInvestments
-      for i in addMarkerInvestments
-        if App.Map.validCoordinates(i)
-          marker = createMarker(i.lat, i.long)
-          marker.options["id"] = i.investment_id
+      addMarkerInvestments.forEach (coordinates) ->
+        if App.Map.validCoordinates(coordinates)
+          marker = createMarker(coordinates.lat, coordinates.long)
+          marker.options["id"] = coordinates.investment_id
 
           marker.on "click", openMarkerPopup
 

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -43,8 +43,7 @@ App.Map =
 
     createRelatedMarker = (latitude, longitude) ->
       markerLatLng  = new (L.LatLng)(latitude, longitude)
-      marker  = L.marker(markerLatLng, { icon: markerRelatedIcon })
-      return marker.addTo(map)
+      return L.marker(markerLatLng, { icon: markerRelatedIcon, zIndexOffset: "-1" })
 
     removeMarker = (e) ->
       e.preventDefault()

--- a/app/assets/javascripts/map.js.coffee
+++ b/app/assets/javascripts/map.js.coffee
@@ -27,6 +27,7 @@ App.Map =
     removeMarkerSelector     = $(element).data("marker-remove-selector")
     addMarkerInvestments     = $(element).data("marker-investments-coordinates")
     addMarkerProposals       = $(element).data("marker-related-proposals-coordinates")
+    relatedProposalsLayerText = $(element).data("related-proposals-layer-text")
     editable                 = $(element).data("marker-editable")
     marker                   = null
     markerIcon               = App.Map.createMarkerIcon(icon_related: false)
@@ -92,7 +93,7 @@ App.Map =
 
     mapCenterLatLng  = new (L.LatLng)(mapCenterLatitude, mapCenterLongitude)
     map              = L.map(element.id).setView(mapCenterLatLng, zoom)
-    L.tileLayer(mapTilesProvider, attribution: mapAttribution).addTo map
+    L.tileLayer(mapTilesProvider, attribution: mapAttribution).addTo(map)
 
     if markerLatitude && markerLongitude && !addMarkerInvestments
       marker  = createMarker(markerLatitude, markerLongitude)
@@ -111,11 +112,21 @@ App.Map =
           marker.on "click", openMarkerPopup
 
     if addMarkerProposals
+      relatedMarkers = L.layerGroup()
       addMarkerProposals.forEach (proposal_info) ->
         if App.Map.validCoordinates(proposal_info)
           marker = createRelatedMarker(proposal_info.lat, proposal_info.long)
-
           marker.bindPopup(getProposalPopupContent(proposal_info.url, proposal_info.title))
+          relatedMarkers.addLayer(marker)
+
+      App.Map.setupControlLayer(map, relatedMarkers, relatedProposalsLayerText)
+
+  setupControlLayer: (map, relatedMarkers, text) ->
+    relatedProposalsLayer = {}
+    relatedIconLayer = ' <div class="layer-related-icon"></div>'
+    relatedProposalsLayer[text+relatedIconLayer] = relatedMarkers
+    L.control.layers(null, relatedProposalsLayer, { collapsed: false }).addTo(map)
+    map.addLayer(relatedMarkers)
 
   toggleMap: ->
     $(".map").toggle()

--- a/app/assets/javascripts/polls.js.coffee
+++ b/app/assets/javascripts/polls.js.coffee
@@ -9,11 +9,11 @@ App.Polls =
     token = token.substring(0, 64)
     return token
 
-  replaceToken: ->
-    for link in $(".js-question-answer")
-      token_param = link.search.slice(-6)
+  replaceToken: (token) ->
+    $(".js-question-answer").each ->
+      token_param = this.search.slice(-6)
       if token_param == "token="
-        link.href = link.href + @token
+        this.href = this.href + token
 
   showTokenMessage: ->
     token_message = $(".js-token-message")
@@ -22,8 +22,8 @@ App.Polls =
       token_message.show()
 
   initialize: ->
-    @token = App.Polls.generateToken()
-    App.Polls.replaceToken()
+    token = App.Polls.generateToken()
+    App.Polls.replaceToken(token)
 
     false
 

--- a/app/assets/javascripts/stats.js.coffee
+++ b/app/assets/javascripts/stats.js.coffee
@@ -8,4 +8,4 @@ buildGraph = (el) ->
 
 App.Stats =
   initialize: ->
-    buildGraph(g) for g in $("[data-graph]")
+    $("[data-graph]").each -> buildGraph(this)

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1147,6 +1147,24 @@ code {
   width: 100%;
   height: 350px;
 
+  %marker-icon {
+    background: #00cae9;
+    border-radius: 50% 50% 50% 0;
+    height: 1em;
+    transform: rotate(-45deg);
+    width: 1em;
+
+    &::after {
+      background: #fff;
+      border-radius: 50%;
+      content: "";
+      height: 46%;
+      margin: 27% 0 0 27%;
+      position: absolute;
+      width: 46%;
+    }
+  }
+
   .map-marker {
     visibility: visible;
     position: absolute;
@@ -1155,21 +1173,8 @@ code {
     margin-top: -5px;
 
     .map-icon {
-      width: 30px;
-      height: 30px;
-      border-radius: 50% 50% 50% 0;
-      background: #00cae9;
-      transform: rotate(-45deg);
-    }
-
-    .map-icon::after {
-      content: "";
-      width: 14px;
-      height: 14px;
-      margin: 8px 0 0 8px;
-      background: #fff;
-      position: absolute;
-      border-radius: 50%;
+      @extend %marker-icon;
+      font-size: 30px;
     }
 
     .map-icon-related {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1171,6 +1171,10 @@ code {
       position: absolute;
       border-radius: 50%;
     }
+
+    .map-icon-related {
+      background: $brand;
+    }
   }
 
   .map-attributtion {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1182,9 +1182,24 @@ code {
     }
   }
 
+  .layer-related-icon {
+    @extend %marker-icon;
+    display: inline-block;
+    background: $brand;
+  }
+
   .map-attributtion {
     visibility: visible;
     height: auto;
+  }
+
+  .leaflet-control-layers-overlays label {
+    font-size: $small-font-size;
+    font-weight: normal;
+
+    input[type="checkbox"] {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/app/helpers/map_locations_helper.rb
+++ b/app/helpers/map_locations_helper.rb
@@ -64,7 +64,10 @@ module MapLocationsHelper
     }
     options[:marker_latitude] = map_location.latitude if map_location.latitude.present?
     options[:marker_longitude] = map_location.longitude if map_location.longitude.present?
-    options[:marker_related_proposals_coordinates] = map_related_proposals_coordinates(map_location.proposal) if map_location.proposal.present?
+
+    if render_related_proposals?(map_location, editable)
+      options[:marker_related_proposals_coordinates] = map_related_proposals_coordinates(map_location.proposal)
+    end
     options
   end
 
@@ -74,5 +77,9 @@ module MapLocationsHelper
     related_proposals.map do |related_proposal|
       related_proposal.map_location.json_data.merge({ url: proposal_path(related_proposal), title: related_proposal.title })
     end
+  end
+
+  def render_related_proposals?(map_location, editable)
+     map_location.proposal.present? && !editable
   end
 end

--- a/app/helpers/map_locations_helper.rb
+++ b/app/helpers/map_locations_helper.rb
@@ -66,7 +66,12 @@ module MapLocationsHelper
     options[:marker_longitude] = map_location.longitude if map_location.longitude.present?
 
     if render_related_proposals?(map_location, editable)
-      options[:marker_related_proposals_coordinates] = map_related_proposals_coordinates(map_location.proposal)
+      related_proposals_coordinates = map_related_proposals_coordinates(map_location.proposal)
+
+      if related_proposals_coordinates.present?
+        options[:marker_related_proposals_coordinates] = related_proposals_coordinates
+        options[:related_proposals_layer_text] = t("map.related_proposals")
+      end
     end
     options
   end

--- a/app/helpers/map_locations_helper.rb
+++ b/app/helpers/map_locations_helper.rb
@@ -77,7 +77,7 @@ module MapLocationsHelper
   end
 
   def map_related_proposals_coordinates(proposal)
-    related_proposals = proposal.related_proposals.published.not_retired.not_archived.joins(:map_location)
+    related_proposals = proposal.related_proposals.published.not_retired.not_archived.joins(:map_location).order(:created_at)
 
     related_proposals.map do |related_proposal|
       related_proposal.map_location.json_data.merge({ url: proposal_path(related_proposal), title: related_proposal.title })

--- a/app/helpers/map_locations_helper.rb
+++ b/app/helpers/map_locations_helper.rb
@@ -64,7 +64,15 @@ module MapLocationsHelper
     }
     options[:marker_latitude] = map_location.latitude if map_location.latitude.present?
     options[:marker_longitude] = map_location.longitude if map_location.longitude.present?
+    options[:marker_related_proposals_coordinates] = map_related_proposals_coordinates(map_location.proposal) if map_location.proposal.present?
     options
   end
 
+  def map_related_proposals_coordinates(proposal)
+    related_proposals = proposal.related_proposals.published.not_retired.not_archived.joins(:map_location)
+
+    related_proposals.map do |related_proposal|
+      related_proposal.map_location.json_data.merge({ url: proposal_path(related_proposal), title: related_proposal.title })
+    end
+  end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -314,21 +314,25 @@ class Proposal < ApplicationRecord
     end
   end
 
-  def previous(author_id) 
+  def previous(author_id)
     if author_id == nil
-      Proposal.where('proposals.id > ?', self.id).first 
+      Proposal.where('proposals.id > ?', self.id).first
     else
-      Proposal.where(author_id: author_id).where('proposals.id > ?', self.id).first 
+      Proposal.where(author_id: author_id).where('proposals.id > ?', self.id).first
     end
-  end 
+  end
 
   def next(author_id)
     if author_id == nil
-      Proposal.where('proposals.id < ?', self.id).last 
+      Proposal.where('proposals.id < ?', self.id).last
     else
-      Proposal.where(author_id: author_id).where('proposals.id < ?', self.id).last 
+      Proposal.where(author_id: author_id).where('proposals.id < ?', self.id).last
     end
-  end 
+  end
+
+  def related_proposals
+    self.class.where.not(id: id).tagged_with(tag_list, any: true)
+  end
 
   protected
 

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -16,7 +16,8 @@
           @proposal,
           @proposal.author,
           Flag.flagged?(current_user, @proposal),
-          @proposal_votes] do %>
+          @proposal_votes,
+          map_related_proposals_coordinates(@proposal).hash] do %>
   <div class="proposal-show">
     <div id="<%= dom_id(@proposal) unless @proposal.blank? %>" class="row">
       <div class="small-12 medium-9 column">

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -288,6 +288,7 @@ en:
     proposal_for_district: "Start a proposal for your district"
     select_district: Scope of operation
     start_proposal: Create a proposal
+    related_proposals: Related proposals
   omniauth:
     facebook:
       sign_in: Sign in with Facebook

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -220,10 +220,10 @@ es:
       title_3: "¿Te gustaría decidir con nosotros sobre algunas de las actuaciones que se llevarán a cabo?"
       content_1: "Si vives en alguno de los 9 distritos del Plan Sures, regístrate y participa en decidir cómo mejorarlos."
       content_2: "<p>
-          Carabanchel, Latina, Moratalaz, Puente de Vallecas, San Blas, Usera, Vicálvaro, Villa de Vallecas y 
+          Carabanchel, Latina, Moratalaz, Puente de Vallecas, San Blas, Usera, Vicálvaro, Villa de Vallecas y
           Villaverde son los 9 distritos que están en el ámbito de actuación del Plan SURES:
         </p>
-        <p>El Plan SURES es un PLAN de desarrollo de los distritos del Sur y del Este de Madrid. 
+        <p>El Plan SURES es un PLAN de desarrollo de los distritos del Sur y del Este de Madrid.
         <a href=\"http://preview.munimadrid.es:8080/portales/munimadrid/es/Inicio/El-Ayuntamiento/Oficina-del-Sur/?vgnextfmt=default&vgnextchannel=1c9c5c3a93f30710VgnVCM2000001f4a900aRCRD\">
         Conoce más sobre el Plan Sures</a>.</p>"
     application:
@@ -319,6 +319,7 @@ es:
     edit_organization: Edición de organización
     start_organization: Crea una organización
     access_denied: No tienes permisos para operar en este distrito.
+    related_proposals: Propuestas relacionadas
   omniauth:
     facebook:
       sign_in: Entra con Facebook

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -226,6 +226,24 @@ describe "Proposals" do
     end
   end
 
+  context "Edit" do
+    scenario "Does not show markers for related proposals by tag on proposal map", :js do
+      Setting["feature.map"] = true
+      proposal = create(:proposal, tag_list: "culture, sports", map_location: create(:map_location))
+      create(:proposal, tag_list: "culture", map_location: create(:map_location))
+      create(:proposal, tag_list: "sports")
+      login_as(proposal.author)
+
+      visit edit_proposal_path(proposal)
+
+      within ".map_location" do
+        expect(page).to have_selector(".map-icon", count: 1)
+        expect(page).not_to have_selector ".map-icon-related"
+        expect(page).not_to have_field "Related proposals"
+      end
+    end
+  end
+
   context "Show on mobile screens" do
     let!(:window_size) { Capybara.current_window.size }
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -206,8 +206,8 @@ describe "Proposals" do
 
     scenario "Shows clickable markers for related proposals by tag on proposal map", :js do
       Setting["feature.map"] = true
-      proposal = create(:proposal, tag_list: "culture, sports", map_location: create(:map_location))
-      related_proposal = create(:proposal, tag_list: "culture", map_location: create(:map_location))
+      proposal = create(:proposal, tag_list: "culture, sports", map_location: create(:map_location, latitude: 51.48))
+      related_proposal = create(:proposal, tag_list: "culture", map_location: create(:map_location, latitude: 51.50))
       create(:proposal, tag_list: "sports", map_location: nil)
 
       visit proposal_path(proposal)

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -203,6 +203,27 @@ describe "Proposals" do
         expect(page).not_to have_link("No comments", href: "#comments")
       end
     end
+
+    scenario "Shows clickable markers for related proposals by tag on proposal map", :js do
+      Setting["feature.map"] = true
+      proposal = create(:proposal, tag_list: "culture, sports", map_location: create(:map_location))
+      related_proposal = create(:proposal, tag_list: "culture", map_location: create(:map_location))
+      create(:proposal, tag_list: "sports", map_location: nil)
+
+      visit proposal_path(proposal)
+
+      within ".map_location" do
+        expect(page).to have_selector(".map-icon", count: 2)
+        expect(page).to have_selector(".map-icon.map-icon-related", count: 1)
+      end
+
+      find(".map-icon-related").click
+      within ".leaflet-popup-pane" do
+        click_link related_proposal.title
+      end
+
+      expect(page).to have_current_path proposal_path(related_proposal)
+    end
   end
 
   context "Show on mobile screens" do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -224,6 +224,41 @@ describe "Proposals" do
 
       expect(page).to have_current_path proposal_path(related_proposal)
     end
+
+    describe "Control layer to show/hide related proposals", :js do
+      scenario "Allow to hide related proposals" do
+        Setting["feature.map"] = true
+        proposal = create(:proposal, tag_list: "culture, sports", map_location: create(:map_location))
+        create(:proposal, tag_list: "culture", map_location: create(:map_location))
+
+        visit proposal_path(proposal)
+
+        within ".map_location" do
+          expect(page).to have_field "Related proposals"
+          expect(page).to have_selector ".map-icon", count: 2
+          expect(page).to have_selector ".map-icon.map-icon-related", count: 1
+          uncheck "Related proposals"
+          expect(page).to have_selector ".map-icon", count: 1
+          expect(page).to have_field "Related proposals"
+          expect(page).not_to have_selector ".map-icon.map-icon-related"
+        end
+      end
+
+      scenario "Does not render when there are no related proposals" do
+        Setting["feature.map"] = true
+        proposal = create(:proposal, tag_list: "culture", map_location: create(:map_location))
+        create(:proposal, tag_list: "sports", map_location: create(:map_location))
+
+        visit proposal_path(proposal)
+
+        within ".map_location" do
+          expect(page).to have_selector(".map-icon", count: 1)
+          expect(page).not_to have_field "Related proposals"
+          expect(page).not_to have_selector ".map-icon-related"
+        end
+        expect(page).not_to have_selector(".leaflet-control-layers-selector")
+      end
+    end
   end
 
   context "Edit" do

--- a/spec/helpers/map_locations_helper_spec.rb
+++ b/spec/helpers/map_locations_helper_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe MapLocationsHelper do
+  context "#related_proposals_coordinates" do
+    it "returns related proposals by any tag for given proposal" do
+      proposal = create(:proposal, tag_list: "culture, sports", map_location: create(:map_location))
+      sports_proposal = create(:proposal, tag_list: "sports", map_location: create(:map_location))
+      culture_proposal = create(:proposal, tag_list: "culture", map_location: create(:map_location))
+      draft_proposal = create(:proposal, :draft, tag_list: "culture", map_location: create(:map_location))
+      archived_proposal = create(:proposal, :archived, tag_list: "sports", map_location: create(:map_location))
+      retired_proposal = create(:proposal, :retired, tag_list: "culture", map_location: create(:map_location))
+      unlocated_proposal = create(:proposal, tag_list: "sports")
+
+      map_locations = map_related_proposals_coordinates(proposal)
+      ids = map_locations.collect { |map_location| map_location[:proposal_id] }
+      expect(ids).to include(sports_proposal.id, culture_proposal.id)
+      expect(ids).not_to include(proposal.id, draft_proposal.id, archived_proposal.id, retired_proposal.id, unlocated_proposal.id)
+    end
+  end
+end


### PR DESCRIPTION
## Objectives
- For geolocated proposals, display other similar proposals on the same map. When a proposal is not geolocated, neither the map nor the related proposals will be shown.
- We show proposals that have any of the tags of the original proposal.
- All the similar proposals are shown without being within a radius of the original proposal.
- The centre of the map and zoom level are maintained.
- There will be cases in which similar proposals will not be displayed on the map, they will be displayed if the user reduces the zoom level.
- A smaller icon is used than the original proposal, with a different colour, gradient or similar. Clicking on the map icon of a related proposal will display the title of the proposal and the link to allow navigation to all related proposals.
- This module only applies to citizen proposals, it will not apply to other elements that display the map such as investment projects. 

## Visual Changes
![Captura de pantalla 2021-03-05 a las 13 31 34](https://user-images.githubusercontent.com/16189/110115987-26e59780-7db7-11eb-890b-5ab1a340076f.png)
![Captura de pantalla 2021-03-05 a las 13 31 42](https://user-images.githubusercontent.com/16189/110116006-2e0ca580-7db7-11eb-8d59-8b2ec40a8ba8.png)

## Notes
This PR is done against the "executions-tab-management" branch (last stable branch of the repository) to ensure that all tests pass correctly. This is our guarantee that everything works correctly.
As soon as we get the go-ahead we will change the "executions-tab-management" base to stable/master.

The  "A smaller icon is used than the original proposal" requirement we have not done so, as we considered the change of color of the icon to be sufficiently clear and it seemed a better solution.