### PR TITLE
Bump mimemagic to version 0.3.10 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)


### PR DESCRIPTION
## References

The mimemagic gem has yanked version 0.3.5 (among others) due to license issues. 

More information about this topic: rails/rails#41750

## Objectives
Update the mimemagic dependency so the application is able to build.



